### PR TITLE
Factor out new class called MetricCreator.

### DIFF
--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/InquireChannelCmdCollector.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/InquireChannelCmdCollector.java
@@ -45,10 +45,12 @@ public class InquireChannelCmdCollector extends MetricsCollector {
 
 	public static final Logger logger = ExtensionsLoggerFactory.getLogger(InquireChannelCmdCollector.class);
 	private static final String ARTIFACT = "Channels";
+	private final MetricCreator metricCreator;
 
-	public InquireChannelCmdCollector(Map<String, WMQMetricOverride> metricsToReport, MonitorContextConfiguration monitorContextConfig, PCFMessageAgent agent, QueueManager queueManager, MetricWriteHelper metricWriteHelper) {
+	public InquireChannelCmdCollector(Map<String, WMQMetricOverride> metricsToReport, MonitorContextConfiguration monitorContextConfig, PCFMessageAgent agent, QueueManager queueManager, MetricWriteHelper metricWriteHelper, MetricCreator metricCreator) {
 		super(metricsToReport, monitorContextConfig, agent, metricWriteHelper, queueManager, null, ARTIFACT);
-	}
+        this.metricCreator = metricCreator;
+    }
 
 
 	@Override
@@ -91,7 +93,7 @@ public class InquireChannelCmdCollector extends MetricsCollector {
 								continue;
 							}
                             int metricVal = pcfMessage.getIntParameterValue(wmqOverride.getConstantValue());
-                            Metric metric = createMetric(queueManager, metrickey, metricVal, wmqOverride, getArtifact(), channelName, metrickey);
+                            Metric metric = metricCreator.createMetric(metrickey, metricVal, wmqOverride, getArtifact(), channelName, metrickey);
                             metrics.add(metric);
                         }
 						metricWriteHelper.transformAndPrintMetrics(metrics);

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/InquireQCmdCollector.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/InquireQCmdCollector.java
@@ -35,9 +35,11 @@ final class InquireQCmdCollector extends QueueMetricsCollector implements Runnab
 
     static final String COMMAND = "MQCMD_INQUIRE_Q";
 
