### PR TITLE
Migrate several other implementations away from MetricsCollector ancestry

### DIFF
--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/ChannelMetricsCollector.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/ChannelMetricsCollector.java
@@ -88,7 +88,7 @@ public final class ChannelMetricsCollector implements MetricsPublisher {
 				}
                 for (PCFMessage pcfMessage : response) {
                     String channelName = pcfMessage.getStringParameterValue(CMQCFC.MQCACH_CHANNEL_NAME).trim();
-                    Set<ExcludeFilters> excludeFilters = context.getChannelExcludeFilterNames();
+                    Set<ExcludeFilters> excludeFilters = context.getChannelExcludeFilters();
                     if (!ExcludeFilters.isExcluded(channelName, excludeFilters)) { //check for exclude filters
                         logger.debug("Pulling out metrics for channel name {}", channelName);
 						List<Metric> responseMetrics = Lists.newArrayList();

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/InquireChannelCmdCollector.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/InquireChannelCmdCollector.java
@@ -74,7 +74,7 @@ public class InquireChannelCmdCollector implements MetricsPublisher {
 				}
                 for (PCFMessage pcfMessage : response) {
                     String channelName = pcfMessage.getStringParameterValue(CMQCFC.MQCACH_CHANNEL_NAME).trim();
-                    Set<ExcludeFilters> excludeFilters = context.getChannelExcludeFilterNames();
+                    Set<ExcludeFilters> excludeFilters = context.getChannelExcludeFilters();
                     if (!ExcludeFilters.isExcluded(channelName, excludeFilters)) { //check for exclude filters
                         logger.debug("Pulling out metrics for channel name {}", channelName);
 						List<Metric> responseMetrics = Lists.newArrayList();

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/InquireTStatusCmdCollector.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/InquireTStatusCmdCollector.java
@@ -18,7 +18,6 @@ package com.appdynamics.extensions.webspheremq.metricscollector;
 
 import com.appdynamics.extensions.metrics.Metric;
 import com.appdynamics.extensions.webspheremq.config.ExcludeFilters;
-import com.appdynamics.extensions.webspheremq.config.WMQMetricOverride;
 import com.google.common.collect.Lists;
 import com.ibm.mq.constants.CMQC;
 import com.ibm.mq.constants.CMQCFC;
@@ -45,8 +44,8 @@ final class InquireTStatusCmdCollector implements MetricsPublisher {
     private final MetricsCollectorContext context;
 
     public InquireTStatusCmdCollector(MetricsCollectorContext context, MetricCreator metricCreator) {
-        this.metricCreator = metricCreator;
         this.context = context;
+        this.metricCreator = metricCreator;
     }
 
     @Override
@@ -59,7 +58,6 @@ final class InquireTStatusCmdCollector implements MetricsPublisher {
             return;
         }
         Set<String> topicGenericNames = context.getTopicIncludeFilterNames();
-        //
         //  to query the current status of topics, which is essential for monitoring and managing the publish/subscribe environment in IBM MQ.
         for (String topicGenericName : topicGenericNames) {
             // Request: https://www.ibm.com/support/knowledgecenter/SSFKSJ_8.0.0/com.ibm.mq.ref.adm.doc/q088140_.htm
@@ -98,7 +96,7 @@ final class InquireTStatusCmdCollector implements MetricsPublisher {
 
         for (PCFMessage pcfMessage : response) {
             String topicString = pcfMessage.getStringParameterValue(CMQC.MQCA_TOPIC_STRING).trim();
-            Set<ExcludeFilters> excludeFilters = context.getTopicExcludeFilterNames();
+            Set<ExcludeFilters> excludeFilters = context.getTopicExcludeFilters();
             if (!ExcludeFilters.isExcluded(topicString, excludeFilters)) { //check for exclude filters
                 logger.debug("Pulling out metrics for topic name {} for command {}", topicString, command);
                 List<Metric> responseMetrics = extractMetrics(command, pcfMessage, topicString);

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/IntAttributesBuilder.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/IntAttributesBuilder.java
@@ -2,7 +2,9 @@ package com.appdynamics.extensions.webspheremq.metricscollector;
 
 import com.appdynamics.extensions.webspheremq.config.WMQMetricOverride;
 
+import javax.annotation.Nullable;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -14,12 +16,12 @@ import java.util.Map;
 public final class IntAttributesBuilder {
     private final Collection<WMQMetricOverride> metrics;
 
-    public IntAttributesBuilder(Map<String, WMQMetricOverride> metrics) {
-        this(metrics.values());
+    public IntAttributesBuilder(@Nullable Map<String, WMQMetricOverride> metrics) {
+        this(metrics == null ? null : metrics.values());
     }
 
-    public IntAttributesBuilder(Collection<WMQMetricOverride> metrics) {
-        this.metrics = metrics;
+    public IntAttributesBuilder(@Nullable Collection<WMQMetricOverride> metrics) {
+        this.metrics = metrics == null ? Collections.emptySet() : metrics;
     }
 
     int[] buildIntAttributesArray(int... inputAttrs) {

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/JobSubmitterContext.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/JobSubmitterContext.java
@@ -1,0 +1,57 @@
+package com.appdynamics.extensions.webspheremq.metricscollector;
+
+import com.appdynamics.extensions.conf.MonitorContextConfiguration;
+import com.appdynamics.extensions.webspheremq.config.WMQMetricOverride;
+
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
+
+/**
+ * JobSubmitterContext is a bundle class used by MetricsPublisher instances in order
+ * to bundle together collaborators and to encapsulate some common repeated
+ * functionality.
+ */
+public class JobSubmitterContext {
+
+    private final MonitorContextConfiguration monitorContextConfig;
+    private final CountDownLatch countDownLatch;
+    private final MetricsCollectorContext collectorContext;
+
+    public JobSubmitterContext(MonitorContextConfiguration monitorContextConfig, CountDownLatch countDownLatch, MetricsCollectorContext collectorContext) {
+        this.monitorContextConfig = monitorContextConfig;
+        this.countDownLatch = countDownLatch;
+        this.collectorContext = collectorContext;
+    }
+
+    public String getMetricPrefix() {
+        return monitorContextConfig.getMetricPrefix();
+    }
+
+    public Future<?> submitPublishJob(String name, MetricsPublisher publisher) {
+        MetricsPublisherJob job = new MetricsPublisherJob(publisher, countDownLatch);
+        return monitorContextConfig.getContext()
+                .getExecutorService()
+                .submit(name, job);
+    }
+
+    public int getConfigInt(String key, int defaultValue) {
+        Object result = monitorContextConfig.getConfigYml().get(key);
+        if(result == null){
+            return defaultValue;
+        }
+        return (Integer) result;
+    }
+
+    public MetricCreator newMetricCreator(String firstPathComponent) {
+        return new MetricCreator(getMetricPrefix(), collectorContext.getQueueManagerName(), firstPathComponent);
+    }
+
+    public MetricsCollectorContext newCollectorContext(Map<String, WMQMetricOverride> newMetrics) {
+        IntAttributesBuilder attributesBuilder = new IntAttributesBuilder(newMetrics);
+        return new MetricsCollectorContext(newMetrics, attributesBuilder,
+                collectorContext.getQueueManager(),
+                collectorContext.getAgent(),
+                collectorContext.getMetricWriteHelper());
+    }
+}

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/JobSubmitterContext.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/JobSubmitterContext.java
@@ -12,7 +12,7 @@ import java.util.concurrent.Future;
  * to bundle together collaborators and to encapsulate some common repeated
  * functionality.
  */
-public class JobSubmitterContext {
+final public class JobSubmitterContext {
 
     private final MonitorContextConfiguration monitorContextConfig;
     private final CountDownLatch countDownLatch;

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/MetricCreator.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/MetricCreator.java
@@ -9,22 +9,25 @@ import javax.annotation.Nullable;
 public final class MetricCreator {
 
     private final String metricPrefix;
-    private final QueueManager queueManager;
+    private final String queueManagerName;
     @Nullable
     private final String firstPathComponent;
 
     public MetricCreator(String metricPrefix, QueueManager queueManager) {
-        this(metricPrefix, queueManager, null);
+        this(metricPrefix, WMQUtil.getQueueManagerNameFromConfig(queueManager), null);
     }
 
     public MetricCreator(String metricPrefix, QueueManager queueManager, @Nullable String firstPathComponent) {
+        this(metricPrefix, WMQUtil.getQueueManagerNameFromConfig(queueManager), firstPathComponent);
+    }
+
+    public MetricCreator(String metricPrefix, String queueManagerName, @Nullable String firstPathComponent) {
         this.metricPrefix = metricPrefix;
-        this.queueManager = queueManager;
+        this.queueManagerName = queueManagerName;
         this.firstPathComponent = firstPathComponent;
     }
 
     Metric createMetric(String metricName, int metricValue, WMQMetricOverride wmqOverride, String... pathElements) {
-        String queueManagerName = WMQUtil.getQueueManagerNameFromConfig(queueManager);
         String metricPath = getMetricsName(queueManagerName, pathElements);
         if (wmqOverride != null && wmqOverride.getMetricProperties() != null) {
             return new Metric(metricName, String.valueOf(metricValue), metricPath, wmqOverride.getMetricProperties());

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/MetricsCollectorContext.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/MetricsCollectorContext.java
@@ -60,10 +60,6 @@ public final class MetricsCollectorContext {
     }
 
     Set<ExcludeFilters> getChannelExcludeFilters() {
-        return queueManager.getTopicFilters().getInclude();
-    }
-
-    public Set<ExcludeFilters> getChannelExcludeFilterNames() {
         return queueManager.getChannelFilters().getExclude();
     }
 
@@ -84,11 +80,6 @@ public final class MetricsCollectorContext {
     }
 
     PCFMessage[] send(PCFMessage request) throws IOException, MQDataException {
-    public Set<ExcludeFilters> getTopicExcludeFilterNames() {
-        return queueManager.getTopicFilters().getExclude();
-    }
-
-    public PCFMessage[] send(PCFMessage request) throws IOException, MQDataException {
         return agent.send(request);
     }
 

--- a/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/ChannelMetricsCollectorTest.java
+++ b/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/ChannelMetricsCollectorTest.java
@@ -52,6 +52,7 @@ import java.util.stream.Stream;
 
 import static com.appdynamics.extensions.webspheremq.metricscollector.MetricAssert.assertThatMetric;
 import static com.appdynamics.extensions.webspheremq.metricscollector.MetricPropertiesAssert.metricPropertiesMatching;
+import static com.appdynamics.extensions.webspheremq.metricscollector.MetricPropertiesAssert.standardPropsForAlias;
 import static com.ibm.mq.constants.CMQC.MQRC_SELECTOR_ERROR;
 import static com.ibm.mq.constants.CMQCFC.MQRCCF_CHL_STATUS_NOT_FOUND;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -167,14 +168,6 @@ class ChannelMetricsCollectorTest {
                 .hasPath("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Channels|DEV." + component + ".SVRCONN|ByteReceived")
                 .hasValue("5772")
                 .withPropertiesMatching(standardPropsForAlias("Byte Received"));
-    }
-
-    Function<MetricProperties, MetricPropertiesAssert> standardPropsForAlias(String alias) {
-        return mp -> metricPropertiesMatching(mp)
-                .alias(alias)
-                .multiplier(BigDecimal.ONE)
-                .aggregationType("AVERAGE").timeRollup("AVERAGE").clusterRollUp("INDIVIDUAL")
-                .delta(false);
     }
 
     /*

--- a/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/ListenerMetricsCollectorTest.java
+++ b/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/ListenerMetricsCollectorTest.java
@@ -77,11 +77,12 @@ class ListenerMetricsCollectorTest {
     }
 
     @Test
-    public void testpublishMetrics() throws Exception {
+    public void testPublishMetrics() throws Exception {
         CountDownLatch latch = mock(CountDownLatch.class);
         when(pcfMessageAgent.send(any(PCFMessage.class))).thenReturn(createPCFResponseForInquireListenerStatusCmd());
-        classUnderTest = new ListenerMetricsCollector(listenerMetricsToReport, monitorContextConfig, pcfMessageAgent,
-                queueManager, metricWriteHelper, latch, metricCreator);
+        IntAttributesBuilder attributesBuilder = new IntAttributesBuilder(listenerMetricsToReport);
+        MetricsCollectorContext context = new MetricsCollectorContext(listenerMetricsToReport, attributesBuilder, queueManager, pcfMessageAgent, metricWriteHelper);
+        classUnderTest = new ListenerMetricsCollector(context, metricCreator);
         classUnderTest.publishMetrics();
         verify(metricWriteHelper, times(2)).transformAndPrintMetrics(pathCaptor.capture());
         List<String> metricPathsList = Lists.newArrayList();

--- a/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/ListenerMetricsCollectorTest.java
+++ b/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/ListenerMetricsCollectorTest.java
@@ -26,7 +26,6 @@ import com.appdynamics.extensions.webspheremq.common.WMQUtil;
 import com.appdynamics.extensions.webspheremq.config.QueueManager;
 import com.appdynamics.extensions.webspheremq.config.WMQMetricOverride;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.Lists;
 import com.ibm.mq.constants.CMQCFC;
 import com.ibm.mq.headers.pcf.PCFMessage;
 import com.ibm.mq.headers.pcf.PCFMessageAgent;
@@ -40,8 +39,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CountDownLatch;
 
+import static com.appdynamics.extensions.webspheremq.metricscollector.MetricAssert.assertThatMetric;
+import static com.appdynamics.extensions.webspheremq.metricscollector.MetricPropertiesAssert.standardPropsForAlias;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
@@ -78,37 +78,29 @@ class ListenerMetricsCollectorTest {
 
     @Test
     public void testPublishMetrics() throws Exception {
-        CountDownLatch latch = mock(CountDownLatch.class);
         when(pcfMessageAgent.send(any(PCFMessage.class))).thenReturn(createPCFResponseForInquireListenerStatusCmd());
         IntAttributesBuilder attributesBuilder = new IntAttributesBuilder(listenerMetricsToReport);
         MetricsCollectorContext context = new MetricsCollectorContext(listenerMetricsToReport, attributesBuilder, queueManager, pcfMessageAgent, metricWriteHelper);
         classUnderTest = new ListenerMetricsCollector(context, metricCreator);
         classUnderTest.publishMetrics();
         verify(metricWriteHelper, times(2)).transformAndPrintMetrics(pathCaptor.capture());
-        List<String> metricPathsList = Lists.newArrayList();
-        metricPathsList.add("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QM1|Listeners|DEV.DEFAULT.LISTENER.TCP|Status");
-        metricPathsList.add("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QM1|Listeners|DEV.LISTENER.TCP|Status");
-        metricPathsList.add("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QM1|Listeners|SYSTEM.DEFAULT.LISTENER.TCP|Status");
 
         List<List<Metric>> allValues = pathCaptor.getAllValues();
         assertThat(allValues).hasSize(2);
         assertThat(allValues.get(0)).hasSize(1);
         assertThat(allValues.get(1)).hasSize(1);
-        for (List<Metric> metricList : allValues) {
-            /* TODO: Note -- the list could be the right size but the data inside completely borked
-               and this poorly written test would still pass. Please fix some day. */
-            for (Metric metric : metricList) {
-                if (metricPathsList.contains(metric.getMetricPath())) {
-                    if (metric.getMetricPath().equals("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QM1|Listeners|DEV.DEFAULT.LISTENER.TCP|Status")) {
-                        assertThat(metric.getMetricValue()).isEqualTo("2");
-                        assertThat(metric.getMetricValue()).isNotEqualTo("10");
-                    }
-                    if (metric.getMetricPath().equals("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QM1|Listeners|DEV.LISTENER.TCP|Status")) {
-                        assertThat(metric.getMetricValue()).isEqualTo("3");
-                    }
-                }
-            }
-        }
+
+        assertThatMetric(allValues.get(0).get(0))
+                .hasName("Status")
+                .hasPath("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Listeners|DEV.DEFAULT.LISTENER.TCP|Status")
+                .hasValue("2")
+                .withPropertiesMatching(standardPropsForAlias("Status"));
+
+        assertThatMetric(allValues.get(1).get(0))
+                .hasName("Status")
+                .hasPath("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Listeners|DEV.LISTENER.TCP|Status")
+                .hasValue("3")
+                .withPropertiesMatching(standardPropsForAlias("Status"));
     }
 
     /*

--- a/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/MetricPropertiesAssert.java
+++ b/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/MetricPropertiesAssert.java
@@ -3,6 +3,7 @@ package com.appdynamics.extensions.webspheremq.metricscollector;
 import com.appdynamics.extensions.metrics.MetricProperties;
 
 import java.math.BigDecimal;
+import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -42,4 +43,13 @@ public class MetricPropertiesAssert {
         assertThat(metricProperties.getDelta()).isEqualTo(delta);
         return this;
     }
+
+    public static Function<MetricProperties, MetricPropertiesAssert> standardPropsForAlias(String alias) {
+        return mp -> metricPropertiesMatching(mp)
+                .alias(alias)
+                .multiplier(BigDecimal.ONE)
+                .aggregationType("AVERAGE").timeRollup("AVERAGE").clusterRollUp("INDIVIDUAL")
+                .delta(false);
+    }
+
 }

--- a/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/QueueManagerMetricsCollectorTest.java
+++ b/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/QueueManagerMetricsCollectorTest.java
@@ -66,6 +66,7 @@ class QueueManagerMetricsCollectorTest {
     QueueManager queueManager;
     ArgumentCaptor<List> pathCaptor;
     MetricCreator metricCreator;
+    MetricsCollectorContext context;
 
     @BeforeEach
     public void setup() {
@@ -78,14 +79,14 @@ class QueueManagerMetricsCollectorTest {
         queueMgrMetricsToReport = metricsMap.get(Constants.METRIC_TYPE_QUEUE_MANAGER);
         pathCaptor = ArgumentCaptor.forClass(List.class);
         metricCreator = new MetricCreator(monitorContextConfig.getMetricPrefix(), queueManager);
+        context = new MetricsCollectorContext(queueMgrMetricsToReport, queueManager, pcfMessageAgent, metricWriteHelper);
     }
 
     @Test
     public void testProcessPCFRequestAndPublishQMetricsForInquireQStatusCmd() throws Exception {
         CountDownLatch latch = mock(CountDownLatch.class);
         when(pcfMessageAgent.send(any(PCFMessage.class))).thenReturn(createPCFResponseForInquireQMgrStatusCmd());
-        classUnderTest = new QueueManagerMetricsCollector(queueMgrMetricsToReport, monitorContextConfig, pcfMessageAgent,
-                queueManager, metricWriteHelper, latch, metricCreator);
+        classUnderTest = new QueueManagerMetricsCollector(context, metricCreator);
         classUnderTest.publishMetrics();
         verify(metricWriteHelper, times(1)).transformAndPrintMetrics(pathCaptor.capture());
         List<String> metricPathsList = Lists.newArrayList();
@@ -156,8 +157,7 @@ class QueueManagerMetricsCollectorTest {
     public void testDisplayName() throws Exception {
         CountDownLatch latch = mock(CountDownLatch.class);
         when(pcfMessageAgent.send(any(PCFMessage.class))).thenReturn(createPCFResponseForInquireQMgrStatusCmd());
-        classUnderTest = new QueueManagerMetricsCollector(queueMgrMetricsToReport, monitorContextConfig, pcfMessageAgent,
-                queueManager, metricWriteHelper, latch, metricCreator);
+        classUnderTest = new QueueManagerMetricsCollector(context, metricCreator);
         classUnderTest.publishMetrics();
         verify(metricWriteHelper, times(1)).transformAndPrintMetrics(pathCaptor.capture());
         List<String> metricPathsList = Lists.newArrayList();

--- a/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/TopicMetricsCollectorTest.java
+++ b/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/TopicMetricsCollectorTest.java
@@ -78,9 +78,13 @@ public class TopicMetricsCollectorTest {
     }
 
     @Test
-    void testpublishMetrics() throws Exception {
+    void testPublishMetrics() throws Exception {
+        MetricsCollectorContext collectorContext = new MetricsCollectorContext(topicMetricsToReport, queueManager, pcfMessageAgent, metricWriteHelper);
+        JobSubmitterContext jobContext = new JobSubmitterContext(monitorContextConfig, mock(CountDownLatch.class), collectorContext);
+        classUnderTest = new TopicMetricsCollector(topicMetricsToReport, jobContext);
+
         when(pcfMessageAgent.send(any(PCFMessage.class))).thenReturn(createPCFResponseForInquireTopicStatusCmd());
-        classUnderTest = new TopicMetricsCollector(topicMetricsToReport, monitorContextConfig, pcfMessageAgent, queueManager, metricWriteHelper, Mockito.mock(CountDownLatch.class));
+
         classUnderTest.publishMetrics();
         verify(metricWriteHelper, times(2)).transformAndPrintMetrics(pathCaptor.capture());
         List<String> metricPathsList = Lists.newArrayList();

--- a/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/TopicMetricsCollectorTest.java
+++ b/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/TopicMetricsCollectorTest.java
@@ -20,6 +20,7 @@ import com.appdynamics.extensions.AMonitorJob;
 import com.appdynamics.extensions.MetricWriteHelper;
 import com.appdynamics.extensions.conf.MonitorContextConfiguration;
 import com.appdynamics.extensions.metrics.Metric;
+import com.appdynamics.extensions.metrics.MetricProperties;
 import com.appdynamics.extensions.util.PathResolver;
 import com.appdynamics.extensions.webspheremq.common.Constants;
 import com.appdynamics.extensions.webspheremq.common.WMQUtil;
@@ -40,10 +41,15 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
+import java.util.function.Function;
 
+import static com.appdynamics.extensions.webspheremq.metricscollector.MetricAssert.assertThatMetric;
+import static com.appdynamics.extensions.webspheremq.metricscollector.MetricPropertiesAssert.metricPropertiesMatching;
+import static com.appdynamics.extensions.webspheremq.metricscollector.MetricPropertiesAssert.standardPropsForAlias;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
@@ -97,21 +103,29 @@ public class TopicMetricsCollectorTest {
         assertThat(allValues.get(0)).hasSize(2);
         assertThat(allValues.get(1)).hasSize(2);
 
-        for (List<Metric> metricList : allValues) {
-            /* TODO: Note -- the list could be the right size but the data inside completely borked
-               and this poorly written test would still pass. Please fix some day. */
-            for (Metric metric : metricList) {
-                if (metricPathsList.contains(metric.getMetricPath())) {
-                    if (metric.getMetricPath().equals("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QM1|Topics|test|PublishCount")) {
-                        assertThat(metric.getMetricValue()).isEqualTo("2");
-                        assertThat(metric.getMetricValue()).isNotEqualTo("10");
-                    }
-                    if (metric.getMetricPath().equals("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QM1|dev|SubscriptionCount")) {
-                        assertThat(metric.getMetricValue()).isEqualTo("4");
-                    }
-                }
-            }
-        }
+        assertThatMetric(allValues.get(0).get(0))
+                .hasName("SubscriptionCount")
+                .hasPath("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Topics|test|SubscriptionCount")
+                .hasValue("3")
+                .withPropertiesMatching(standardPropsForAlias("Subscription Count"));
+
+        assertThatMetric(allValues.get(0).get(1))
+                .hasName("PublishCount")
+                .hasPath("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Topics|test|PublishCount")
+                .hasValue("2")
+                .withPropertiesMatching(standardPropsForAlias("Publish Count"));
+
+        assertThatMetric(allValues.get(1).get(0))
+                .hasName("SubscriptionCount")
+                .hasPath("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Topics|dev|SubscriptionCount")
+                .hasValue("4")
+                .withPropertiesMatching(standardPropsForAlias("Subscription Count"));
+
+        assertThatMetric(allValues.get(1).get(1))
+                .hasName("PublishCount")
+                .hasPath("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Topics|dev|PublishCount")
+                .hasValue("3")
+                .withPropertiesMatching(standardPropsForAlias("Publish Count"));
     }
 
     private PCFMessage[] createPCFResponseForInquireTopicStatusCmd() {


### PR DESCRIPTION
This one includes refactoring of:

* `QueueManagerMetricsCollector`
* `TopicMetricsCollector`...which is responsible for creating and scheduling...
* `InquireTStatusCmdCollector`

There's a new class called `JobSubmitterContext` in order to help those classes that are `MetricsPublisher` implementations that also schedule delegate `MetricsPublisherJobs` via the executor service. This isn't yet used by the QueueMetricsCollector but soon will be. 