### PR TITLE
Tidy code around QueueManager connection instantiation

### DIFF
--- a/src/main/java/com/appdynamics/extensions/webspheremq/WMQContext.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/WMQContext.java
@@ -37,9 +37,11 @@ public class WMQContext {
 
 	public static final Logger logger = LoggerFactory.getLogger(WMQContext.class);
 	private final QueueManager queueManager;
+	private final String encryptionKey;
 
-	public WMQContext(QueueManager queueManager) {
+	public WMQContext(QueueManager queueManager, String encryptionKey) {
 		this.queueManager = queueManager;
+		this.encryptionKey = encryptionKey;
 		validateArgs();
 	}
 
@@ -123,12 +125,11 @@ public class WMQContext {
 		if (!Strings.isNullOrEmpty(password)) {
 			return password;
 		}
-		String encryptionKey = queueManager.getEncryptionKey();
 		String encryptedPassword = queueManager.getEncryptedPassword();
-		if (!Strings.isNullOrEmpty(encryptionKey) && !Strings.isNullOrEmpty(encryptedPassword)) {
+		if (!Strings.isNullOrEmpty(this.encryptionKey) && !Strings.isNullOrEmpty(encryptedPassword)) {
 			java.util.Map<String, String> cryptoMap = Maps.newHashMap();
 			cryptoMap.put(com.appdynamics.extensions.Constants.ENCRYPTED_PASSWORD, encryptedPassword);
-			cryptoMap.put(com.appdynamics.extensions.Constants.ENCRYPTION_KEY, encryptionKey);
+			cryptoMap.put(com.appdynamics.extensions.Constants.ENCRYPTION_KEY, this.encryptionKey);
 			return CryptoUtils.getPassword(cryptoMap);
 		}
 		return null;

--- a/src/main/java/com/appdynamics/extensions/webspheremq/config/QueueManager.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/config/QueueManager.java
@@ -34,7 +34,6 @@ public class QueueManager {
 	private String cipherSuite;
 	private String cipherSpec;
 	private String encryptedPassword;
-	private String encryptionKey;
 	private String replyQueuePrefix;
 	private String modelQueueName;
 	private String configurationQueueName = "SYSTEM.ADMIN.CONFIG.EVENT";
@@ -176,14 +175,6 @@ public class QueueManager {
 
 	public void setEncryptedPassword(String encryptedPassword) {
 		this.encryptedPassword = encryptedPassword;
-	}
-
-	public String getEncryptionKey() {
-		return encryptionKey;
-	}
-
-	public void setEncryptionKey(String encryptionKey) {
-		this.encryptionKey = encryptionKey;
 	}
 
 	public String getReplyQueuePrefix() {


### PR DESCRIPTION
simplify instantiation of the queue manager, inlining its creation.
Move the encryptionkey out of the QueueManager configuration since it is global.