### PR TITLE
Add the ability to read queue manager configuration from configuration events

### DIFF
--- a/src/main/java/com/appdynamics/extensions/opentelemetry/MQOtelTranslator.java
+++ b/src/main/java/com/appdynamics/extensions/opentelemetry/MQOtelTranslator.java
@@ -184,6 +184,7 @@ class MQOtelTranslator {
         put("Reusable Log Size", "mq.reusable.log.size");
         put("Archive Log Size", "mq.archive.log.size");
         put("Statistics Interval", "mq.manager.statistics.interval");
+        put("Max Handles", "mq.manager.max.handles");
     }},
             segments -> {
                 AttributesBuilder builder = Attributes.builder();

--- a/src/main/java/com/appdynamics/extensions/webspheremq/WMQMonitorTask.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/WMQMonitorTask.java
@@ -73,7 +73,7 @@ public class WMQMonitorTask implements AMonitorTaskRunnable {
 				logger.debug("MQQueueManager connection initiated for queueManager {} in thread {}", queueManagerTobeDisplayed, Thread.currentThread().getName());
 				heartBeatMetricValue = BigDecimal.ONE;
 				agent = initPCFMesageAgent(ibmQueueManager);
-				extractAndReportMetrics(agent);
+				extractAndReportMetrics(ibmQueueManager, agent);
 			} else {
 				logger.error("MQQueueManager connection could not be initiated for queueManager {} in thread {} ", queueManagerTobeDisplayed, Thread.currentThread().getName());
 			}
@@ -134,7 +134,7 @@ public class WMQMonitorTask implements AMonitorTaskRunnable {
 		return agent;
 	}
 
-	private void extractAndReportMetrics(PCFMessageAgent agent) {
+	private void extractAndReportMetrics(MQQueueManager mqQueueManager, PCFMessageAgent agent) {
 		Map<String, Map<String, WMQMetricOverride>> metricsMap = WMQUtil.getMetricsToReportFromConfigYml((List<Map>) configMap.get("mqMetrics"));
 
 		CountDownLatch countDownLatch = new CountDownLatch(metricsMap.size());
@@ -197,6 +197,15 @@ public class WMQMonitorTask implements AMonitorTaskRunnable {
 			monitorContextConfig.getContext().getExecutorService().execute("TopicMetricsCollector", job);
 		} else {
 			logger.warn("No topic metrics to report");
+		}
+
+		Map<String, WMQMetricOverride> configurationMetricsToReport = metricsMap.get(Constants.METRIC_TYPE_CONFIGURATION);
+		if (configurationMetricsToReport != null) {
+			ReadConfigurationEventQueueCollector configurationEventQueueCollector = new ReadConfigurationEventQueueCollector(configurationMetricsToReport, this.monitorContextConfig, agent, mqQueueManager, queueManager, metricWriteHelper, countDownLatch);
+            Runnable job = new MetricsPublisherJob(configurationEventQueueCollector, countDownLatch);
+            monitorContextConfig.getContext().getExecutorService().execute("ReadConfigurationEventQueueCollector", job);
+		} else {
+			logger.warn("No configuration queue metrics to report");
 		}
 
 		try {

--- a/src/main/java/com/appdynamics/extensions/webspheremq/WMQMonitorTask.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/WMQMonitorTask.java
@@ -201,7 +201,7 @@ public class WMQMonitorTask implements AMonitorTaskRunnable {
 
 		Map<String, WMQMetricOverride> configurationMetricsToReport = metricsMap.get(Constants.METRIC_TYPE_CONFIGURATION);
 		if (configurationMetricsToReport != null) {
-			ReadConfigurationEventQueueCollector configurationEventQueueCollector = new ReadConfigurationEventQueueCollector(configurationMetricsToReport, this.monitorContextConfig, agent, mqQueueManager, queueManager, metricWriteHelper, countDownLatch);
+			ReadConfigurationEventQueueCollector configurationEventQueueCollector = new ReadConfigurationEventQueueCollector(configurationMetricsToReport, this.monitorContextConfig, agent, mqQueueManager, queueManager, metricWriteHelper);
             Runnable job = new MetricsPublisherJob(configurationEventQueueCollector, countDownLatch);
             monitorContextConfig.getContext().getExecutorService().execute("ReadConfigurationEventQueueCollector", job);
 		} else {

--- a/src/main/java/com/appdynamics/extensions/webspheremq/common/Constants.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/common/Constants.java
@@ -22,6 +22,7 @@ public class Constants {
 	public static final String METRIC_TYPE_CHANNEL = "channelMetrics";
 	public static final String METRIC_TYPE_LISTENER = "listenerMetrics";
 	public static final String METRIC_TYPE_TOPIC = "topicMetrics";
+	public static final String METRIC_TYPE_CONFIGURATION = "configurationMetrics";
 	
 	public static final String TRANSPORT_TYPE_CLIENT = "Client";
 	public static final String TRANSPORT_TYPE_BINGINGS = "Bindings";

--- a/src/main/java/com/appdynamics/extensions/webspheremq/config/QueueManager.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/config/QueueManager.java
@@ -37,6 +37,9 @@ public class QueueManager {
 	private String encryptionKey;
 	private String replyQueuePrefix;
 	private String modelQueueName;
+	private String configurationQueueName = "SYSTEM.ADMIN.CONFIG.EVENT";
+	private long consumeConfigurationEventInterval;
+	private boolean refreshQueueManagerConfigurationEnabled;
 
 	private ResourceFilters queueFilters;
 	private ResourceFilters channelFilters;
@@ -235,5 +238,29 @@ public class QueueManager {
 
 	public void setTopicFilters(ResourceFilters topicFilters) {
 		this.topicFilters = topicFilters;
+	}
+
+	public String getConfigurationQueueName() {
+		return this.configurationQueueName;
+	}
+
+	public void setConfigurationQueueName(String configurationQueueName) {
+		this.configurationQueueName = configurationQueueName;
+	}
+
+	public long getConsumeConfigurationEventInterval() {
+		return this.consumeConfigurationEventInterval;
+	}
+
+	public void setConsumeConfigurationEventInterval(long consumeConfigurationEventInterval) {
+		this.consumeConfigurationEventInterval = consumeConfigurationEventInterval;
+	}
+
+	public boolean isRefreshQueueManagerConfigurationEnabled() {
+		return refreshQueueManagerConfigurationEnabled;
+	}
+
+	public void setRefreshQueueManagerConfigurationEnabled(boolean refreshQueueManagerConfigurationEnabled) {
+		this.refreshQueueManagerConfigurationEnabled = refreshQueueManagerConfigurationEnabled;
 	}
 }

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/ReadConfigurationEventQueueCollector.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/ReadConfigurationEventQueueCollector.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.appdynamics.extensions.webspheremq.metricscollector;
+
+import com.appdynamics.extensions.MetricWriteHelper;
+import com.appdynamics.extensions.conf.MonitorContextConfiguration;
+import com.appdynamics.extensions.logging.ExtensionsLoggerFactory;
+import com.appdynamics.extensions.metrics.Metric;
+import com.appdynamics.extensions.webspheremq.common.WMQUtil;
+import com.appdynamics.extensions.webspheremq.config.QueueManager;
+import com.appdynamics.extensions.webspheremq.config.WMQMetricOverride;
+import com.google.common.collect.Lists;
+import com.ibm.mq.MQException;
+import com.ibm.mq.MQGetMessageOptions;
+import com.ibm.mq.MQMessage;
+import com.ibm.mq.MQQueue;
+import com.ibm.mq.MQQueueManager;
+import com.ibm.mq.constants.CMQC;
+import com.ibm.mq.constants.CMQCFC;
+import com.ibm.mq.constants.MQConstants;
+import com.ibm.mq.headers.pcf.MQCFH;
+import com.ibm.mq.headers.pcf.PCFMessage;
+import com.ibm.mq.headers.pcf.PCFMessageAgent;
+import com.singularity.ee.agent.systemagent.api.exception.TaskExecutionException;
+import org.slf4j.Logger;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+
+public class ReadConfigurationEventQueueCollector implements MetricsPublisher {
+
+	private static final Logger logger = ExtensionsLoggerFactory.getLogger(ReadConfigurationEventQueueCollector.class);
+	private final CountDownLatch countDownLatch;
+	private final MetricWriteHelper metricWriteHelper;
+	private final QueueManager queueManager;
+	private final PCFMessageAgent agent;
+	private final MonitorContextConfiguration monitorContextConfig;
+	private final MQQueueManager mqQueueManager;
+	private final Map<String, WMQMetricOverride> metricsToReport;
+	private final long bootTime;
+
+	public ReadConfigurationEventQueueCollector(Map<String, WMQMetricOverride> metricsToReport, MonitorContextConfiguration monitorContextConfig, PCFMessageAgent agent, MQQueueManager mqQueueManager, QueueManager queueManager, MetricWriteHelper metricWriteHelper, CountDownLatch countDownLatch) {
+		this.metricsToReport = metricsToReport;
+		this.monitorContextConfig = monitorContextConfig;
+		this.agent = agent;
+		this.mqQueueManager = mqQueueManager;
+		this.queueManager = queueManager;
+		this.metricWriteHelper = metricWriteHelper;
+		this.countDownLatch = countDownLatch;
+		this.bootTime = System.currentTimeMillis();
+	}
+
+	private PCFMessage findLastUpdate(long entryTime, String configurationQueueName) throws Exception {
+		// find the last update:
+		PCFMessage candidate = null;
+
+		boolean consumeEvents = this.queueManager.getConsumeConfigurationEventInterval() > 0 && (entryTime-this.bootTime) % this.queueManager.getConsumeConfigurationEventInterval() == 0;
+
+		MQQueue queue = null;
+		try {
+			int queueAccessOptions = MQConstants.MQOO_FAIL_IF_QUIESCING | MQConstants.MQOO_INPUT_SHARED;
+			if (!consumeEvents) {
+				// we are not consuming the events.
+				queueAccessOptions |= MQConstants.MQOO_BROWSE;
+			}
+			queue = mqQueueManager.accessQueue(configurationQueueName, queueAccessOptions);
+			int maxSequenceNumber = 0;
+			while (true) {
+				try {
+					MQGetMessageOptions getOptions = new MQGetMessageOptions();
+					getOptions.options = MQConstants.MQGMO_NO_WAIT | MQConstants.MQGMO_FAIL_IF_QUIESCING;
+					if (!consumeEvents) {
+						getOptions.options |= MQConstants.MQGMO_BROWSE_NEXT;
+					}
+					MQMessage message = new MQMessage();
+
+					queue.get(message, getOptions);
+					PCFMessage received = new PCFMessage(message);
+					if (received.getMsgSeqNumber() > maxSequenceNumber) {
+						maxSequenceNumber = received.getMsgSeqNumber();
+						candidate = received;
+					}
+
+				} catch (MQException e) {
+					if (e.reasonCode != MQConstants.MQRC_NO_MSG_AVAILABLE) {
+						logger.error(e.getMessage(), e);
+					}
+					break;
+				} catch (IOException e) {
+					logger.error(e.getMessage(), e);
+					break;
+				}
+			}
+		} finally {
+			if (queue != null) {
+				queue.close();
+			}
+		}
+		return candidate;
+	}
+
+    @Override
+	public void publishMetrics() throws TaskExecutionException {
+		long entryTime = System.currentTimeMillis();
+		String configurationQueueName = this.queueManager.getConfigurationQueueName();
+		logger.info("sending PCF agent request to read configuration events from queue {}", configurationQueueName);
+		try {
+
+			PCFMessage candidate = findLastUpdate(entryTime, configurationQueueName);
+
+			if (candidate == null) {
+				if (queueManager.isRefreshQueueManagerConfigurationEnabled()) {
+					// no event found.
+					// we issue a refresh request, which will generate a configuration event on the configuration event queue.
+					// note this may incur a performance cost to the queue manager.
+					PCFMessage request = new PCFMessage(CMQCFC.MQCMD_REFRESH_Q_MGR);
+					request.addParameter(CMQCFC.MQIACF_REFRESH_TYPE, CMQCFC.MQRT_CONFIGURATION);
+					request.addParameter(CMQCFC.MQIACF_OBJECT_TYPE, CMQC.MQOT_Q_MGR);
+					agent.send(request);
+					// try again:
+					candidate = findLastUpdate(entryTime, configurationQueueName);
+				}
+			}
+
+			if (candidate != null) {
+				List<Metric> metrics = Lists.newArrayList();
+				Iterator<String> overrideItr = metricsToReport.keySet().iterator();
+				while (overrideItr.hasNext()) {
+					String metrickey = overrideItr.next();
+					WMQMetricOverride wmqOverride = metricsToReport.get(metrickey);
+					if (candidate.getParameter(wmqOverride.getConstantValue()) != null) {
+						int metricValue = candidate.getIntParameterValue(wmqOverride.getConstantValue());
+						String metricPath = getMetricsName(WMQUtil.getQueueManagerNameFromConfig(queueManager), metrickey);
+						Metric m = new Metric(metrickey, String.valueOf(metricValue), metricPath, wmqOverride.getMetricProperties());
+						metrics.add(m);
+					}
+				}
+				this.metricWriteHelper.transformAndPrintMetrics(metrics);
+			}
+
+		} catch (Exception e) {
+			logger.error("Unexpected Error occoured while collecting configuration events for queue " + configurationQueueName, e);
+		}
+		long exitTime = System.currentTimeMillis() - entryTime;
+		logger.debug("Time taken to publish metrics for configuration events is {} milliseconds", exitTime);
+	}
+
+	private String getMetricsName(String qmNameToBeDisplayed, String... pathelements) {
+		StringBuilder pathBuilder = new StringBuilder(monitorContextConfig.getMetricPrefix()).append("|").append(qmNameToBeDisplayed).append("|");
+		for (int i = 0; i < pathelements.length; i++) {
+			pathBuilder.append(pathelements[i]);
+			if (i != pathelements.length - 1) {
+				pathBuilder.append("|");
+			}
+		}
+		return pathBuilder.toString();
+	}
+}

--- a/src/main/resources/conf/config.yml
+++ b/src/main/resources/conf/config.yml
@@ -50,6 +50,19 @@ queueManagers:
     #modelQueueName: ""
     #replyQueuePrefix: ""
 
+    # Name of the temporary dynamic queue holding the configuration events. This queue contains information regarding the configuration of the queue manager, notable MaxChannels and MaxActiveChannels.
+    # If unset, the default queue name `SYSTEM.ADMIN.CONFIG.EVENT` is applied.
+    # Configuration events need to be enabled explicitly in the queue manager configuration. See https://www.ibm.com/docs/en/ibm-mq/9.4.x?topic=monitoring-configuration-events for reference.
+    #configurationQueueName: "SYSTEM.ADMIN.CONFIG.EVENT"
+
+    # Interval in milliseconds at which the configuration events in the configuration queue can be consumed.
+    # By default, no events are consumed.
+    #consumeConfigurationEventInterval: 600000 # 10 minutes
+
+    # Enable running a queue manager refresh request to reload its configuration and create a configuration event.
+    # This action is only executed if no configuration events are found when reading the configuration queue.name:
+    # By default, this action is disabled.
+    #refreshQueueManagerConfigurationEnabled: false
 
     #Sets the CCSID used in the message descriptor of request and response messages. The default value is MQC.MQCCSI_Q_MGR.
     #To set this, please use the integer value.
@@ -290,6 +303,14 @@ mqMetrics:
             alias: "Subscription Count"
             ibmConstant: "com.ibm.mq.constants.CMQC.MQIA_SUB_COUNT"
             ibmCommand: "MQCMD_INQUIRE_TOPIC_STATUS"
+
+  # Sets up reading configuration events from the configuration queue.
+  - metricsType: "configurationMetrics"
+    metrics:
+      include:
+        - MaxHandles:
+            alias: "Max Handles"
+            ibmConstant: "com.ibm.mq.constants.CMQC.MQIA_MAX_HANDLES"
 
 #Run it as a scheduled task instead of running every minute.
 #If you want to run this every minute, comment this out


### PR DESCRIPTION
Rebasing https://github.com/signalfx/opentelemetry-ibm-mq-monitoring/pull/24 off latest main.