### PR TITLE
Decouple implementations from parent via getMetricsToReport().

### DIFF
--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/InquireChannelCmdCollector.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/InquireChannelCmdCollector.java
@@ -45,11 +45,13 @@ public class InquireChannelCmdCollector extends MetricsCollector {
 
 	public static final Logger logger = ExtensionsLoggerFactory.getLogger(InquireChannelCmdCollector.class);
 	public static final String ARTIFACT = "Channels";
+	private final Map<String, WMQMetricOverride> metrics;
 	private final MetricCreator metricCreator;
 
 	public InquireChannelCmdCollector(Map<String, WMQMetricOverride> metricsToReport, MonitorContextConfiguration monitorContextConfig, PCFMessageAgent agent, QueueManager queueManager, MetricWriteHelper metricWriteHelper, MetricCreator metricCreator) {
-		super(metricsToReport, monitorContextConfig, agent, metricWriteHelper, queueManager, null);
+		super(monitorContextConfig, agent, metricWriteHelper, queueManager, null);
         this.metricCreator = metricCreator;
+		this.metrics = metricsToReport;
     }
 
 
@@ -57,7 +59,7 @@ public class InquireChannelCmdCollector extends MetricsCollector {
 	public void publishMetrics() throws TaskExecutionException {
 		long entryTime = System.currentTimeMillis();
 
-		if (getMetricsToReport() == null || getMetricsToReport().isEmpty()) {
+		if (metrics == null || metrics.isEmpty()) {
 			logger.debug("Channel metrics to report from the config is null or empty, nothing to publish");
 			return;
 		}
@@ -83,20 +85,20 @@ public class InquireChannelCmdCollector extends MetricsCollector {
                     Set<ExcludeFilters> excludeFilters = this.queueManager.getChannelFilters().getExclude();
                     if (!ExcludeFilters.isExcluded(channelName, excludeFilters)) { //check for exclude filters
                         logger.debug("Pulling out metrics for channel name {}", channelName);
-                        Iterator<String> itr = getMetricsToReport().keySet().iterator();
-                        List<Metric> metrics = Lists.newArrayList();
+                        Iterator<String> itr = metrics.keySet().iterator();
+                        List<Metric> responseMetrics = Lists.newArrayList();
                         while (itr.hasNext()) {
                             String metrickey = itr.next();
-                            WMQMetricOverride wmqOverride = getMetricsToReport().get(metrickey);
+                            WMQMetricOverride wmqOverride = metrics.get(metrickey);
 							if (pcfMessage.getParameter(wmqOverride.getConstantValue()) == null) {
 								logger.debug("Missing property {} on {}", metrickey, channelName);
 								continue;
 							}
                             int metricVal = pcfMessage.getIntParameterValue(wmqOverride.getConstantValue());
                             Metric metric = metricCreator.createMetric(metrickey, metricVal, wmqOverride, channelName, metrickey);
-                            metrics.add(metric);
+                            responseMetrics.add(metric);
                         }
-						metricWriteHelper.transformAndPrintMetrics(metrics);
+						metricWriteHelper.transformAndPrintMetrics(responseMetrics);
                     } else {
                         logger.debug("Channel name {} is excluded.", channelName);
                     }

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/InquireQStatusCmdCollector.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/InquireQStatusCmdCollector.java
@@ -34,7 +34,7 @@ import java.util.Set;
  * queue metrics using the IBM MQ command `MQCMD_INQUIRE_Q_STATUS`. It extends the
  * QueueMetricsCollector class and implements the Runnable interface, enabling
  * execution within a separate thread.
- *
+ * <p>
  * This class interacts with PCF (Programmable Command Formats) messages to
  * query queue metrics based on the configuration provided. It retrieves status information
  * about a queue, such as:
@@ -43,11 +43,11 @@ import java.util.Set;
  * 	•	Whether the queue is in use for input/output
  * 	•	Last get/put timestamps
  * 	•	And other real-time statistics
- *
+ * <p>
  * Thread Safety:
  * This class is thread-safe, as it operates independently with state shared only
  * through immutable or synchronized structures where necessary.
- *
+ * <p>
  * Usage:
  * - Instantiate this class by providing an existing QueueMetricsCollector instance,
  *   a map of metrics to report, and shared state.
@@ -59,12 +59,14 @@ final class InquireQStatusCmdCollector extends QueueMetricsCollector implements 
 
     static final String COMMAND = "MQCMD_INQUIRE_Q_STATUS";
     private final IntAttributesBuilder attributesBuilder;
+    private final Map<String, WMQMetricOverride> metrics;
 
     public InquireQStatusCmdCollector(QueueMetricsCollector collector, Map<String, WMQMetricOverride> metricsToReport,
                                       QueueCollectorSharedState sharedState, MetricCreator metricCreator){
         super(metricsToReport, collector.monitorContextConfig, collector.agent, collector.metricWriteHelper,
                 collector.queueManager, collector.countDownLatch, sharedState, metricCreator);
         this.attributesBuilder = new IntAttributesBuilder(metricsToReport);
+        this.metrics = metricsToReport;
     }
 
     @Override
@@ -81,7 +83,7 @@ final class InquireQStatusCmdCollector extends QueueMetricsCollector implements 
         logger.info("Collecting metrics for command {}", COMMAND);
         long entryTime = System.currentTimeMillis();
 
-        if (getMetricsToReport() == null || getMetricsToReport().isEmpty()) {
+        if (metrics == null || metrics.isEmpty()) {
             logger.debug("Queue metrics to report from the config is null or empty, nothing to publish for command {}", COMMAND);
             return;
         }

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/InquireQueueManagerCmdCollector.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/InquireQueueManagerCmdCollector.java
@@ -23,7 +23,6 @@ import com.appdynamics.extensions.metrics.Metric;
 import com.appdynamics.extensions.webspheremq.config.QueueManager;
 import com.appdynamics.extensions.webspheremq.config.WMQMetricOverride;
 import com.google.common.collect.Lists;
-import com.ibm.mq.constants.CMQC;
 import com.ibm.mq.constants.CMQCFC;
 import com.ibm.mq.constants.MQConstants;
 import com.ibm.mq.headers.pcf.MQCFIL;
@@ -45,10 +44,12 @@ final public class InquireQueueManagerCmdCollector extends MetricsCollector {
 	private static final Logger logger = ExtensionsLoggerFactory.getLogger(InquireQueueManagerCmdCollector.class);
 	public final static String ARTIFACT = "Queue Manager";
 	private final MetricCreator metricCreator;
+	private final Map<String, WMQMetricOverride> metrics;
 
 	public InquireQueueManagerCmdCollector(Map<String, WMQMetricOverride> metricsToReport, MonitorContextConfiguration monitorContextConfig, PCFMessageAgent agent, QueueManager queueManager, MetricWriteHelper metricWriteHelper, CountDownLatch countDownLatch, MetricCreator metricCreator) {
-		super(metricsToReport, monitorContextConfig, agent, metricWriteHelper, queueManager, countDownLatch);
+		super(monitorContextConfig, agent, metricWriteHelper, queueManager, countDownLatch);
         this.metricCreator = metricCreator;
+		this.metrics = metricsToReport;
     }
 
 	@Override
@@ -73,19 +74,19 @@ final public class InquireQueueManagerCmdCollector extends MetricsCollector {
 				logger.debug("Unexpected Error while PCFMessage.send(), response is either null or empty");
 				return;
 			}
-			Iterator<String> overrideItr = getMetricsToReport().keySet().iterator();
-			List<Metric> metrics = Lists.newArrayList();
+			Iterator<String> overrideItr = metrics.keySet().iterator();
+			List<Metric> responseMetrics = Lists.newArrayList();
 			while (overrideItr.hasNext()) {
 				String metrickey = overrideItr.next();
-				WMQMetricOverride wmqOverride = getMetricsToReport().get(metrickey);
+				WMQMetricOverride wmqOverride = metrics.get(metrickey);
 				int metricVal = responses[0].getIntParameterValue(wmqOverride.getConstantValue());
 				if (logger.isDebugEnabled()) {
 					logger.debug("Metric: " + metrickey + "=" + metricVal);
 				}
 				Metric metric = metricCreator.createMetric(metrickey, metricVal, wmqOverride, metrickey);
-				metrics.add(metric);
+				responseMetrics.add(metric);
 			}
-			metricWriteHelper.transformAndPrintMetrics(metrics);
+			metricWriteHelper.transformAndPrintMetrics(responseMetrics);
 		} catch (Exception e) {
 			logger.error(e.getMessage());
 			throw new TaskExecutionException(e);

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/InquireTStatusCmdCollector.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/InquireTStatusCmdCollector.java
@@ -44,12 +44,14 @@ final class InquireTStatusCmdCollector extends MetricsCollector {
     private final MetricCreator metricCreator;
 
     static final String COMMAND = "MQCMD_INQUIRE_TOPIC_STATUS";
+    private final Map<String, WMQMetricOverride> metrics;
 
     public InquireTStatusCmdCollector(TopicMetricsCollector collector, Map<String, WMQMetricOverride> metricsToReport, MetricCreator metricCreator) {
-        super(metricsToReport, collector.monitorContextConfig, collector.agent,
+        super(collector.monitorContextConfig, collector.agent,
                 collector.metricWriteHelper, collector.queueManager,
                 collector.countDownLatch);
         this.metricCreator = metricCreator;
+        this.metrics = metricsToReport;
     }
 
     @Override
@@ -57,7 +59,7 @@ final class InquireTStatusCmdCollector extends MetricsCollector {
         logger.info("Collecting metrics for command {}", COMMAND);
         long entryTime = System.currentTimeMillis();
 
-        if (getMetricsToReport() == null || getMetricsToReport().isEmpty()) {
+        if (metrics == null || metrics.isEmpty()) {
             logger.debug("Topic metrics to report from the config is null or empty, nothing to publish for command {}", COMMAND);
             return;
         }
@@ -104,24 +106,24 @@ final class InquireTStatusCmdCollector extends MetricsCollector {
             Set<ExcludeFilters> excludeFilters = this.queueManager.getTopicFilters().getExclude();
             if (!ExcludeFilters.isExcluded(topicString, excludeFilters)) { //check for exclude filters
                 logger.debug("Pulling out metrics for topic name {} for command {}", topicString, command);
-                Iterator<String> itr = getMetricsToReport().keySet().iterator();
-                List<Metric> metrics = Lists.newArrayList();
+                Iterator<String> itr = metrics.keySet().iterator();
+                List<Metric> responseMetrics = Lists.newArrayList();
                 while (itr.hasNext()) {
                     String metrickey = itr.next();
-                    WMQMetricOverride wmqOverride = getMetricsToReport().get(metrickey);
+                    WMQMetricOverride wmqOverride = metrics.get(metrickey);
                     try {
                         PCFParameter pcfParam = pcfMessage.getParameter(wmqOverride.getConstantValue());
                         if (pcfParam instanceof MQCFIN) {
                             int metricVal = pcfMessage.getIntParameterValue(wmqOverride.getConstantValue());
                             Metric metric = metricCreator.createMetric(metrickey, metricVal, wmqOverride, topicString, metrickey);
-                            metrics.add(metric);
+                            responseMetrics.add(metric);
                         }
                     } catch (PCFException pcfe) {
                         logger.error("PCFException caught while collecting metric for Topic: {} for metric: {} in command {}", topicString, wmqOverride.getIbmCommand(), command, pcfe);
                     }
 
                 }
-                metricWriteHelper.transformAndPrintMetrics(metrics);
+                metricWriteHelper.transformAndPrintMetrics(responseMetrics);
             } else {
                 logger.debug("Topic name {} is excluded.", topicString);
             }

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/MetricsCollector.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/MetricsCollector.java
@@ -19,10 +19,8 @@ package com.appdynamics.extensions.webspheremq.metricscollector;
 import com.appdynamics.extensions.MetricWriteHelper;
 import com.appdynamics.extensions.conf.MonitorContextConfiguration;
 import com.appdynamics.extensions.webspheremq.config.QueueManager;
-import com.appdynamics.extensions.webspheremq.config.WMQMetricOverride;
 import com.ibm.mq.headers.pcf.PCFMessageAgent;
 
-import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 
 /**
@@ -31,28 +29,21 @@ import java.util.concurrent.CountDownLatch;
  */
 public abstract class MetricsCollector implements MetricsPublisher {
 
-	private final Map<String, WMQMetricOverride> metricsToReport;
 	protected final MonitorContextConfiguration monitorContextConfig;
 	protected final PCFMessageAgent agent;
 	protected final MetricWriteHelper metricWriteHelper;
 	protected final QueueManager queueManager;
 	protected final CountDownLatch countDownLatch;
 
-	public MetricsCollector(Map<String, WMQMetricOverride> metricsToReport,
-                            MonitorContextConfiguration monitorContextConfig, PCFMessageAgent agent,
-                            MetricWriteHelper metricWriteHelper, QueueManager queueManager,
-                            CountDownLatch countDownLatch) {
-		this.metricsToReport = metricsToReport;
+	public MetricsCollector(MonitorContextConfiguration monitorContextConfig, PCFMessageAgent agent,
+							MetricWriteHelper metricWriteHelper, QueueManager queueManager,
+							CountDownLatch countDownLatch) {
 		this.monitorContextConfig = monitorContextConfig;
 		this.agent = agent;
 		this.metricWriteHelper = metricWriteHelper;
 		this.queueManager = queueManager;
 		this.countDownLatch = countDownLatch;
     }
-
-	final public Map<String, WMQMetricOverride> getMetricsToReport() {
-		return metricsToReport;
-	}
 
 	public enum FilterType {
 		STARTSWITH, EQUALS, ENDSWITH, CONTAINS, NONE

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/ResetQStatsCmdCollector.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/ResetQStatsCmdCollector.java
@@ -36,6 +36,7 @@ final class ResetQStatsCmdCollector extends QueueMetricsCollector implements Run
 
     static final String COMMAND = "MQCMD_RESET_Q_STATS";
     private final IntAttributesBuilder attributesBuilder;
+    private final Map<String, WMQMetricOverride> metrics;
 
     public ResetQStatsCmdCollector(QueueMetricsCollector collector, Map<String, WMQMetricOverride> metricsToReport,
                                    QueueCollectorSharedState sharedState, MetricCreator metricCreator){
@@ -43,6 +44,7 @@ final class ResetQStatsCmdCollector extends QueueMetricsCollector implements Run
                 collector.metricWriteHelper, collector.queueManager, collector.countDownLatch, sharedState,
                 metricCreator);
         this.attributesBuilder = new IntAttributesBuilder(metricsToReport);
+        this.metrics = metricsToReport;
     }
 
     @Override
@@ -62,7 +64,7 @@ final class ResetQStatsCmdCollector extends QueueMetricsCollector implements Run
 		 */
         long entryTime = System.currentTimeMillis();
 
-        if (getMetricsToReport() == null || getMetricsToReport().isEmpty()) {
+        if (metrics == null || metrics.isEmpty()) {
             logger.debug("Queue metrics to report from the config is null or empty, nothing to publish for command {}",COMMAND);
             return;
         }

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/TopicMetricsCollector.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/TopicMetricsCollector.java
@@ -34,10 +34,11 @@ import java.util.concurrent.*;
 
 public class TopicMetricsCollector extends MetricsCollector {
     private static final Logger logger = LoggerFactory.getLogger(TopicMetricsCollector.class);
-    private static final String ARTIFACT = "Topics";
+    private final Map<String, WMQMetricOverride> metrics;
 
     public TopicMetricsCollector(Map<String, WMQMetricOverride> metricsToReport, MonitorContextConfiguration monitorContextConfig, PCFMessageAgent agent, QueueManager queueManager, MetricWriteHelper metricWriteHelper, CountDownLatch countDownLatch) {
-        super(metricsToReport, monitorContextConfig, agent, metricWriteHelper, queueManager, countDownLatch);
+        super(monitorContextConfig, agent, metricWriteHelper, queueManager, countDownLatch);
+        this.metrics = metricsToReport;
     }
 
     @Override
@@ -73,14 +74,14 @@ public class TopicMetricsCollector extends MetricsCollector {
 
     private Map<String, WMQMetricOverride> getMetricsToReport(String command) {
         Map<String, WMQMetricOverride> commandMetrics = Maps.newHashMap();
-        if (getMetricsToReport() == null || getMetricsToReport().isEmpty()) {
+        if (metrics == null || metrics.isEmpty()) {
             logger.debug("There are no metrics configured for {}", command);
             return commandMetrics;
         }
-        Iterator<String> itr = getMetricsToReport().keySet().iterator();
+        Iterator<String> itr = metrics.keySet().iterator();
         while (itr.hasNext()) {
             String metricKey = itr.next();
-            WMQMetricOverride wmqOverride = getMetricsToReport().get(metricKey);
+            WMQMetricOverride wmqOverride = metrics.get(metricKey);
             if (wmqOverride.getIbmCommand().equalsIgnoreCase(command)) {
                 commandMetrics.put(metricKey, wmqOverride);
             }


### PR DESCRIPTION
This is the last method in the `MetricsCollector` parent that was called by child implementations. Removing that is this next step in breaking apart this parent/child dependency.