### PR TITLE
Remove obsolete copy <fileset dir="src/main/resources/conf"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -381,7 +381,6 @@
                             <target>
                                 <mkdir dir="${target.dir}"/>
                                 <copy todir="${target.dir}">
-                                    <fileset dir="src/main/resources/conf" includes="monitor.xml,config.yml"/>
                                     <fileset dir="${project.basedir}" includes="LICENSE.txt"/>
                                     <fileset dir="${project.basedir}" includes="NOTICE.txt"/>
                                 </copy>


### PR DESCRIPTION
- remove obsolete copy <fileset dir="src/main/resources/conf" include……s="monitor.xml,config.yml"/>

Before remove, I got the following error during build: 

[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  41.116 s
[INFO] Finished at: 2025-04-30T00:36:38-07:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-antrun-plugin:3.0.0:run (install) on project ibm-mq-monitoring-extension: An Ant BuildException has occured: /Users/matho/appdynamics/signalfx/opentelemetry-ibm-mq-monitoring/src/main/resources/conf does not exist.
[ERROR] around Ant part ...<copy todir="/Users/matho/appdynamics/signalfx/opentelemetry-ibm-mq-monitoring/target/WMQMonitor">... @ 5:103 in /Users/matho/appdynamics/signalfx/opentelemetry-ibm-mq-monitoring/target/antrun/build-main.xml
 