-    public InquireQCmdCollector(QueueMetricsCollector collector, Map<String, WMQMetricOverride> metricsToReport, QueueCollectorSharedState sharedState){
+    public InquireQCmdCollector(QueueMetricsCollector collector, Map<String, WMQMetricOverride> metricsToReport,
+                                QueueCollectorSharedState sharedState, MetricCreator metricCreator){
         super(metricsToReport, collector.monitorContextConfig, collector.agent,
-                collector.metricWriteHelper, collector.queueManager, collector.countDownLatch, sharedState);
+                collector.metricWriteHelper, collector.queueManager, collector.countDownLatch, sharedState,
+                metricCreator);
     }
 
     @Override

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/InquireQStatusCmdCollector.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/InquireQStatusCmdCollector.java
@@ -36,9 +36,9 @@ final class InquireQStatusCmdCollector extends QueueMetricsCollector implements 
     static final String COMMAND = "MQCMD_INQUIRE_Q_STATUS";
 
     public InquireQStatusCmdCollector(QueueMetricsCollector collector, Map<String, WMQMetricOverride> metricsToReport,
-                                      QueueCollectorSharedState sharedState){
+                                      QueueCollectorSharedState sharedState, MetricCreator metricCreator){
         super(metricsToReport, collector.monitorContextConfig, collector.agent, collector.metricWriteHelper,
-                collector.queueManager, collector.countDownLatch, sharedState);
+                collector.queueManager, collector.countDownLatch, sharedState, metricCreator);
     }
 
     @Override

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/InquireQueueManagerCmdCollector.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/InquireQueueManagerCmdCollector.java
@@ -44,10 +44,12 @@ final public class InquireQueueManagerCmdCollector extends MetricsCollector {
 
 	private static final Logger logger = ExtensionsLoggerFactory.getLogger(InquireQueueManagerCmdCollector.class);
 	private final static String ARTIFACT = "Queue Manager";
+	private final MetricCreator metricCreator;
 
-	public InquireQueueManagerCmdCollector(Map<String, WMQMetricOverride> metricsToReport, MonitorContextConfiguration monitorContextConfig, PCFMessageAgent agent, QueueManager queueManager, MetricWriteHelper metricWriteHelper, CountDownLatch countDownLatch) {
+	public InquireQueueManagerCmdCollector(Map<String, WMQMetricOverride> metricsToReport, MonitorContextConfiguration monitorContextConfig, PCFMessageAgent agent, QueueManager queueManager, MetricWriteHelper metricWriteHelper, CountDownLatch countDownLatch, MetricCreator metricCreator) {
 		super(metricsToReport, monitorContextConfig, agent, metricWriteHelper, queueManager, countDownLatch, ARTIFACT);
-	}
+        this.metricCreator = metricCreator;
+    }
 
 	@Override
 	public void publishMetrics() throws TaskExecutionException {
@@ -80,7 +82,7 @@ final public class InquireQueueManagerCmdCollector extends MetricsCollector {
 				if (logger.isDebugEnabled()) {
 					logger.debug("Metric: " + metrickey + "=" + metricVal);
 				}
-				Metric metric = createMetric(queueManager, metrickey, metricVal, wmqOverride, metrickey);
+				Metric metric = metricCreator.createMetric(metrickey, metricVal, wmqOverride, metrickey);
 				metrics.add(metric);
 			}
 			metricWriteHelper.transformAndPrintMetrics(metrics);

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/InquireTStatusCmdCollector.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/InquireTStatusCmdCollector.java
@@ -41,13 +41,15 @@ final class InquireTStatusCmdCollector extends MetricsCollector {
 
     private static final Logger logger = LoggerFactory.getLogger(InquireTStatusCmdCollector.class);
     private static final String ARTIFACT = "Topics";
+    private final MetricCreator metricCreator;
 
     static final String COMMAND = "MQCMD_INQUIRE_TOPIC_STATUS";
 
-    public InquireTStatusCmdCollector(TopicMetricsCollector collector, Map<String, WMQMetricOverride> metricsToReport) {
+    public InquireTStatusCmdCollector(TopicMetricsCollector collector, Map<String, WMQMetricOverride> metricsToReport, MetricCreator metricCreator) {
         super(metricsToReport, collector.monitorContextConfig, collector.agent,
                 collector.metricWriteHelper, collector.queueManager,
                 collector.countDownLatch, ARTIFACT);
+        this.metricCreator = metricCreator;
     }
 
     @Override
@@ -110,7 +112,7 @@ final class InquireTStatusCmdCollector extends MetricsCollector {
                         PCFParameter pcfParam = pcfMessage.getParameter(wmqOverride.getConstantValue());
                         if (pcfParam instanceof MQCFIN) {
                             int metricVal = pcfMessage.getIntParameterValue(wmqOverride.getConstantValue());
-                            Metric metric = createMetric(queueManager, metrickey, metricVal, wmqOverride, getArtifact(), topicString, metrickey);
+                            Metric metric = metricCreator.createMetric(metrickey, metricVal, wmqOverride, getArtifact(), topicString, metrickey);
                             metrics.add(metric);
                         }
                     } catch (PCFException pcfe) {

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/ListenerMetricsCollector.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/ListenerMetricsCollector.java
@@ -36,11 +36,13 @@ import java.util.concurrent.CountDownLatch;
 
 final public class ListenerMetricsCollector extends MetricsCollector {
 
-    private static final Logger logger = LoggerFactory.getLogger(ListenerMetricsCollector.class);
+    private  final static Logger logger = LoggerFactory.getLogger(ListenerMetricsCollector.class);
     private final static String ARTIFACT = "Listeners";
+    private final MetricCreator metricCreator;
 
-    public ListenerMetricsCollector(Map<String, WMQMetricOverride> metricsToReport, MonitorContextConfiguration monitorContextConfig, PCFMessageAgent agent, QueueManager queueManager, MetricWriteHelper metricWriteHelper, CountDownLatch countDownLatch) {
+    public ListenerMetricsCollector(Map<String, WMQMetricOverride> metricsToReport, MonitorContextConfiguration monitorContextConfig, PCFMessageAgent agent, QueueManager queueManager, MetricWriteHelper metricWriteHelper, CountDownLatch countDownLatch, MetricCreator metricCreator) {
         super(metricsToReport, monitorContextConfig, agent, metricWriteHelper, queueManager, countDownLatch, ARTIFACT);
+        this.metricCreator = metricCreator;
     }
 
     @Override
@@ -81,7 +83,7 @@ final public class ListenerMetricsCollector extends MetricsCollector {
                             String metrickey = itr.next();
                             WMQMetricOverride wmqOverride = getMetricsToReport().get(metrickey);
                             int metricVal = pcfMessage.getIntParameterValue(wmqOverride.getConstantValue());
-                            Metric metric = createMetric(queueManager, metrickey, metricVal, wmqOverride, getArtifact(), listenerName, metrickey);
+                            Metric metric = metricCreator.createMetric(metrickey, metricVal, wmqOverride, getArtifact(), listenerName, metrickey);
                             metrics.add(metric);
                         }
                         metricWriteHelper.transformAndPrintMetrics(metrics);

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/MetricCreator.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/MetricCreator.java
@@ -1,0 +1,41 @@
+package com.appdynamics.extensions.webspheremq.metricscollector;
+
+import com.appdynamics.extensions.conf.MonitorContextConfiguration;
+import com.appdynamics.extensions.metrics.Metric;
+import com.appdynamics.extensions.webspheremq.common.WMQUtil;
+import com.appdynamics.extensions.webspheremq.config.QueueManager;
+import com.appdynamics.extensions.webspheremq.config.WMQMetricOverride;
+
+public class MetricCreator {
+
+    private final MonitorContextConfiguration monitorContextConfig;
+    protected final QueueManager queueManager;
+
+    public MetricCreator(MonitorContextConfiguration monitorContextConfig, QueueManager queueManager) {
+        this.monitorContextConfig = monitorContextConfig;
+        this.queueManager = queueManager;
+    }
+
+    Metric createMetric(String metricName, int metricValue, WMQMetricOverride wmqOverride, String... pathelements) {
+        String queueManagerName = WMQUtil.getQueueManagerNameFromConfig(queueManager);
+        String metricPath = getMetricsName(queueManagerName, pathelements);
+        if (wmqOverride != null && wmqOverride.getMetricProperties() != null) {
+            return new Metric(metricName, String.valueOf(metricValue), metricPath, wmqOverride.getMetricProperties());
+        }
+        return new Metric(metricName, String.valueOf(metricValue), metricPath);
+    }
+
+    private String getMetricsName(String qmNameToBeDisplayed, String... pathelements) {
+        StringBuilder pathBuilder = new StringBuilder(monitorContextConfig.getMetricPrefix());
+        pathBuilder.append("|")
+                .append(qmNameToBeDisplayed)
+                .append("|");
+        for (int i = 0; i < pathelements.length; i++) {
+            pathBuilder.append(pathelements[i]);
+            if (i != pathelements.length - 1) {
+                pathBuilder.append("|");
+            }
+        }
+        return pathBuilder.toString();
+    }
+}

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/MetricCreator.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/MetricCreator.java
@@ -6,10 +6,10 @@ import com.appdynamics.extensions.webspheremq.common.WMQUtil;
 import com.appdynamics.extensions.webspheremq.config.QueueManager;
 import com.appdynamics.extensions.webspheremq.config.WMQMetricOverride;
 
-public class MetricCreator {
+public final class MetricCreator {
 
     private final MonitorContextConfiguration monitorContextConfig;
-    protected final QueueManager queueManager;
+    private final QueueManager queueManager;
 
     public MetricCreator(MonitorContextConfiguration monitorContextConfig, QueueManager queueManager) {
         this.monitorContextConfig = monitorContextConfig;

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/MetricsCollector.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/MetricsCollector.java
@@ -35,7 +35,7 @@ import java.util.concurrent.CountDownLatch;
  */
 public abstract class MetricsCollector implements MetricsPublisher {
 
-	protected final Map<String, WMQMetricOverride> metricsToReport;
+	private final Map<String, WMQMetricOverride> metricsToReport;
 	protected final MonitorContextConfiguration monitorContextConfig;
 	protected final PCFMessageAgent agent;
 	protected final MetricWriteHelper metricWriteHelper;
@@ -73,28 +73,6 @@ public abstract class MetricsCollector implements MetricsPublisher {
 	 */
 	public final void process() throws TaskExecutionException {
 		publishMetrics();
-	}
-
-	protected String getMetricsName(String qmNameToBeDisplayed, String... pathelements) {
-		StringBuilder pathBuilder = new StringBuilder(monitorContextConfig.getMetricPrefix()).append("|").append(qmNameToBeDisplayed).append("|");
-		for (int i = 0; i < pathelements.length; i++) {
-			pathBuilder.append(pathelements[i]);
-			if (i != pathelements.length - 1) {
-				pathBuilder.append("|");
-			}
-		}
-		return pathBuilder.toString();
-	}
-
-	protected Metric createMetric(QueueManager queueManager, String metricName, int metricValue, WMQMetricOverride wmqOverride, String... pathelements) {
-		String metricPath = getMetricsName(WMQUtil.getQueueManagerNameFromConfig(queueManager), pathelements);
-		Metric metric;
-		if (wmqOverride != null && wmqOverride.getMetricProperties() != null) {
-			metric = new Metric(metricName, String.valueOf(metricValue), metricPath, wmqOverride.getMetricProperties());
-		} else {
-			metric = new Metric(metricName, String.valueOf(metricValue), metricPath);
-		}
-		return metric;
 	}
 
 	public enum FilterType {

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/QueueManagerMetricsCollector.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/QueueManagerMetricsCollector.java
@@ -41,10 +41,12 @@ final public class QueueManagerMetricsCollector extends MetricsCollector {
 
 	private static final Logger logger = LoggerFactory.getLogger(QueueManagerMetricsCollector.class);
 	private final static String ARTIFACT = "Queue Manager";
+	private final MetricCreator metricCreator;
 
-	public QueueManagerMetricsCollector(Map<String, WMQMetricOverride> metricsToReport, MonitorContextConfiguration monitorContextConfig, PCFMessageAgent agent, QueueManager queueManager, MetricWriteHelper metricWriteHelper, CountDownLatch countDownLatch) {
+	public QueueManagerMetricsCollector(Map<String, WMQMetricOverride> metricsToReport, MonitorContextConfiguration monitorContextConfig, PCFMessageAgent agent, QueueManager queueManager, MetricWriteHelper metricWriteHelper, CountDownLatch countDownLatch, MetricCreator metricCreator) {
 		super(metricsToReport, monitorContextConfig, agent, metricWriteHelper, queueManager, countDownLatch, ARTIFACT);
-	}
+        this.metricCreator = metricCreator;
+    }
 
 	@Override
 	public void publishMetrics() throws TaskExecutionException {
@@ -76,7 +78,7 @@ final public class QueueManagerMetricsCollector extends MetricsCollector {
 				if (logger.isDebugEnabled()) {
 					logger.debug("Metric: " + metrickey + "=" + metricVal);
 				}
-				Metric metric = createMetric(queueManager, metrickey, metricVal, wmqOverride, metrickey);
+				Metric metric = metricCreator.createMetric(metrickey, metricVal, wmqOverride, metrickey);
 				metrics.add(metric);
 			}
 			metricWriteHelper.transformAndPrintMetrics(metrics);

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/ResetQStatsCmdCollector.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/ResetQStatsCmdCollector.java
@@ -42,9 +42,10 @@ final class ResetQStatsCmdCollector extends QueueMetricsCollector implements Run
     protected static final String COMMAND = "MQCMD_RESET_Q_STATS";
 
     public ResetQStatsCmdCollector(QueueMetricsCollector collector, Map<String, WMQMetricOverride> metricsToReport,
-                                   QueueCollectorSharedState sharedState){
+                                   QueueCollectorSharedState sharedState, MetricCreator metricCreator){
         super(metricsToReport, collector.monitorContextConfig, collector.agent,
-                collector.metricWriteHelper, collector.queueManager, collector.countDownLatch, sharedState);
+                collector.metricWriteHelper, collector.queueManager, collector.countDownLatch, sharedState,
+                metricCreator);
     }
 
     @Override

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/TopicMetricsCollector.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/TopicMetricsCollector.java
@@ -48,7 +48,8 @@ public class TopicMetricsCollector extends MetricsCollector {
         //  to query the current status of topics, which is essential for monitoring and managing the publish/subscribe environment in IBM MQ.
         Map<String, WMQMetricOverride> metricsForInquireTStatusCmd = getMetricsToReport(InquireTStatusCmdCollector.COMMAND);
         if (!metricsForInquireTStatusCmd.isEmpty()) {
-            InquireTStatusCmdCollector metricsPublisher = new InquireTStatusCmdCollector(this, metricsForInquireTStatusCmd);
+            MetricCreator metricCreator = new MetricCreator(monitorContextConfig, queueManager);
+            InquireTStatusCmdCollector metricsPublisher = new InquireTStatusCmdCollector(this, metricsForInquireTStatusCmd, metricCreator);
             MetricsPublisherJob job = new MetricsPublisherJob(metricsPublisher, countDownLatch);
             futures.add(monitorContextConfig.getContext().getExecutorService()
                     .submit("Topic Status Cmd Collector", job));

--- a/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/InquireChannelCmdCollectorTest.java
+++ b/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/InquireChannelCmdCollectorTest.java
@@ -52,23 +52,24 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-public class InquireChannelCmdCollectorTest {
+class InquireChannelCmdCollectorTest {
 
-    private InquireChannelCmdCollector classUnderTest;
-
-    @Mock
-    private AMonitorJob aMonitorJob;
+    InquireChannelCmdCollector classUnderTest;
 
     @Mock
-    private PCFMessageAgent pcfMessageAgent;
+    AMonitorJob aMonitorJob;
 
     @Mock
-    private MetricWriteHelper metricWriteHelper;
+    PCFMessageAgent pcfMessageAgent;
 
-    private MonitorContextConfiguration monitorContextConfig;
-    private Map<String, WMQMetricOverride> channelMetricsToReport;
-    private QueueManager queueManager;
-    private ArgumentCaptor<List> pathCaptor;
+    @Mock
+    MetricWriteHelper metricWriteHelper;
+
+    MonitorContextConfiguration monitorContextConfig;
+    Map<String, WMQMetricOverride> channelMetricsToReport;
+    QueueManager queueManager;
+    ArgumentCaptor<List> pathCaptor;
+    MetricCreator metricCreator;
 
     @BeforeEach
     public void setup() {
@@ -88,12 +89,14 @@ public class InquireChannelCmdCollectorTest {
         }
         channelMetricsToReport = metricsByCommand.get("MQCMD_INQUIRE_CHANNEL");
         pathCaptor = ArgumentCaptor.forClass(List.class);
+        metricCreator = new MetricCreator(monitorContextConfig, queueManager);
     }
 
     @Test
     public void testProcessPCFRequestAndPublishQMetricsForInquireQStatusCmd() throws Exception {
         when(pcfMessageAgent.send(any(PCFMessage.class))).thenReturn(createPCFResponseForInquireChannelCmd());
-        classUnderTest = new InquireChannelCmdCollector(channelMetricsToReport, monitorContextConfig, pcfMessageAgent, queueManager, metricWriteHelper);
+        classUnderTest = new InquireChannelCmdCollector(channelMetricsToReport, monitorContextConfig, pcfMessageAgent,
+                queueManager, metricWriteHelper, metricCreator);
         classUnderTest.publishMetrics();
         verify(metricWriteHelper, times(1)).transformAndPrintMetrics(pathCaptor.capture());
         List<String> metricPathsList = Lists.newArrayList();

--- a/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/QueueMetricsCollectorTest.java
+++ b/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/QueueMetricsCollectorTest.java
@@ -66,6 +66,7 @@ public class QueueMetricsCollectorTest {
     private Map<String, WMQMetricOverride> queueMetricsToReport;
     private QueueManager queueManager;
     ArgumentCaptor<List<Metric>> pathCaptor;
+    MetricCreator metricCreator;
 
     @BeforeEach
     void setup() {
@@ -78,6 +79,7 @@ public class QueueMetricsCollectorTest {
         queueMetricsToReport = metricsMap.get(Constants.METRIC_TYPE_QUEUE);
         QueueCollectorSharedState.getInstance().resetForTest();
         pathCaptor = ArgumentCaptor.forClass(List.class);
+        metricCreator = new MetricCreator(monitorContextConfig, queueManager);
     }
 
     @Test
@@ -89,7 +91,7 @@ public class QueueMetricsCollectorTest {
         PCFMessage request = createPCFRequestForInquireQStatusCmd();
         when(pcfMessageAgent.send(request)).thenReturn(createPCFResponseForInquireQStatusCmd());
         classUnderTest = new QueueMetricsCollector(queueMetricsToReport, monitorContextConfig, pcfMessageAgent,
-                metricWriteHelper, queueManager, phaser, sharedState);
+                metricWriteHelper, queueManager, phaser, sharedState, metricCreator);
         classUnderTest.processPCFRequestAndPublishQMetrics("*", request, "MQCMD_INQUIRE_Q_STATUS");
 
         verify(metricWriteHelper, times(2)).transformAndPrintMetrics(pathCaptor.capture());
@@ -122,7 +124,7 @@ public class QueueMetricsCollectorTest {
         PCFMessage request = createPCFRequestForInquireQCmd();
         when(pcfMessageAgent.send(request)).thenReturn(createPCFResponseForInquireQCmd());
         classUnderTest = new QueueMetricsCollector(queueMetricsToReport, monitorContextConfig, pcfMessageAgent,
-                metricWriteHelper, queueManager, phaser, QueueCollectorSharedState.getInstance());
+                metricWriteHelper, queueManager, phaser, QueueCollectorSharedState.getInstance(), metricCreator);
         classUnderTest.processPCFRequestAndPublishQMetrics("*", request, "MQCMD_INQUIRE_Q");
 
         verify(metricWriteHelper, times(2)).transformAndPrintMetrics(pathCaptor.capture());
@@ -164,7 +166,7 @@ public class QueueMetricsCollectorTest {
         PCFMessage request = createPCFRequestForResetQStatsCmd();
         when(pcfMessageAgent.send(request)).thenReturn(createPCFResponseForResetQStatsCmd());
         classUnderTest = new QueueMetricsCollector(queueMetricsToReport, monitorContextConfig, pcfMessageAgent,
-                metricWriteHelper, queueManager, phaser, QueueCollectorSharedState.getInstance());
+                metricWriteHelper, queueManager, phaser, QueueCollectorSharedState.getInstance(), metricCreator);
         classUnderTest.processPCFRequestAndPublishQMetrics("*", request, "MQCMD_RESET_Q_STATS");
 
         verify(metricWriteHelper, times(1)).transformAndPrintMetrics(pathCaptor.capture());


### PR DESCRIPTION
This new class is responsible for creating the metric. By factoring it out of the MetricCollector base class, we continue to decouple the child implementations from the parent. This also helps to modularize and shrink responsibilities.