### PR TITLE
Finally free the ChannelMetricsCollector

### DIFF
--- a/src/main/java/com/appdynamics/extensions/webspheremq/WMQMonitorTask.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/WMQMonitorTask.java
@@ -166,10 +166,11 @@ public class WMQMonitorTask implements AMonitorTaskRunnable {
 				metricsByCommand.get(cmd).put(key, wmqOverride);
 			}
 			if (metricsByCommand.get("MQCMD_INQUIRE_CHANNEL_STATUS") != null) {
+				Map<String, WMQMetricOverride> metricsToReport = metricsByCommand.get("MQCMD_INQUIRE_CHANNEL_STATUS");
 				MetricCreator metricCreator = new MetricCreator(monitorContextConfig.getMetricPrefix(), queueManager, ChannelMetricsCollector.ARTIFACT);
-				MetricsCollector channelMetricsCollector =
-						new ChannelMetricsCollector(metricsByCommand.get("MQCMD_INQUIRE_CHANNEL_STATUS"),
-							monitorContextConfig, agent, queueManager, metricWriteHelper, metricCreator);
+				IntAttributesBuilder attributesBuilder = new IntAttributesBuilder(metricsToReport);
+				MetricsCollectorContext context = new MetricsCollectorContext(metricsToReport, attributesBuilder, queueManager, agent, metricWriteHelper);
+				MetricsPublisher channelMetricsCollector = new ChannelMetricsCollector(context, metricCreator);
 				Runnable job = new MetricsPublisherJob(channelMetricsCollector, countDownLatch);
 				monitorContextConfig.getContext().getExecutorService().execute("ChannelMetricsCollector", job);
 			}

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/ChannelMetricsCollector.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/ChannelMetricsCollector.java
@@ -16,19 +16,13 @@
 
 package com.appdynamics.extensions.webspheremq.metricscollector;
 
-import com.appdynamics.extensions.MetricWriteHelper;
-import com.appdynamics.extensions.conf.MonitorContextConfiguration;
 import com.appdynamics.extensions.metrics.Metric;
-import com.appdynamics.extensions.webspheremq.common.WMQUtil;
 import com.appdynamics.extensions.webspheremq.config.ExcludeFilters;
-import com.appdynamics.extensions.webspheremq.config.QueueManager;
-import com.appdynamics.extensions.webspheremq.config.WMQMetricOverride;
 import com.google.common.collect.Lists;
 import com.ibm.mq.constants.CMQC;
 import com.ibm.mq.constants.CMQCFC;
 import com.ibm.mq.headers.pcf.PCFException;
 import com.ibm.mq.headers.pcf.PCFMessage;
-import com.ibm.mq.headers.pcf.PCFMessageAgent;
 import com.singularity.ee.agent.systemagent.api.exception.TaskExecutionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,39 +35,36 @@ import static com.ibm.mq.constants.CMQCFC.MQRCCF_CHL_STATUS_NOT_FOUND;
 /**
  * This class is responsible for channel metric collection.
  */
