### PR TITLE
More test cleanup/enhancement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>5.12.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>5.17.0</version>

--- a/src/main/java/com/appdynamics/extensions/webspheremq/WMQMonitorTask.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/WMQMonitorTask.java
@@ -141,15 +141,17 @@ public class WMQMonitorTask implements AMonitorTaskRunnable {
 		Map<String, WMQMetricOverride> qMgrMetricsToReport = metricsMap.get(Constants.METRIC_TYPE_QUEUE_MANAGER);
 		if (qMgrMetricsToReport != null) {
 			MetricsCollector qMgrMetricsCollector = new QueueManagerMetricsCollector(qMgrMetricsToReport, this.monitorContextConfig, agent, queueManager, metricWriteHelper, countDownLatch);
-			monitorContextConfig.getContext().getExecutorService().execute("QueueManagerMetricsCollector", qMgrMetricsCollector);
+			Runnable job = new MetricsPublisherJob(qMgrMetricsCollector, countDownLatch);
+			monitorContextConfig.getContext().getExecutorService().execute("QueueManagerMetricsCollector", job);
 		} else {
 			logger.warn("No queue manager metrics to report");
 		}
 
 		Map<String, WMQMetricOverride> channelMetricsToReport = metricsMap.get(Constants.METRIC_TYPE_CHANNEL);
 		if (channelMetricsToReport != null) {
-			MetricsCollector channelMetricsCollector = new ChannelMetricsCollector(channelMetricsToReport, this.monitorContextConfig, agent, queueManager, metricWriteHelper, countDownLatch);
-			monitorContextConfig.getContext().getExecutorService().execute("ChannelMetricsCollector", channelMetricsCollector);
+			MetricsCollector channelMetricsCollector = new ChannelMetricsCollector(channelMetricsToReport, this.monitorContextConfig, agent, queueManager, metricWriteHelper);
+			Runnable job = new MetricsPublisherJob(channelMetricsCollector, countDownLatch);
+			monitorContextConfig.getContext().getExecutorService().execute("ChannelMetricsCollector", job);
 		} else {
 			logger.warn("No channel metrics to report");
 		}
@@ -158,7 +160,8 @@ public class WMQMonitorTask implements AMonitorTaskRunnable {
 		if (queueMetricsToReport != null) {
 			QueueCollectorSharedState sharedState = QueueCollectorSharedState.getInstance();
 			MetricsCollector queueMetricsCollector = new QueueMetricsCollector(queueMetricsToReport, this.monitorContextConfig, agent, metricWriteHelper, queueManager, countDownLatch, sharedState);
-			monitorContextConfig.getContext().getExecutorService().execute("QueueMetricsCollector", queueMetricsCollector);
+			Runnable job = new MetricsPublisherJob(queueMetricsCollector, countDownLatch);
+			monitorContextConfig.getContext().getExecutorService().execute("QueueMetricsCollector", job);
 		} else {
 			logger.warn("No queue metrics to report");
 		}
@@ -166,7 +169,8 @@ public class WMQMonitorTask implements AMonitorTaskRunnable {
 		Map<String, WMQMetricOverride> listenerMetricsToReport = metricsMap.get(Constants.METRIC_TYPE_LISTENER);
 		if (listenerMetricsToReport != null) {
 			MetricsCollector listenerMetricsCollector = new ListenerMetricsCollector(listenerMetricsToReport, this.monitorContextConfig, agent, queueManager, metricWriteHelper, countDownLatch);
-			monitorContextConfig.getContext().getExecutorService().execute("ListenerMetricsCollector", listenerMetricsCollector);
+			Runnable job = new MetricsPublisherJob(listenerMetricsCollector, countDownLatch);
+			monitorContextConfig.getContext().getExecutorService().execute("ListenerMetricsCollector", job);
 		} else {
 			logger.warn("No listener metrics to report");
 		}
@@ -174,7 +178,8 @@ public class WMQMonitorTask implements AMonitorTaskRunnable {
 		Map<String, WMQMetricOverride> topicMetricsToReport = metricsMap.get(Constants.METRIC_TYPE_TOPIC);
 		if (topicMetricsToReport != null) {
 			MetricsCollector topicsMetricsCollector = new TopicMetricsCollector(topicMetricsToReport, this.monitorContextConfig, agent, queueManager, metricWriteHelper, countDownLatch);
-			monitorContextConfig.getContext().getExecutorService().execute("TopicMetricsCollector", topicsMetricsCollector);
+			Runnable job = new MetricsPublisherJob(topicsMetricsCollector, countDownLatch);
+			monitorContextConfig.getContext().getExecutorService().execute("TopicMetricsCollector", job);
 		} else {
 			logger.warn("No topic metrics to report");
 		}

--- a/src/main/java/com/appdynamics/extensions/webspheremq/WMQMonitorTask.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/WMQMonitorTask.java
@@ -200,7 +200,7 @@ public class WMQMonitorTask implements AMonitorTaskRunnable {
 				agent.disconnect();
 				logger.debug("PCFMessageAgent disconnected for queueManager {} in thread {}", qMgrName, Thread.currentThread().getName());
 			} catch (Exception e) {
-				logger.error("Error occoured  while disconnting PCFMessageAgent for queueManager {} in thread {}", queueManager.getName(), Thread.currentThread().getName(), e);
+				logger.error("Error occurred  while disconnecting PCFMessageAgent for queueManager {} in thread {}", queueManager.getName(), Thread.currentThread().getName(), e);
 			}
 		}
 
@@ -209,9 +209,9 @@ public class WMQMonitorTask implements AMonitorTaskRunnable {
 		if (ibmQueueManager != null) {
 			try {
 				ibmQueueManager.disconnect();
-				//logger.debug("Connection diconnected for queue manager {} in thread {}", ibmQueueManager.getName(), Thread.currentThread().getName());
+				//logger.debug("Connection disconnected for queue manager {} in thread {}", ibmQueueManager.getName(), Thread.currentThread().getName());
 			} catch (Exception e) {
-				logger.error("Error occoured while disconnting queueManager {} in thread {}", queueManager.getName(), Thread.currentThread().getName(), e);
+				logger.error("Error occurred while disconnecting queueManager {} in thread {}", queueManager.getName(), Thread.currentThread().getName(), e);
 			}
 		}
 	}

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/ChannelMetricsCollector.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/ChannelMetricsCollector.java
@@ -26,7 +26,6 @@ import com.appdynamics.extensions.webspheremq.config.WMQMetricOverride;
 import com.google.common.collect.Lists;
 import com.ibm.mq.constants.CMQC;
 import com.ibm.mq.constants.CMQCFC;
-import com.ibm.mq.constants.MQConstants;
 import com.ibm.mq.headers.pcf.PCFException;
 import com.ibm.mq.headers.pcf.PCFMessage;
 import com.ibm.mq.headers.pcf.PCFMessageAgent;
@@ -36,6 +35,9 @@ import org.slf4j.LoggerFactory;
 
 import java.util.*;
 import java.util.concurrent.CountDownLatch;
+
+import static com.ibm.mq.constants.CMQC.MQRC_SELECTOR_ERROR;
+import static com.ibm.mq.constants.CMQCFC.MQRCCF_CHL_STATUS_NOT_FOUND;
 
 /**
  * This class is responsible for channel metric collection.
@@ -123,12 +125,12 @@ public final class ChannelMetricsCollector extends MetricsCollector implements R
                 }
 			}
 			catch (PCFException pcfe) {
-				if (pcfe.getReason() == MQConstants.MQRCCF_CHL_STATUS_NOT_FOUND) {
+				if (pcfe.getReason() == MQRCCF_CHL_STATUS_NOT_FOUND) {
 					String errorMsg = "Channel- " + channelGenericName + " :";
 					errorMsg += "Could not collect channel information as channel is stopped or inactive: Reason '3065'\n";
 					errorMsg += "If the channel type is MQCHT_RECEIVER, MQCHT_SVRCONN or MQCHT_CLUSRCVR, then the only action is to enable the channel, not start it.";
-					logger.error(errorMsg,pcfe);
-				} else if (pcfe.getReason() == MQConstants.MQRC_SELECTOR_ERROR) {
+					logger.error(errorMsg, pcfe);
+				} else if (pcfe.getReason() == MQRC_SELECTOR_ERROR) {
 					logger.error("Invalid metrics passed while collecting channel metrics, check config.yaml: Reason '2067'",pcfe);
 				}
 			} catch (Exception e) {

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/ChannelMetricsCollector.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/ChannelMetricsCollector.java
@@ -34,7 +34,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.*;
-import java.util.concurrent.CountDownLatch;
 
 import static com.ibm.mq.constants.CMQC.MQRC_SELECTOR_ERROR;
 import static com.ibm.mq.constants.CMQCFC.MQRCCF_CHL_STATUS_NOT_FOUND;
@@ -42,7 +41,7 @@ import static com.ibm.mq.constants.CMQCFC.MQRCCF_CHL_STATUS_NOT_FOUND;
 /**
  * This class is responsible for channel metric collection.
  */
-public final class ChannelMetricsCollector extends MetricsCollector implements Runnable {
+public final class ChannelMetricsCollector extends MetricsCollector {
 
 	public static final Logger logger = LoggerFactory.getLogger(ChannelMetricsCollector.class);
 	private static final String ARTIFACT = "Channels";
@@ -50,23 +49,12 @@ public final class ChannelMetricsCollector extends MetricsCollector implements R
 	/*
 	 * The Channel Status values are mentioned here http://www.ibm.com/support/knowledgecenter/SSFKSJ_7.5.0/com.ibm.mq.ref.dev.doc/q090880_.htm
 	 */
-	public ChannelMetricsCollector(Map<String, WMQMetricOverride> metricsToReport, MonitorContextConfiguration monitorContextConfig, PCFMessageAgent agent, QueueManager queueManager, MetricWriteHelper metricWriteHelper, CountDownLatch countDownLatch) {
-		super(metricsToReport, monitorContextConfig, agent, metricWriteHelper, queueManager, countDownLatch, ARTIFACT);
+	public ChannelMetricsCollector(Map<String, WMQMetricOverride> metricsToReport, MonitorContextConfiguration monitorContextConfig, PCFMessageAgent agent, QueueManager queueManager, MetricWriteHelper metricWriteHelper) {
+		super(metricsToReport, monitorContextConfig, agent, metricWriteHelper, queueManager, null, ARTIFACT);
 	}
 
 	@Override
-	public void run() {
-		try {
-			super.process();
-		} catch (TaskExecutionException e) {
-			logger.error("Error in ChannelMetricsCollector ", e);
-		} finally {
-			countDownLatch.countDown();
-		}
-	}
-
-	@Override
-	protected void publishMetrics() throws TaskExecutionException {
+	public void publishMetrics() throws TaskExecutionException {
 		long entryTime = System.currentTimeMillis();
 
 		if (getMetricsToReport() == null || getMetricsToReport().isEmpty()) {

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/ChannelMetricsCollector.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/ChannelMetricsCollector.java
@@ -132,7 +132,7 @@ public final class ChannelMetricsCollector extends MetricsCollector implements R
 					logger.error("Invalid metrics passed while collecting channel metrics, check config.yaml: Reason '2067'",pcfe);
 				}
 			} catch (Exception e) {
-				logger.error("Unexpected Error occoured while collecting metrics for channel " + channelGenericName, e);
+				logger.error("Unexpected Error occurred while collecting metrics for channel " + channelGenericName, e);
 			}
 		}
 

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/InquireQCmdCollector.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/InquireQCmdCollector.java
@@ -51,7 +51,7 @@ final class InquireQCmdCollector extends QueueMetricsCollector implements Runnab
     }
 
     @Override
-    protected void publishMetrics() throws TaskExecutionException {
+    public void publishMetrics() throws TaskExecutionException {
 		/*
 		 * attrs = { CMQC.MQCA_Q_NAME, CMQC.MQIA_CURRENT_Q_DEPTH, CMQC.MQIA_MAX_Q_DEPTH, CMQC.MQIA_OPEN_INPUT_COUNT, CMQC.MQIA_OPEN_OUTPUT_COUNT };
 		 */

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/InquireQCmdCollector.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/InquireQCmdCollector.java
@@ -43,7 +43,6 @@ final class InquireQCmdCollector extends QueueMetricsCollector implements Runnab
     @Override
     public void run() {
         try {
-            logger.info("Collecting metrics for command {}", COMMAND);
             publishMetrics();
         } catch (TaskExecutionException e) {
             logger.error("Something unforeseen has happened ",e);
@@ -52,6 +51,7 @@ final class InquireQCmdCollector extends QueueMetricsCollector implements Runnab
 
     @Override
     public void publishMetrics() throws TaskExecutionException {
+        logger.info("Collecting metrics for command {}", COMMAND);
 		/*
 		 * attrs = { CMQC.MQCA_Q_NAME, CMQC.MQIA_CURRENT_Q_DEPTH, CMQC.MQIA_MAX_Q_DEPTH, CMQC.MQIA_OPEN_INPUT_COUNT, CMQC.MQIA_OPEN_OUTPUT_COUNT };
 		 */

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/InquireQStatusCmdCollector.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/InquireQStatusCmdCollector.java
@@ -52,7 +52,7 @@ final class InquireQStatusCmdCollector extends QueueMetricsCollector implements 
     }
 
     @Override
-    protected void publishMetrics() throws TaskExecutionException {
+    public void publishMetrics() throws TaskExecutionException {
         long entryTime = System.currentTimeMillis();
 
         if (getMetricsToReport() == null || getMetricsToReport().isEmpty()) {

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/InquireQStatusCmdCollector.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/InquireQStatusCmdCollector.java
@@ -44,7 +44,6 @@ final class InquireQStatusCmdCollector extends QueueMetricsCollector implements 
     @Override
     public void run() {
         try {
-            logger.info("Collecting metrics for command {}", COMMAND);
             publishMetrics();
         } catch (TaskExecutionException e) {
             logger.error("Something unforeseen has happened ",e);
@@ -53,6 +52,7 @@ final class InquireQStatusCmdCollector extends QueueMetricsCollector implements 
 
     @Override
     public void publishMetrics() throws TaskExecutionException {
+        logger.info("Collecting metrics for command {}", COMMAND);
         long entryTime = System.currentTimeMillis();
 
         if (getMetricsToReport() == null || getMetricsToReport().isEmpty()) {

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/InquireTStatusCmdCollector.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/InquireTStatusCmdCollector.java
@@ -61,7 +61,7 @@ final class InquireTStatusCmdCollector extends MetricsCollector implements Runna
     }
 
     @Override
-    protected void publishMetrics() throws TaskExecutionException {
+    public void publishMetrics() throws TaskExecutionException {
         long entryTime = System.currentTimeMillis();
 
         if (getMetricsToReport() == null || getMetricsToReport().isEmpty()) {

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/InquireTStatusCmdCollector.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/InquireTStatusCmdCollector.java
@@ -37,31 +37,22 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-final class InquireTStatusCmdCollector extends MetricsCollector implements Runnable {
+final class InquireTStatusCmdCollector extends MetricsCollector {
 
     private static final Logger logger = LoggerFactory.getLogger(InquireTStatusCmdCollector.class);
     private static final String ARTIFACT = "Topics";
 
     static final String COMMAND = "MQCMD_INQUIRE_TOPIC_STATUS";
 
-    public InquireTStatusCmdCollector(TopicMetricsCollector collector, Map<String, WMQMetricOverride> metricsToReport){
+    public InquireTStatusCmdCollector(TopicMetricsCollector collector, Map<String, WMQMetricOverride> metricsToReport) {
         super(metricsToReport, collector.monitorContextConfig, collector.agent,
                 collector.metricWriteHelper, collector.queueManager,
                 collector.countDownLatch, ARTIFACT);
     }
 
     @Override
-    public void run() {
-        try {
-            logger.info("Collecting metrics for command {}", COMMAND);
-            publishMetrics();
-        } catch (TaskExecutionException e) {
-            logger.error("Something unforeseen has happened ", e);
-        }
-    }
-
-    @Override
     public void publishMetrics() throws TaskExecutionException {
+        logger.info("Collecting metrics for command {}", COMMAND);
         long entryTime = System.currentTimeMillis();
 
         if (getMetricsToReport() == null || getMetricsToReport().isEmpty()) {
@@ -70,8 +61,8 @@ final class InquireTStatusCmdCollector extends MetricsCollector implements Runna
         }
         Set<String> topicGenericNames = this.queueManager.getTopicFilters().getInclude();
         //
-         //  to query the current status of topics, which is essential for monitoring and managing the publish/subscribe environment in IBM MQ.
-        for(String topicGenericName : topicGenericNames){
+        //  to query the current status of topics, which is essential for monitoring and managing the publish/subscribe environment in IBM MQ.
+        for (String topicGenericName : topicGenericNames) {
             // Request: https://www.ibm.com/support/knowledgecenter/SSFKSJ_8.0.0/com.ibm.mq.ref.adm.doc/q088140_.htm
             // list of all metrics extracted through MQCMD_INQUIRE_TOPIC_STATUS is mentioned here https://www.ibm.com/support/knowledgecenter/SSFKSJ_8.0.0/com.ibm.mq.ref.adm.doc/q088150_.htm
             PCFMessage request = new PCFMessage(CMQCFC.MQCMD_INQUIRE_TOPIC_STATUS);
@@ -92,17 +83,17 @@ final class InquireTStatusCmdCollector extends MetricsCollector implements Runna
             }
         }
         long exitTime = System.currentTimeMillis() - entryTime;
-        logger.debug("Time taken to publish metrics for all queues is {} milliseconds for command {}", exitTime,COMMAND);
+        logger.debug("Time taken to publish metrics for all queues is {} milliseconds for command {}", exitTime, COMMAND);
     }
 
     private void processPCFRequestAndPublishQMetrics(String topicGenericName, PCFMessage request, String command) throws IOException, MQDataException {
-        logger.debug("sending PCF agent request to topic metrics for generic topic {} for command {}",topicGenericName,command);
+        logger.debug("sending PCF agent request to topic metrics for generic topic {} for command {}", topicGenericName, command);
         long startTime = System.currentTimeMillis();
         PCFMessage[] response = agent.send(request);
         long endTime = System.currentTimeMillis() - startTime;
-        logger.debug("PCF agent topic metrics query response for generic topic {} for command {} received in {} milliseconds", topicGenericName, command,endTime);
+        logger.debug("PCF agent topic metrics query response for generic topic {} for command {} received in {} milliseconds", topicGenericName, command, endTime);
         if (response == null || response.length <= 0) {
-            logger.debug("Unexpected Error while PCFMessage.send() for command {}, response is either null or empty",command);
+            logger.debug("Unexpected Error while PCFMessage.send() for command {}, response is either null or empty", command);
             return;
         }
         for (PCFMessage pcfMessage : response) {

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/ListenerMetricsCollector.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/ListenerMetricsCollector.java
@@ -55,7 +55,7 @@ final public class ListenerMetricsCollector extends MetricsCollector implements 
     }
 
     @Override
-    protected void publishMetrics() throws TaskExecutionException {
+    public void publishMetrics() throws TaskExecutionException {
         long entryTime = System.currentTimeMillis();
 
         if (getMetricsToReport() == null || getMetricsToReport().isEmpty()) {

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/ListenerMetricsCollector.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/ListenerMetricsCollector.java
@@ -34,24 +34,13 @@ import java.util.*;
 import java.util.concurrent.CountDownLatch;
 
 
-final public class ListenerMetricsCollector extends MetricsCollector implements Runnable {
+final public class ListenerMetricsCollector extends MetricsCollector {
 
     private static final Logger logger = LoggerFactory.getLogger(ListenerMetricsCollector.class);
     private final static String ARTIFACT = "Listeners";
 
     public ListenerMetricsCollector(Map<String, WMQMetricOverride> metricsToReport, MonitorContextConfiguration monitorContextConfig, PCFMessageAgent agent, QueueManager queueManager, MetricWriteHelper metricWriteHelper, CountDownLatch countDownLatch) {
         super(metricsToReport, monitorContextConfig, agent, metricWriteHelper, queueManager, countDownLatch, ARTIFACT);
-    }
-
-    @Override
-    public void run() {
-        try {
-            super.process();
-        } catch (TaskExecutionException e) {
-            logger.error("Error in ListenerMetricsCollector ", e);
-        } finally {
-            countDownLatch.countDown();
-        }
     }
 
     @Override

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/ListenerMetricsCollector.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/ListenerMetricsCollector.java
@@ -102,7 +102,7 @@ final public class ListenerMetricsCollector extends MetricsCollector implements 
                 }
             }
             catch (Exception e) {
-                logger.error("Unexpected Error occoured while collecting metrics for listener " + listenerGenericName, e);
+                logger.error("Unexpected Error occurred while collecting metrics for listener " + listenerGenericName, e);
             }
         }
         long exitTime = System.currentTimeMillis() - entryTime;

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/MetricsCollector.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/MetricsCollector.java
@@ -20,25 +20,20 @@ import com.appdynamics.extensions.MetricWriteHelper;
 import com.appdynamics.extensions.conf.MonitorContextConfiguration;
 import com.appdynamics.extensions.metrics.Metric;
 import com.appdynamics.extensions.webspheremq.common.WMQUtil;
-import com.appdynamics.extensions.webspheremq.config.ExcludeFilters;
 import com.appdynamics.extensions.webspheremq.config.QueueManager;
 import com.appdynamics.extensions.webspheremq.config.WMQMetricOverride;
-import com.google.common.base.Strings;
 import com.ibm.mq.headers.pcf.PCFMessageAgent;
 import com.singularity.ee.agent.systemagent.api.exception.TaskExecutionException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Iterator;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 
 /**
  * MetricsCollector class is abstract and serves as superclass for all types of metric collection class.<br>
  * It contains common methods to extract or transform metric value and names.
  */
-public abstract class MetricsCollector implements Runnable {
+public abstract class MetricsCollector implements MetricsPublisher {
 
 	protected final Map<String, WMQMetricOverride> metricsToReport;
 	protected final MonitorContextConfiguration monitorContextConfig;
@@ -48,7 +43,6 @@ public abstract class MetricsCollector implements Runnable {
 	protected final CountDownLatch countDownLatch;
 	private final String artifact;
 
-	private static final Logger logger = LoggerFactory.getLogger(MetricsCollector.class);
 	public MetricsCollector(Map<String, WMQMetricOverride> metricsToReport,
                             MonitorContextConfiguration monitorContextConfig, PCFMessageAgent agent,
                             MetricWriteHelper metricWriteHelper, QueueManager queueManager,
@@ -62,7 +56,6 @@ public abstract class MetricsCollector implements Runnable {
         this.artifact = artifact;
     }
 
-	protected abstract void publishMetrics() throws TaskExecutionException;
 
 	final public String getArtifact(){
 		return artifact;

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/MetricsPublisher.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/MetricsPublisher.java
@@ -1,0 +1,9 @@
+package com.appdynamics.extensions.webspheremq.metricscollector;
+
+import com.singularity.ee.agent.systemagent.api.exception.TaskExecutionException;
+
+public interface MetricsPublisher {
+
+    void publishMetrics() throws TaskExecutionException;
+
+}

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/MetricsPublisherJob.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/MetricsPublisherJob.java
@@ -1,0 +1,33 @@
+package com.appdynamics.extensions.webspheremq.metricscollector;
+
+import com.singularity.ee.agent.systemagent.api.exception.TaskExecutionException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * A simple job that just runs a MetricsPublisher one time.
+ */
+public class MetricsPublisherJob implements Runnable {
+
+    public static final Logger logger = LoggerFactory.getLogger(MetricsPublisherJob.class);
+    private final MetricsPublisher delegate;
+    private final CountDownLatch latch;
+
+    public MetricsPublisherJob(MetricsPublisher delegate, CountDownLatch latch) {
+        this.delegate = delegate;
+        this.latch = latch;
+    }
+
+    @Override
+    public void run() {
+        try {
+            delegate.publishMetrics();
+        } catch (TaskExecutionException e) {
+            logger.error("Error executing " + delegate.getClass().getSimpleName(), e);
+        } finally {
+            latch.countDown();
+        }
+    }
+}

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/QueueManagerMetricsCollector.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/QueueManagerMetricsCollector.java
@@ -37,24 +37,13 @@ import java.util.concurrent.CountDownLatch;
 /**
  * This class is responsible for queue metric collection.
  */
-final public class QueueManagerMetricsCollector extends MetricsCollector implements Runnable {
+final public class QueueManagerMetricsCollector extends MetricsCollector {
 
 	private static final Logger logger = LoggerFactory.getLogger(QueueManagerMetricsCollector.class);
 	private final static String ARTIFACT = "Queue Manager";
 
 	public QueueManagerMetricsCollector(Map<String, WMQMetricOverride> metricsToReport, MonitorContextConfiguration monitorContextConfig, PCFMessageAgent agent, QueueManager queueManager, MetricWriteHelper metricWriteHelper, CountDownLatch countDownLatch) {
 		super(metricsToReport, monitorContextConfig, agent, metricWriteHelper, queueManager, countDownLatch, ARTIFACT);
-	}
-
-	@Override
-	public void run() {
-		try {
-			super.process();
-		} catch (TaskExecutionException e) {
-			logger.error("Error in QueueManagerMetricsCollector ", e);
-		} finally {
-			countDownLatch.countDown();
-		}
 	}
 
 	@Override

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/QueueMetricsCollector.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/QueueMetricsCollector.java
@@ -74,7 +74,7 @@ public class QueueMetricsCollector extends MetricsCollector implements Runnable 
 	}
 
 	@Override
-	protected void publishMetrics() throws TaskExecutionException {
+	public void publishMetrics() throws TaskExecutionException {
 		logger.info("Collecting queue metrics...");
 		List<Future> futures = Lists.newArrayList();
 		Map<String, WMQMetricOverride>  metricsForInquireQCmd = getMetricsToReport(InquireQCmdCollector.COMMAND);

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/QueueMetricsCollector.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/QueueMetricsCollector.java
@@ -44,7 +44,7 @@ import static com.ibm.mq.constants.CMQC.MQQT_LOCAL;
 import static com.ibm.mq.constants.CMQC.MQQT_MODEL;
 import static com.ibm.mq.constants.CMQC.MQQT_REMOTE;
 
-public class QueueMetricsCollector extends MetricsCollector implements Runnable {
+public class QueueMetricsCollector extends MetricsCollector {
 
 	private static final Logger logger = LoggerFactory.getLogger(QueueMetricsCollector.class);
 	private final static String ARTIFACT = "Queues";
@@ -60,17 +60,6 @@ public class QueueMetricsCollector extends MetricsCollector implements Runnable 
 								 QueueCollectorSharedState sharedState) {
 		super(metricsToReport, monitorContextConfig, agent, metricWriteHelper, queueManager, countDownLatch, ARTIFACT);
 		this.sharedState = sharedState;
-	}
-
-	@Override
-	public void run() {
-		try {
-			super.process();
-		} catch (TaskExecutionException e) {
-			logger.error("Error in QueueMetricsCollector ", e);
-		} finally {
-			countDownLatch.countDown();
-		}
 	}
 
 	@Override

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/ResetQStatsCmdCollector.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/ResetQStatsCmdCollector.java
@@ -58,7 +58,7 @@ final class ResetQStatsCmdCollector extends QueueMetricsCollector implements Run
     }
 
     @Override
-    protected void publishMetrics() throws TaskExecutionException {
+    public void publishMetrics() throws TaskExecutionException {
 		/*
 		 * attrs = { CMQC.MQCA_Q_NAME, MQIA_HIGH_Q_DEPTH,MQIA_MSG_DEQ_COUNT, MQIA_MSG_ENQ_COUNT };
 		 */

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/ResetQStatsCmdCollector.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/ResetQStatsCmdCollector.java
@@ -50,7 +50,6 @@ final class ResetQStatsCmdCollector extends QueueMetricsCollector implements Run
     @Override
     public void run() {
         try {
-            logger.info("Collecting metrics for command {}",COMMAND);
             publishMetrics();
         } catch (TaskExecutionException e) {
             logger.error("Something unforeseen has happened ",e);
@@ -59,6 +58,7 @@ final class ResetQStatsCmdCollector extends QueueMetricsCollector implements Run
 
     @Override
     public void publishMetrics() throws TaskExecutionException {
+        logger.info("Collecting metrics for command {}",COMMAND);
 		/*
 		 * attrs = { CMQC.MQCA_Q_NAME, MQIA_HIGH_Q_DEPTH,MQIA_MSG_DEQ_COUNT, MQIA_MSG_ENQ_COUNT };
 		 */

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/TopicMetricsCollector.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/TopicMetricsCollector.java
@@ -58,7 +58,7 @@ public class TopicMetricsCollector extends MetricsCollector implements Runnable 
     }
 
     @Override
-    protected void publishMetrics() throws TaskExecutionException {
+    public void publishMetrics() throws TaskExecutionException {
         logger.info("Collecting Topic metrics...");
         List<Future> futures = Lists.newArrayList();
 

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/TopicMetricsCollector.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/TopicMetricsCollector.java
@@ -48,8 +48,10 @@ public class TopicMetricsCollector extends MetricsCollector {
         //  to query the current status of topics, which is essential for monitoring and managing the publish/subscribe environment in IBM MQ.
         Map<String, WMQMetricOverride> metricsForInquireTStatusCmd = getMetricsToReport(InquireTStatusCmdCollector.COMMAND);
         if (!metricsForInquireTStatusCmd.isEmpty()) {
-            futures.add(monitorContextConfig.getContext().getExecutorService().submit("Topic Status Cmd Collector",
-                    new InquireTStatusCmdCollector(this, metricsForInquireTStatusCmd)));
+            InquireTStatusCmdCollector metricsPublisher = new InquireTStatusCmdCollector(this, metricsForInquireTStatusCmd);
+            MetricsPublisherJob job = new MetricsPublisherJob(metricsPublisher, countDownLatch);
+            futures.add(monitorContextConfig.getContext().getExecutorService()
+                    .submit("Topic Status Cmd Collector", job));
         }
         for (Future f : futures) {
             try {

--- a/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/ChannelMetricsCollectorTest.java
+++ b/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/ChannelMetricsCollectorTest.java
@@ -55,10 +55,8 @@ import static com.appdynamics.extensions.webspheremq.metricscollector.MetricAsse
 import static com.appdynamics.extensions.webspheremq.metricscollector.MetricPropertiesAssert.metricPropertiesMatching;
 import static com.ibm.mq.constants.CMQC.MQRC_SELECTOR_ERROR;
 import static com.ibm.mq.constants.CMQCFC.MQRCCF_CHL_STATUS_NOT_FOUND;
-import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.Mockito.*;
 
@@ -100,7 +98,7 @@ class ChannelMetricsCollectorTest {
         metricPathsList.add("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QM1|Channels|ActiveChannelsCount");
 
         when(pcfMessageAgent.send(any(PCFMessage.class))).thenReturn(createPCFResponseForInquireChannelStatusCmd());
-        classUnderTest = new ChannelMetricsCollector(channelMetricsToReport, monitorContextConfig, pcfMessageAgent, queueManager, metricWriteHelper, Mockito.mock(CountDownLatch.class));
+        classUnderTest = new ChannelMetricsCollector(channelMetricsToReport, monitorContextConfig, pcfMessageAgent, queueManager, metricWriteHelper);
 
         classUnderTest.publishMetrics();
 
@@ -239,7 +237,7 @@ class ChannelMetricsCollectorTest {
     void testPublishMetrics_nullResponse() throws Exception {
         when(pcfMessageAgent.send(any(PCFMessage.class))).thenReturn(null);
         classUnderTest = new ChannelMetricsCollector(channelMetricsToReport, null, pcfMessageAgent,
-                queueManager, metricWriteHelper, Mockito.mock(CountDownLatch.class));
+                queueManager, metricWriteHelper);
 
         classUnderTest.publishMetrics();
 
@@ -250,7 +248,7 @@ class ChannelMetricsCollectorTest {
     void testPublishMetrics_emptyResponse() throws Exception {
         when(pcfMessageAgent.send(any(PCFMessage.class))).thenReturn(new PCFMessage[]{});
         classUnderTest = new ChannelMetricsCollector(channelMetricsToReport, null, pcfMessageAgent,
-                queueManager, metricWriteHelper, Mockito.mock(CountDownLatch.class));
+                queueManager, metricWriteHelper);
 
         classUnderTest.publishMetrics();
 
@@ -262,7 +260,7 @@ class ChannelMetricsCollectorTest {
     void testPublishMetrics_pfException(Exception exceptionToThrow) throws Exception {
         when(pcfMessageAgent.send(any(PCFMessage.class))).thenThrow(exceptionToThrow);
         classUnderTest = new ChannelMetricsCollector(channelMetricsToReport, monitorContextConfig, pcfMessageAgent,
-                queueManager, metricWriteHelper, Mockito.mock(CountDownLatch.class));
+                queueManager, metricWriteHelper);
 
         classUnderTest.publishMetrics();
 
@@ -282,16 +280,16 @@ class ChannelMetricsCollectorTest {
     @Test
     void noMetricsToReport() throws Exception {
         classUnderTest = new ChannelMetricsCollector(null, monitorContextConfig, pcfMessageAgent,
-                queueManager, metricWriteHelper, Mockito.mock(CountDownLatch.class));
+                queueManager, metricWriteHelper);
         classUnderTest.publishMetrics();
         verifyNoInteractions(metricWriteHelper);
         classUnderTest = new ChannelMetricsCollector(emptyMap(), monitorContextConfig, pcfMessageAgent,
-                queueManager, metricWriteHelper, Mockito.mock(CountDownLatch.class));
+                queueManager, metricWriteHelper);
         classUnderTest.publishMetrics();
         verifyNoInteractions(metricWriteHelper);
     }
 
-    static Stream<Arguments> exceptionsToThrow(){
+    static Stream<Arguments> exceptionsToThrow() {
         return Stream.of(
                 arguments(new RuntimeException("KBAOOM")),
                 arguments(new PCFException(91, MQRCCF_CHL_STATUS_NOT_FOUND, "flimflam")),

--- a/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/ListenerMetricsCollectorTest.java
+++ b/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/ListenerMetricsCollectorTest.java
@@ -47,7 +47,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
-public class ListenerMetricsCollectorTest {
+class ListenerMetricsCollectorTest {
     private ListenerMetricsCollector classUnderTest;
     @Mock
     private AMonitorJob aMonitorJob;
@@ -61,7 +61,7 @@ public class ListenerMetricsCollectorTest {
     private MonitorContextConfiguration monitorContextConfig;
     private Map<String, WMQMetricOverride> listenerMetricsToReport;
     private QueueManager queueManager;
-    ArgumentCaptor<List<Metric>> pathCaptor = ArgumentCaptor.forClass(List.class);
+    private ArgumentCaptor<List<Metric>> pathCaptor;
 
     @BeforeEach
     public void setup() {
@@ -72,6 +72,7 @@ public class ListenerMetricsCollectorTest {
         queueManager = mapper.convertValue(((List)configMap.get("queueManagers")).get(0), QueueManager.class);
         Map<String, Map<String, WMQMetricOverride>> metricsMap = WMQUtil.getMetricsToReportFromConfigYml((List<Map>) configMap.get("mqMetrics"));
         listenerMetricsToReport = metricsMap.get(Constants.METRIC_TYPE_LISTENER);
+        pathCaptor = ArgumentCaptor.forClass(List.class);
     }
 
     @Test

--- a/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/MetricAssert.java
+++ b/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/MetricAssert.java
@@ -1,0 +1,47 @@
+package com.appdynamics.extensions.webspheremq.metricscollector;
+
+import com.appdynamics.extensions.metrics.Metric;
+import com.appdynamics.extensions.metrics.MetricProperties;
+import org.assertj.core.api.Assertions;
+
+import java.util.function.Function;
+
+import static com.appdynamics.extensions.webspheremq.metricscollector.MetricPropertiesAssert.metricPropertiesMatching;
+
+public class MetricAssert {
+
+    private final Metric metric;
+
+    public MetricAssert(Metric metric) {
+        this.metric = metric;
+    }
+
+    static MetricAssert assertThatMetric(Metric metric){
+        return new MetricAssert(metric);
+    }
+
+    MetricAssert hasName(String name){
+        Assertions.assertThat(metric.getMetricName()).isEqualTo(name);
+        return this;
+    }
+
+    MetricAssert hasValue(String value){
+        Assertions.assertThat(metric.getMetricValue()).isEqualTo(value);
+        return this;
+    }
+
+    MetricPropertiesAssert withPropertiesMatching(){
+        return metricPropertiesMatching(metric.getMetricProperties());
+    }
+
+    MetricPropertiesAssert withPropertiesMatching(Function<MetricProperties,MetricPropertiesAssert> fn){
+        return fn.apply(metric.getMetricProperties());
+    }
+
+    MetricAssert hasPath(String path){
+        Assertions.assertThat(metric.getMetricPath()).isEqualTo(path);
+        return this;
+    }
+
+
+}

--- a/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/MetricPropertiesAssert.java
+++ b/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/MetricPropertiesAssert.java
@@ -1,0 +1,45 @@
+package com.appdynamics.extensions.webspheremq.metricscollector;
+
+import com.appdynamics.extensions.metrics.MetricProperties;
+
+import java.math.BigDecimal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class MetricPropertiesAssert {
+
+    private final MetricProperties metricProperties;
+
+    public MetricPropertiesAssert(MetricProperties metricProperties) {
+        this.metricProperties = metricProperties;
+    }
+
+    static MetricPropertiesAssert metricPropertiesMatching(MetricProperties props){
+        return new MetricPropertiesAssert(props);
+    }
+
+    MetricPropertiesAssert alias(String alias){
+        assertThat(metricProperties.getAlias()).isEqualTo(alias);
+        return this;
+    }
+    MetricPropertiesAssert multiplier(BigDecimal multiplier){
+        assertThat(metricProperties.getMultiplier()).isEqualTo(multiplier);
+        return this;
+    }
+    MetricPropertiesAssert aggregationType(String aggregationType){
+        assertThat(metricProperties.getAggregationType()).isEqualTo(aggregationType);
+        return this;
+    }
+    MetricPropertiesAssert timeRollup(String rollup){
+        assertThat(metricProperties.getTimeRollUpType()).isEqualTo(rollup);
+        return this;
+    }
+    MetricPropertiesAssert clusterRollUp(String clusterRollUp){
+        assertThat(metricProperties.getClusterRollUpType()).isEqualTo(clusterRollUp);
+        return this;
+    }
+    MetricPropertiesAssert delta(boolean delta){
+        assertThat(metricProperties.getDelta()).isEqualTo(delta);
+        return this;
+    }
+}

--- a/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/MetricsPublisherJobTest.java
+++ b/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/MetricsPublisherJobTest.java
@@ -1,0 +1,51 @@
+package com.appdynamics.extensions.webspheremq.metricscollector;
+
+import com.singularity.ee.agent.systemagent.api.exception.TaskExecutionException;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class MetricsPublisherJobTest {
+    @Test
+    void testSuccess() {
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicBoolean publishCalled = new AtomicBoolean(false);
+        MetricsPublisherJob job = new MetricsPublisherJob(() -> publishCalled.set(true), latch);
+        job.run();
+        assertThat(publishCalled).isTrue();
+        assertThat(latch.getCount()).isEqualTo(0);
+    }
+
+    @Test
+    void otherExceptionsLeak() {
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicBoolean publishCalled = new AtomicBoolean(false);
+        MetricsPublisherJob job = new MetricsPublisherJob(() -> {
+            publishCalled.set(true);
+            throw new IllegalStateException("Boom");
+        }, latch);
+
+        assertThrows(IllegalStateException.class, () -> job.run());
+
+        assertThat(publishCalled).isTrue();
+        assertThat(latch.getCount()).isEqualTo(0);
+    }
+
+    @Test
+    void testTaskExecutionException() {
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicBoolean publishCalled = new AtomicBoolean(false);
+        MetricsPublisherJob job = new MetricsPublisherJob(() -> {
+            publishCalled.set(true);
+            throw new TaskExecutionException("Boom");
+        }, latch);
+        job.run();
+        assertThat(publishCalled).isTrue();
+        assertThat(latch.getCount()).isEqualTo(0);
+    }
+
+}

--- a/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/QueueManagerMetricsCollectorTest.java
+++ b/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/QueueManagerMetricsCollectorTest.java
@@ -46,8 +46,6 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)

--- a/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/QueueMetricsCollectorTest.java
+++ b/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/QueueMetricsCollectorTest.java
@@ -65,7 +65,7 @@ public class QueueMetricsCollectorTest {
     private MonitorContextConfiguration monitorContextConfig;
     private Map<String, WMQMetricOverride> queueMetricsToReport;
     private QueueManager queueManager;
-    ArgumentCaptor<List<Metric>> pathCaptor = ArgumentCaptor.forClass(List.class);
+    ArgumentCaptor<List<Metric>> pathCaptor;
 
     @BeforeEach
     void setup() {
@@ -77,6 +77,7 @@ public class QueueMetricsCollectorTest {
         Map<String, Map<String, WMQMetricOverride>> metricsMap = WMQUtil.getMetricsToReportFromConfigYml((List<Map>) configMap.get("mqMetrics"));
         queueMetricsToReport = metricsMap.get(Constants.METRIC_TYPE_QUEUE);
         QueueCollectorSharedState.getInstance().resetForTest();
+        pathCaptor = ArgumentCaptor.forClass(List.class);
     }
 
     @Test

--- a/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/TopicMetricsCollectorTest.java
+++ b/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/TopicMetricsCollectorTest.java
@@ -63,7 +63,7 @@ public class TopicMetricsCollectorTest {
     private MonitorContextConfiguration monitorContextConfig;
     private Map<String, WMQMetricOverride> topicMetricsToReport;
     private QueueManager queueManager;
-    ArgumentCaptor<List<Metric>> pathCaptor = ArgumentCaptor.forClass(List.class);
+    private ArgumentCaptor<List<Metric>> pathCaptor;
 
     @BeforeEach
     void setup() {
@@ -74,6 +74,7 @@ public class TopicMetricsCollectorTest {
         queueManager = mapper.convertValue(((List)configMap.get("queueManagers")).get(0), QueueManager.class);
         Map<String, Map<String, WMQMetricOverride>> metricsMap = WMQUtil.getMetricsToReportFromConfigYml((List<Map>) configMap.get("mqMetrics"));
         topicMetricsToReport = metricsMap.get(Constants.METRIC_TYPE_TOPIC);
+        pathCaptor = ArgumentCaptor.forClass(List.class);
     }
 
     @Test


### PR DESCRIPTION
This primarily expands the data/test coverage in the ChannelMetricsCollector (now 100%). The previous loop left a lot uncovered. 

This also extracts the `Runnable` nature from the collector in favor of having a separate job class that does that work.