### PR TITLE
Simplify MetricCreator by using true dependency

### DIFF
--- a/src/main/java/com/appdynamics/extensions/webspheremq/WMQMonitorTask.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/WMQMonitorTask.java
@@ -162,13 +162,13 @@ public class WMQMonitorTask implements AMonitorTaskRunnable {
 				metricsByCommand.get(cmd).put(key, wmqOverride);
 			}
 			if (metricsByCommand.get("MQCMD_INQUIRE_Q_MGR_STATUS") != null) {
-				MetricCreator metricCreator = new MetricCreator(monitorContextConfig, queueManager);
+				MetricCreator metricCreator = new MetricCreator(monitorContextConfig.getMetricPrefix(), queueManager);
 				MetricsCollector qMgrMetricsCollector = new QueueManagerMetricsCollector(metricsByCommand.get("MQCMD_INQUIRE_Q_MGR_STATUS"), this.monitorContextConfig, agent, queueManager, metricWriteHelper, countDownLatch, metricCreator);
                 Runnable job = new MetricsPublisherJob(qMgrMetricsCollector, countDownLatch);
                 monitorContextConfig.getContext().getExecutorService().execute("QueueManagerMetricsCollector", job);
 			}
 			if (metricsByCommand.get("MQCMD_INQUIRE_Q_MGR") != null) {
-				MetricCreator metricCreator = new MetricCreator(monitorContextConfig, queueManager, InquireQueueManagerCmdCollector.ARTIFACT);
+				MetricCreator metricCreator = new MetricCreator(monitorContextConfig.getMetricPrefix(), queueManager, InquireQueueManagerCmdCollector.ARTIFACT);
 				MetricsCollector inquireQueueMgrMetricsCollector = new InquireQueueManagerCmdCollector(metricsByCommand.get("MQCMD_INQUIRE_Q_MGR"), this.monitorContextConfig, agent, queueManager, metricWriteHelper, countDownLatch, metricCreator);
                 Runnable job = new MetricsPublisherJob(inquireQueueMgrMetricsCollector, countDownLatch);
                 monitorContextConfig.getContext().getExecutorService().execute("InquireQueueManagerCmdCollector", job);
@@ -187,7 +187,7 @@ public class WMQMonitorTask implements AMonitorTaskRunnable {
 				metricsByCommand.get(cmd).put(key, wmqOverride);
 			}
 			if (metricsByCommand.get("MQCMD_INQUIRE_CHANNEL_STATUS") != null) {
-				MetricCreator metricCreator = new MetricCreator(monitorContextConfig, queueManager, ChannelMetricsCollector.ARTIFACT);
+				MetricCreator metricCreator = new MetricCreator(monitorContextConfig.getMetricPrefix(), queueManager, ChannelMetricsCollector.ARTIFACT);
 				MetricsCollector channelMetricsCollector =
 						new ChannelMetricsCollector(metricsByCommand.get("MQCMD_INQUIRE_CHANNEL_STATUS"),
 							monitorContextConfig, agent, queueManager, metricWriteHelper, metricCreator);
@@ -195,7 +195,7 @@ public class WMQMonitorTask implements AMonitorTaskRunnable {
 				monitorContextConfig.getContext().getExecutorService().execute("ChannelMetricsCollector", job);
 			}
 			if (metricsByCommand.get("MQCMD_INQUIRE_CHANNEL") != null) {
-				MetricCreator metricCreator = new MetricCreator(monitorContextConfig, queueManager, InquireChannelCmdCollector.ARTIFACT);
+				MetricCreator metricCreator = new MetricCreator(monitorContextConfig.getMetricPrefix(), queueManager, InquireChannelCmdCollector.ARTIFACT);
 				MetricsCollector inquireChannelMetricsCollector =
 						new InquireChannelCmdCollector(metricsByCommand.get("MQCMD_INQUIRE_CHANNEL"),
 							monitorContextConfig, agent, queueManager, metricWriteHelper, metricCreator);
@@ -209,7 +209,7 @@ public class WMQMonitorTask implements AMonitorTaskRunnable {
 		Map<String, WMQMetricOverride> queueMetricsToReport = metricsMap.get(Constants.METRIC_TYPE_QUEUE);
 		if (queueMetricsToReport != null) {
 			QueueCollectorSharedState sharedState = QueueCollectorSharedState.getInstance();
-			MetricCreator metricCreator = new MetricCreator(monitorContextConfig, queueManager, QueueMetricsCollector.ARTIFACT);
+			MetricCreator metricCreator = new MetricCreator(monitorContextConfig.getMetricPrefix(), queueManager, QueueMetricsCollector.ARTIFACT);
 			MetricsCollector queueMetricsCollector =
 					new QueueMetricsCollector(queueMetricsToReport,
 						monitorContextConfig, agent, metricWriteHelper, queueManager, countDownLatch, sharedState,
@@ -222,7 +222,7 @@ public class WMQMonitorTask implements AMonitorTaskRunnable {
 
 		Map<String, WMQMetricOverride> listenerMetricsToReport = metricsMap.get(Constants.METRIC_TYPE_LISTENER);
 		if (listenerMetricsToReport != null) {
-			MetricCreator metricCreator = new MetricCreator(monitorContextConfig, queueManager, ListenerMetricsCollector.ARTIFACT);
+			MetricCreator metricCreator = new MetricCreator(monitorContextConfig.getMetricPrefix(), queueManager, ListenerMetricsCollector.ARTIFACT);
 			MetricsCollector listenerMetricsCollector = new ListenerMetricsCollector(listenerMetricsToReport, this.monitorContextConfig, agent, queueManager, metricWriteHelper, countDownLatch, metricCreator);
 			Runnable job = new MetricsPublisherJob(listenerMetricsCollector, countDownLatch);
 			monitorContextConfig.getContext().getExecutorService().execute("ListenerMetricsCollector", job);
@@ -241,7 +241,7 @@ public class WMQMonitorTask implements AMonitorTaskRunnable {
 
 		Map<String, WMQMetricOverride> configurationMetricsToReport = metricsMap.get(Constants.METRIC_TYPE_CONFIGURATION);
 		if (configurationMetricsToReport != null) {
-			MetricCreator metricCreator = new MetricCreator(monitorContextConfig, queueManager);
+			MetricCreator metricCreator = new MetricCreator(monitorContextConfig.getMetricPrefix(), queueManager);
 			ReadConfigurationEventQueueCollector configurationEventQueueCollector = new ReadConfigurationEventQueueCollector(configurationMetricsToReport, this.monitorContextConfig, agent, mqQueueManager, queueManager, metricWriteHelper, metricCreator);
             Runnable job = new MetricsPublisherJob(configurationEventQueueCollector, countDownLatch);
             monitorContextConfig.getContext().getExecutorService().execute("ReadConfigurationEventQueueCollector", job);

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/MetricCreator.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/MetricCreator.java
@@ -1,29 +1,24 @@
 package com.appdynamics.extensions.webspheremq.metricscollector;
 
-import com.appdynamics.extensions.conf.MonitorContextConfiguration;
 import com.appdynamics.extensions.metrics.Metric;
 import com.appdynamics.extensions.webspheremq.common.WMQUtil;
 import com.appdynamics.extensions.webspheremq.config.QueueManager;
 import com.appdynamics.extensions.webspheremq.config.WMQMetricOverride;
-import org.checkerframework.checker.nullness.qual.Nullable;
-
-import javax.annotation.Nullable;
-
 import javax.annotation.Nullable;
 
 public final class MetricCreator {
 
-    private final MonitorContextConfiguration monitorContextConfig;
+    private final String metricPrefix;
     private final QueueManager queueManager;
     @Nullable
     private final String firstPathComponent;
 
-    public MetricCreator(MonitorContextConfiguration monitorContextConfig, QueueManager queueManager) {
-        this(monitorContextConfig, queueManager, null);
+    public MetricCreator(String metricPrefix, QueueManager queueManager) {
+        this(metricPrefix, queueManager, null);
     }
 
-    public MetricCreator(MonitorContextConfiguration monitorContextConfig, QueueManager queueManager, @Nullable String firstPathComponent) {
-        this.monitorContextConfig = monitorContextConfig;
+    public MetricCreator(String metricPrefix, QueueManager queueManager, @Nullable String firstPathComponent) {
+        this.metricPrefix = metricPrefix;
         this.queueManager = queueManager;
         this.firstPathComponent = firstPathComponent;
     }
@@ -38,7 +33,7 @@ public final class MetricCreator {
     }
 
     private String getMetricsName(String qmNameToBeDisplayed, String... pathElements) {
-        StringBuilder pathBuilder = new StringBuilder(monitorContextConfig.getMetricPrefix());
+        StringBuilder pathBuilder = new StringBuilder(metricPrefix);
         pathBuilder.append("|")
                 .append(qmNameToBeDisplayed)
                 .append("|");

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/TopicMetricsCollector.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/TopicMetricsCollector.java
@@ -48,7 +48,7 @@ public class TopicMetricsCollector extends MetricsCollector {
         //  to query the current status of topics, which is essential for monitoring and managing the publish/subscribe environment in IBM MQ.
         Map<String, WMQMetricOverride> metricsForInquireTStatusCmd = getMetricsToReport(InquireTStatusCmdCollector.COMMAND);
         if (!metricsForInquireTStatusCmd.isEmpty()) {
-            MetricCreator metricCreator = new MetricCreator(monitorContextConfig, queueManager, InquireTStatusCmdCollector.ARTIFACT);
+            MetricCreator metricCreator = new MetricCreator(monitorContextConfig.getMetricPrefix(), queueManager, InquireTStatusCmdCollector.ARTIFACT);
             InquireTStatusCmdCollector metricsPublisher = new InquireTStatusCmdCollector(this, metricsForInquireTStatusCmd, metricCreator);
             MetricsPublisherJob job = new MetricsPublisherJob(metricsPublisher, countDownLatch);
             futures.add(monitorContextConfig.getContext().getExecutorService()

--- a/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/ChannelMetricsCollectorTest.java
+++ b/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/ChannelMetricsCollectorTest.java
@@ -96,7 +96,7 @@ class ChannelMetricsCollectorTest {
         }
         channelMetricsToReport = metricsByCommand.get("MQCMD_INQUIRE_CHANNEL_STATUS");
         pathCaptor = ArgumentCaptor.forClass(List.class);
-        metricCreator = new MetricCreator(monitorContextConfig, queueManager, ChannelMetricsCollector.ARTIFACT);
+        metricCreator = new MetricCreator(monitorContextConfig.getMetricPrefix(), queueManager, ChannelMetricsCollector.ARTIFACT);
     }
 
     @Test

--- a/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/InquireChannelCmdCollectorTest.java
+++ b/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/InquireChannelCmdCollectorTest.java
@@ -89,7 +89,7 @@ class InquireChannelCmdCollectorTest {
         }
         channelMetricsToReport = metricsByCommand.get("MQCMD_INQUIRE_CHANNEL");
         pathCaptor = ArgumentCaptor.forClass(List.class);
-        metricCreator = new MetricCreator(monitorContextConfig, queueManager, InquireChannelCmdCollector.ARTIFACT);
+        metricCreator = new MetricCreator(monitorContextConfig.getMetricPrefix(), queueManager, InquireChannelCmdCollector.ARTIFACT);
     }
 
     @Test

--- a/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/ListenerMetricsCollectorTest.java
+++ b/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/ListenerMetricsCollectorTest.java
@@ -73,7 +73,7 @@ class ListenerMetricsCollectorTest {
         Map<String, Map<String, WMQMetricOverride>> metricsMap = WMQUtil.getMetricsToReportFromConfigYml((List<Map>) configMap.get("mqMetrics"));
         listenerMetricsToReport = metricsMap.get(Constants.METRIC_TYPE_LISTENER);
         pathCaptor = ArgumentCaptor.forClass(List.class);
-        metricCreator = new MetricCreator(monitorContextConfig, queueManager, ListenerMetricsCollector.ARTIFACT);
+        metricCreator = new MetricCreator(monitorContextConfig.getMetricPrefix(), queueManager, ListenerMetricsCollector.ARTIFACT);
     }
 
     @Test

--- a/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/QueueManagerMetricsCollectorTest.java
+++ b/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/QueueManagerMetricsCollectorTest.java
@@ -77,7 +77,7 @@ class QueueManagerMetricsCollectorTest {
         Map<String, Map<String, WMQMetricOverride>> metricsMap = WMQUtil.getMetricsToReportFromConfigYml((List<Map>) configMap.get("mqMetrics"));
         queueMgrMetricsToReport = metricsMap.get(Constants.METRIC_TYPE_QUEUE_MANAGER);
         pathCaptor = ArgumentCaptor.forClass(List.class);
-        metricCreator = new MetricCreator(monitorContextConfig, queueManager);
+        metricCreator = new MetricCreator(monitorContextConfig.getMetricPrefix(), queueManager);
     }
 
     @Test

--- a/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/QueueMetricsCollectorTest.java
+++ b/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/QueueMetricsCollectorTest.java
@@ -79,7 +79,7 @@ public class QueueMetricsCollectorTest {
         queueMetricsToReport = metricsMap.get(Constants.METRIC_TYPE_QUEUE);
         QueueCollectorSharedState.getInstance().resetForTest();
         pathCaptor = ArgumentCaptor.forClass(List.class);
-        metricCreator = new MetricCreator(monitorContextConfig, queueManager, QueueMetricsCollector.ARTIFACT);
+        metricCreator = new MetricCreator(monitorContextConfig.getMetricPrefix(), queueManager, QueueMetricsCollector.ARTIFACT);
     }
 
     @Test
@@ -335,8 +335,7 @@ public class QueueMetricsCollectorTest {
         response3.addParameter(CMQC.MQIA_OPEN_OUTPUT_COUNT, 3);
         response3.addParameter(CMQC.MQIA_USAGE, CMQC.MQUS_TRANSMISSION);
 
-        PCFMessage [] messages = { response1, response2, response3 };
-        return messages;
+        return new PCFMessage[]{ response1, response2, response3 };
     }
 
     /*


### PR DESCRIPTION
There was no need for MetricCreator to have the entire `MonitorContextConfiguration` when it just needs the prefix. This simplifies it and fixes the main build.