-public final class ChannelMetricsCollector extends MetricsCollector {
+public final class ChannelMetricsCollector implements MetricsPublisher {
 
 	public static final Logger logger = LoggerFactory.getLogger(ChannelMetricsCollector.class);
 	public static final String ARTIFACT = "Channels";
-	private final Map<String, WMQMetricOverride> metrics;
 	private final MetricCreator metricCreator;
-	private final IntAttributesBuilder attributesBuilder;
+	private final MetricsCollectorContext context;
 
 	/*
 	 * The Channel Status values are mentioned here http://www.ibm.com/support/knowledgecenter/SSFKSJ_7.5.0/com.ibm.mq.ref.dev.doc/q090880_.htm
 	 */
-	public ChannelMetricsCollector(Map<String, WMQMetricOverride> metricsToReport, MonitorContextConfiguration monitorContextConfig, PCFMessageAgent agent, QueueManager queueManager, MetricWriteHelper metricWriteHelper, MetricCreator metricCreator) {
-		super(monitorContextConfig, agent, metricWriteHelper, queueManager, null);
-        this.metricCreator = metricCreator;
-		this.attributesBuilder = new IntAttributesBuilder(metricsToReport == null ? Collections.emptyList() : metricsToReport.values());
-		this.metrics = metricsToReport;
+	public ChannelMetricsCollector(MetricsCollectorContext context, MetricCreator metricCreator) {
+        this.context = context;
+		this.metricCreator = metricCreator;
     }
 
 	@Override
 	public void publishMetrics() throws TaskExecutionException {
 		long entryTime = System.currentTimeMillis();
 
-		if (metrics == null || metrics.isEmpty()) {
+		if (context.hasNoMetricsToReport()) {
 			logger.debug("Channel metrics to report from the config is null or empty, nothing to publish");
 			return;
 		}
 
-		int[] attrs = attributesBuilder.buildIntAttributesArray(CMQCFC.MQCACH_CHANNEL_NAME, CMQCFC.MQCACH_CONNECTION_NAME);
+		int[] attrs = context.buildIntAttributesArray(CMQCFC.MQCACH_CHANNEL_NAME, CMQCFC.MQCACH_CONNECTION_NAME);
 		if (logger.isDebugEnabled()) {
             logger.debug("Attributes being sent along PCF agent request to query channel metrics: {}", Arrays.toString(attrs));
 		}
 
-		Set<String> channelGenericNames = this.queueManager.getChannelFilters().getInclude();
+		Set<String> channelGenericNames = context.getChannelIncludeFilterNames();
 
 		//
  		// The MQCMD_INQUIRE_CHANNEL_STATUS command queries the current operational status of channels.
@@ -88,7 +79,7 @@ public final class ChannelMetricsCollector extends MetricsCollector {
 			try {
 				logger.debug("sending PCF agent request to query metrics for generic channel {}", channelGenericName);
 				long startTime = System.currentTimeMillis();
-				PCFMessage[] response = agent.send(request);
+				PCFMessage[] response = context.send(request);
 				long endTime = System.currentTimeMillis() - startTime;
 				logger.debug("PCF agent queue metrics query response for generic queue {} received in {} milliseconds", channelGenericName, endTime);
 				if (response == null || response.length <= 0) {
@@ -97,22 +88,19 @@ public final class ChannelMetricsCollector extends MetricsCollector {
 				}
                 for (PCFMessage pcfMessage : response) {
                     String channelName = pcfMessage.getStringParameterValue(CMQCFC.MQCACH_CHANNEL_NAME).trim();
-                    Set<ExcludeFilters> excludeFilters = queueManager.getChannelFilters().getExclude();
+                    Set<ExcludeFilters> excludeFilters = context.getChannelExcludeFilterNames();
                     if (!ExcludeFilters.isExcluded(channelName, excludeFilters)) { //check for exclude filters
                         logger.debug("Pulling out metrics for channel name {}", channelName);
-                        Iterator<String> itr = metrics.keySet().iterator();
-                        List<Metric> responseMetrics = Lists.newArrayList();
-                        while (itr.hasNext()) {
-                            String metrickey = itr.next();
-                            WMQMetricOverride wmqOverride = metrics.get(metrickey);
-                            int metricVal = pcfMessage.getIntParameterValue(wmqOverride.getConstantValue());
-                            Metric metric = metricCreator.createMetric(metrickey, metricVal, wmqOverride, channelName, metrickey);
-                            responseMetrics.add(metric);
-                            if ("Status".equals(metrickey) && metricVal == 3) {
-                                activeChannels.add(channelName);
-                            }
-                        }
-						metricWriteHelper.transformAndPrintMetrics(responseMetrics);
+						List<Metric> responseMetrics = Lists.newArrayList();
+						context.forEachMetric((metrickey,wmqOverride) -> {
+							int metricVal = pcfMessage.getIntParameterValue(wmqOverride.getConstantValue());
+							Metric metric = metricCreator.createMetric(metrickey, metricVal, wmqOverride, channelName, metrickey);
+							responseMetrics.add(metric);
+							if ("Status".equals(metrickey) && metricVal == 3) {
+								activeChannels.add(channelName);
+							}
+						});
+						context.transformAndPrintMetrics(responseMetrics);
 					} else {
                         logger.debug("Channel name {} is excluded.", channelName);
                     }
@@ -132,9 +120,9 @@ public final class ChannelMetricsCollector extends MetricsCollector {
 			}
 		}
 
-		logger.info("Active Channels in queueManager {} are {}", WMQUtil.getQueueManagerNameFromConfig(queueManager), activeChannels);
+		logger.info("Active Channels in queueManager {} are {}", context.getQueueManagerName(), activeChannels);
 		Metric activeChannelsCountMetric = metricCreator.createMetric("ActiveChannelsCount", activeChannels.size(), null, "ActiveChannelsCount");
-		metricWriteHelper.transformAndPrintMetrics(Collections.singletonList(activeChannelsCountMetric));
+		context.transformAndPrintMetric(activeChannelsCountMetric);
 
 		long exitTime = System.currentTimeMillis() - entryTime;
 		logger.debug("Time taken to publish metrics for all channels is {} milliseconds", exitTime);

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/IntAttributesBuilder.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/IntAttributesBuilder.java
@@ -3,7 +3,6 @@ package com.appdynamics.extensions.webspheremq.metricscollector;
 import com.appdynamics.extensions.webspheremq.config.WMQMetricOverride;
 
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.Map;
 
 /**
@@ -12,14 +11,14 @@ import java.util.Map;
  * by allocating a new int[] and appending the predefined values to
  * an array of input values.
  */
-final class IntAttributesBuilder {
+public final class IntAttributesBuilder {
     private final Collection<WMQMetricOverride> metrics;
 
-    IntAttributesBuilder(Map<String, WMQMetricOverride> metrics) {
+    public IntAttributesBuilder(Map<String, WMQMetricOverride> metrics) {
         this(metrics.values());
     }
 
-    IntAttributesBuilder(Collection<WMQMetricOverride> metrics) {
+    public IntAttributesBuilder(Collection<WMQMetricOverride> metrics) {
         this.metrics = metrics;
     }
 

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/MetricsCollectorContext.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/MetricsCollectorContext.java
@@ -1,0 +1,86 @@
+package com.appdynamics.extensions.webspheremq.metricscollector;
+
+import com.appdynamics.extensions.MetricWriteHelper;
+import com.appdynamics.extensions.metrics.Metric;
+import com.appdynamics.extensions.webspheremq.common.WMQUtil;
+import com.appdynamics.extensions.webspheremq.config.ExcludeFilters;
+import com.appdynamics.extensions.webspheremq.config.QueueManager;
+import com.appdynamics.extensions.webspheremq.config.WMQMetricOverride;
+import com.ibm.mq.headers.MQDataException;
+import com.ibm.mq.headers.pcf.PCFException;
+import com.ibm.mq.headers.pcf.PCFMessage;
+import com.ibm.mq.headers.pcf.PCFMessageAgent;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+import java.io.IOException;
+import java.util.*;
+
+/**
+ * A temporary bundle to contain the collaborators of the original MetricsCollector
+ * base class until we can finish unwinding things. When done and there are no
+ * longer usages of MetricsCollector, we could consider renaming this.
+ */
+@Immutable
+public final class MetricsCollectorContext {
+
+    private final Map<String, WMQMetricOverride> metricsToReport;
+    private final IntAttributesBuilder attributesBuilder;
+    private final QueueManager queueManager;
+    private final PCFMessageAgent agent;
+    private final MetricWriteHelper metricWriteHelper;
+
+    public MetricsCollectorContext(@Nullable  Map<String, WMQMetricOverride> metricsToReport,
+                            IntAttributesBuilder attributesBuilder, QueueManager queueManager, PCFMessageAgent agent, MetricWriteHelper metricWriteHelper) {
+        this.metricsToReport = metricsToReport == null ? Collections.emptyMap() : new HashMap<>(metricsToReport);
+        this.attributesBuilder = attributesBuilder;
+        this.queueManager = queueManager;
+        this.agent = agent;
+        this.metricWriteHelper = metricWriteHelper;
+    }
+
+    boolean hasNoMetricsToReport(){
+        return metricsToReport.isEmpty();
+    }
+
+    public int[] buildIntAttributesArray(int ... inputAttrs) {
+        return attributesBuilder.buildIntAttributesArray(inputAttrs);
+    }
+
+    public Set<String> getChannelIncludeFilterNames() {
+        return queueManager.getChannelFilters().getInclude();
+    }
+
+    public Set<ExcludeFilters> getChannelExcludeFilterNames() {
+        return queueManager.getChannelFilters().getExclude();
+    }
+
+    public PCFMessage[] send(PCFMessage request) throws IOException, MQDataException {
+        return agent.send(request);
+    }
+
+    public void forEachMetric(MetricConsumerAction action) throws PCFException {
+        if(metricsToReport == null) {
+            return;
+        }
+        for (Map.Entry<String, WMQMetricOverride> entry : metricsToReport.entrySet()) {
+            action.accept(entry.getKey(), entry.getValue());
+        }
+    }
+
+    public void transformAndPrintMetric(Metric responseMetrics) {
+        transformAndPrintMetrics(Collections.singletonList(responseMetrics));
+    }
+
+    public void transformAndPrintMetrics(List<Metric> responseMetrics) {
+        metricWriteHelper.transformAndPrintMetrics(responseMetrics);
+    }
+
+    String getQueueManagerName(){
+        return WMQUtil.getQueueManagerNameFromConfig(queueManager);
+    }
+
+    interface MetricConsumerAction {
+      void accept(String key, WMQMetricOverride wmqMetricOverride) throws PCFException;
+    }
+}

--- a/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/ChannelMetricsCollectorTest.java
+++ b/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/ChannelMetricsCollectorTest.java
@@ -54,7 +54,6 @@ import static com.appdynamics.extensions.webspheremq.metricscollector.MetricAsse
 import static com.appdynamics.extensions.webspheremq.metricscollector.MetricPropertiesAssert.metricPropertiesMatching;
 import static com.ibm.mq.constants.CMQC.MQRC_SELECTOR_ERROR;
 import static com.ibm.mq.constants.CMQCFC.MQRCCF_CHL_STATUS_NOT_FOUND;
-import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.Mockito.*;
@@ -73,10 +72,11 @@ class ChannelMetricsCollectorTest {
     MetricWriteHelper metricWriteHelper;
 
     MonitorContextConfiguration monitorContextConfig;
-    Map<String, WMQMetricOverride> channelMetricsToReport;
+
     QueueManager queueManager;
     ArgumentCaptor<List<Metric>> pathCaptor;
     MetricCreator metricCreator;
+    MetricsCollectorContext context;
 
     @BeforeEach
     void setup() {
@@ -94,9 +94,11 @@ class ChannelMetricsCollectorTest {
             metricsByCommand.putIfAbsent(cmd, new HashMap<>());
             metricsByCommand.get(cmd).put(e.getKey(), e.getValue());
         }
-        channelMetricsToReport = metricsByCommand.get("MQCMD_INQUIRE_CHANNEL_STATUS");
+        Map<String, WMQMetricOverride> channelMetricsToReport = metricsByCommand.get("MQCMD_INQUIRE_CHANNEL_STATUS");
         pathCaptor = ArgumentCaptor.forClass(List.class);
         metricCreator = new MetricCreator(monitorContextConfig.getMetricPrefix(), queueManager, ChannelMetricsCollector.ARTIFACT);
+        IntAttributesBuilder attributesBuilder = new IntAttributesBuilder(channelMetricsToReport);
+        context = new MetricsCollectorContext(channelMetricsToReport, attributesBuilder, queueManager, pcfMessageAgent, metricWriteHelper);
     }
 
     @Test
@@ -107,7 +109,7 @@ class ChannelMetricsCollectorTest {
         metricPathsList.add("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QM1|Channels|ActiveChannelsCount");
 
         when(pcfMessageAgent.send(any(PCFMessage.class))).thenReturn(createPCFResponseForInquireChannelStatusCmd());
-        classUnderTest = new ChannelMetricsCollector(channelMetricsToReport, monitorContextConfig, pcfMessageAgent, queueManager, metricWriteHelper, metricCreator);
+        classUnderTest = new ChannelMetricsCollector(context, metricCreator);
 
         classUnderTest.publishMetrics();
 
@@ -245,8 +247,7 @@ class ChannelMetricsCollectorTest {
     @Test
     void testPublishMetrics_nullResponse() throws Exception {
         when(pcfMessageAgent.send(any(PCFMessage.class))).thenReturn(null);
-        classUnderTest = new ChannelMetricsCollector(channelMetricsToReport, null, pcfMessageAgent,
-                queueManager, metricWriteHelper, metricCreator);
+        classUnderTest = new ChannelMetricsCollector(context, metricCreator);
 
         classUnderTest.publishMetrics();
 
@@ -256,8 +257,7 @@ class ChannelMetricsCollectorTest {
     @Test
     void testPublishMetrics_emptyResponse() throws Exception {
         when(pcfMessageAgent.send(any(PCFMessage.class))).thenReturn(new PCFMessage[]{});
-        classUnderTest = new ChannelMetricsCollector(channelMetricsToReport, null, pcfMessageAgent,
-                queueManager, metricWriteHelper, metricCreator);
+        classUnderTest = new ChannelMetricsCollector(context, metricCreator);
 
         classUnderTest.publishMetrics();
 
@@ -268,8 +268,7 @@ class ChannelMetricsCollectorTest {
     @MethodSource("exceptionsToThrow")
     void testPublishMetrics_pfException(Exception exceptionToThrow) throws Exception {
         when(pcfMessageAgent.send(any(PCFMessage.class))).thenThrow(exceptionToThrow);
-        classUnderTest = new ChannelMetricsCollector(channelMetricsToReport, monitorContextConfig, pcfMessageAgent,
-                queueManager, metricWriteHelper, metricCreator);
+        classUnderTest = new ChannelMetricsCollector(context, metricCreator);
 
         classUnderTest.publishMetrics();
 
@@ -288,12 +287,10 @@ class ChannelMetricsCollectorTest {
 
     @Test
     void noMetricsToReport() throws Exception {
-        classUnderTest = new ChannelMetricsCollector(null, monitorContextConfig, pcfMessageAgent,
-                queueManager, metricWriteHelper, metricCreator);
+        classUnderTest = new ChannelMetricsCollector(context, metricCreator);
         classUnderTest.publishMetrics();
         verifyNoInteractions(metricWriteHelper);
-        classUnderTest = new ChannelMetricsCollector(emptyMap(), monitorContextConfig, pcfMessageAgent,
-                queueManager, metricWriteHelper, metricCreator);
+        classUnderTest = new ChannelMetricsCollector(context, metricCreator);
         classUnderTest.publishMetrics();
         verifyNoInteractions(metricWriteHelper);
     }


### PR DESCRIPTION
This introduces a new bundle/data class called `MetricsCollectorContext` that is a stand-in for the original behavior that was all baked into the parent class `MetricsCollector`. This demonstrates how we can finally free these *Collector classes from the oppression of their ancestry, starting with the `ChannelMetricsCollector`.

Rather than doing all of them at once and making a review nightmare, I just establish the pattern here so that it can be repeated across the remaining collector classes.