### PR TITLE
Add spotless

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,4 +29,4 @@ jobs:
           java-distribution: 'temurin'
           java-version: '11'
       - name: Maven build and test
-        run: ./mvnw package
+        run: ./mvnw verify package

--- a/README.md
+++ b/README.md
@@ -45,6 +45,15 @@ Build the package with:
 ./mvnw package
 ```
 
+### Format
+
+This project uses [spotless](https://github.com/diffplug/spotless/tree/main/plugin-maven) to provide 
+consistent code format. To format your code:
+
+```shell
+./mvnw spotless:apply
+```
+
 ## Run
 
 Run the standalone jar alongside the IBM jar:

--- a/buildscripts/spotless.license.java
+++ b/buildscripts/spotless.license.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/pom.xml
+++ b/pom.xml
@@ -469,6 +469,33 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <version>2.44.4</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal> <!-- so spotless runs in ./mvnw verify -->
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <java>
+                        <includes>
+                            <include>src/main/java/**/*.java</include>
+                            <include>src/test/java/**/*.java</include>
+                            <include>src/integrationTest/java/**/*.java</include>
+                        </includes>
+                        <googleJavaFormat />
+                        <importOrder />
+                    </java>
+                    <!-- TODO: ADD LICENSE HEADER -->
+                    <licenseHeader>
+                        <file>${project.basedir}/buildscripts/spotless.license.java</file>
+                    </licenseHeader>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <repositories>

--- a/src/integrationTest/java/com/splunk/ibm/mq/integration/opentelemetry/TestResultMetricExporter.java
+++ b/src/integrationTest/java/com/splunk/ibm/mq/integration/opentelemetry/TestResultMetricExporter.java
@@ -7,13 +7,12 @@
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package com.splunk.ibm.mq.integration.opentelemetry;
 
 import io.opentelemetry.sdk.common.CompletableResultCode;
@@ -21,39 +20,36 @@ import io.opentelemetry.sdk.metrics.InstrumentType;
 import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
+import java.util.Collection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collection;
-
-/**
- * Metric Exporter for integration test purposes
- */
+/** Metric Exporter for integration test purposes */
 public class TestResultMetricExporter implements MetricExporter {
 
-    private final Logger logger = LoggerFactory.getLogger(TestResultMetricExporter.class);
+  private final Logger logger = LoggerFactory.getLogger(TestResultMetricExporter.class);
 
-    @Override
-    public AggregationTemporality getAggregationTemporality(InstrumentType instrumentType) {
-        return AggregationTemporality.DELTA;
-    }
+  @Override
+  public AggregationTemporality getAggregationTemporality(InstrumentType instrumentType) {
+    return AggregationTemporality.DELTA;
+  }
 
-    @Override
-    public CompletableResultCode export(Collection<MetricData> metrics) {
-        // Initial commit only does logging
-        metrics.forEach(metricData -> logger.info("Exported metric: {}", metricData));
+  @Override
+  public CompletableResultCode export(Collection<MetricData> metrics) {
+    // Initial commit only does logging
+    metrics.forEach(metricData -> logger.info("Exported metric: {}", metricData));
 
-        return CompletableResultCode.ofSuccess();
-    }
+    return CompletableResultCode.ofSuccess();
+  }
 
-    @Override
-    public CompletableResultCode shutdown() {
-        // Placeholder implementation for shutting down the exporter
-        return CompletableResultCode.ofSuccess();
-    }
+  @Override
+  public CompletableResultCode shutdown() {
+    // Placeholder implementation for shutting down the exporter
+    return CompletableResultCode.ofSuccess();
+  }
 
-    @Override
-    public CompletableResultCode flush() {
-        return CompletableResultCode.ofSuccess();
-    }
+  @Override
+  public CompletableResultCode flush() {
+    return CompletableResultCode.ofSuccess();
+  }
 }

--- a/src/integrationTest/java/com/splunk/ibm/mq/integration/tests/TestWMQMonitor.java
+++ b/src/integrationTest/java/com/splunk/ibm/mq/integration/tests/TestWMQMonitor.java
@@ -7,13 +7,12 @@
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package com.splunk.ibm.mq.integration.tests;
 
 import com.appdynamics.extensions.MetricWriteHelper;
@@ -23,47 +22,54 @@ import com.appdynamics.extensions.webspheremq.WMQMonitor;
 import com.appdynamics.extensions.webspheremq.WMQMonitorTask;
 import com.appdynamics.extensions.webspheremq.config.QueueManager;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 /**
- * The TestWMQMonitor class extends the WMQMonitor class and provides a test implementation
- * of the WebSphere MQ monitoring functionality. It is intended for internal integration test purposes
- * and facilitates custom configuration through a test configuration file and a test metric write helper.
+ * The TestWMQMonitor class extends the WMQMonitor class and provides a test implementation of the
+ * WebSphere MQ monitoring functionality. It is intended for internal integration test purposes and
+ * facilitates custom configuration through a test configuration file and a test metric write
+ * helper.
  */
 class TestWMQMonitor extends WMQMonitor {
 
-    private final MetricWriteHelper overrideHelper;
+  private final MetricWriteHelper overrideHelper;
 
-    TestWMQMonitor(String testConfigFile, MetricWriteHelper overrideHelper) {
-        super(overrideHelper);
-        this.overrideHelper = overrideHelper;
-        Map<String, String> args = new HashMap<>();
-        args.put("config-file", testConfigFile);
-        initialize(args);
+  TestWMQMonitor(String testConfigFile, MetricWriteHelper overrideHelper) {
+    super(overrideHelper);
+    this.overrideHelper = overrideHelper;
+    Map<String, String> args = new HashMap<>();
+    args.put("config-file", testConfigFile);
+    initialize(args);
+  }
+
+  /**
+   * Executes a test run for monitoring WebSphere MQ queue managers based on the provided
+   * configuration "testConfigFile".
+   *
+   * <p>The method retrieves "queueManagers" from the yml configuration file and uses a custom
+   * MetricWriteHelper if provided, initializes a TasksExecutionServiceProvider, and executes the
+   * WMQMonitorTask
+   */
+  void testrun() {
+    List<Map> queueManagers =
+        (List<Map>) this.getContextConfiguration().getConfigYml().get("queueManagers");
+    AssertUtils.assertNotNull(
+        queueManagers, "The 'queueManagers' section in config.yml is not initialised");
+    ObjectMapper mapper = new ObjectMapper();
+    // we override this helper to pass in our opentelemetry helper instead.
+    if (this.overrideHelper != null) {
+      TasksExecutionServiceProvider tasksExecutionServiceProvider =
+          new TasksExecutionServiceProvider(this, this.overrideHelper);
+
+      for (Map queueManager : queueManagers) {
+        QueueManager qManager = mapper.convertValue(queueManager, QueueManager.class);
+        WMQMonitorTask wmqTask =
+            new WMQMonitorTask(
+                tasksExecutionServiceProvider, this.getContextConfiguration(), qManager);
+        wmqTask.run();
+      }
     }
-
-    /**
-     * Executes a test run for monitoring WebSphere MQ queue managers based on the provided configuration "testConfigFile".
-     * <p>
-     * The method retrieves "queueManagers" from the yml configuration file and uses a custom MetricWriteHelper if provided, initializes a TasksExecutionServiceProvider,
-     * and executes the WMQMonitorTask
-     */
-    void testrun() {
-        List<Map> queueManagers = (List<Map>) this.getContextConfiguration().getConfigYml().get("queueManagers");
-        AssertUtils.assertNotNull(queueManagers, "The 'queueManagers' section in config.yml is not initialised");
-        ObjectMapper mapper = new ObjectMapper();
-        // we override this helper to pass in our opentelemetry helper instead.
-        if (this.overrideHelper != null) {
-            TasksExecutionServiceProvider tasksExecutionServiceProvider = new TasksExecutionServiceProvider(this, this.overrideHelper);
-
-            for (Map queueManager : queueManagers) {
-                QueueManager qManager = mapper.convertValue(queueManager, QueueManager.class);
-                WMQMonitorTask wmqTask = new WMQMonitorTask(tasksExecutionServiceProvider, this.getContextConfiguration(), qManager);
-                wmqTask.run();
-            }
-        }
-    }
+  }
 }

--- a/src/integrationTest/java/com/splunk/ibm/mq/integration/tests/WMQMonitorIntegrationTest.java
+++ b/src/integrationTest/java/com/splunk/ibm/mq/integration/tests/WMQMonitorIntegrationTest.java
@@ -7,67 +7,62 @@
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-
 package com.splunk.ibm.mq.integration.tests;
 
 import com.appdynamics.extensions.MetricWriteHelper;
 import com.appdynamics.extensions.opentelemetry.OpenTelemetryMetricWriteHelper;
 import com.splunk.ibm.mq.integration.opentelemetry.TestResultMetricExporter;
+import java.io.File;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Paths;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.nio.file.Paths;
-
-/**
- * Integration Test for WMQMonitor
- */
+/** Integration Test for WMQMonitor */
 class WMQMonitorIntegrationTest {
 
-    private static final Logger logger = LoggerFactory.getLogger(WMQMonitorIntegrationTest.class);
+  private static final Logger logger = LoggerFactory.getLogger(WMQMonitorIntegrationTest.class);
 
-    @NotNull
-    private String getConfigFile(String resourcePath) throws URISyntaxException {
-        URL resource = getClass().getClassLoader().getResource(resourcePath);
-        if (resource == null) {
-            throw new IllegalArgumentException("file not found!");
-        }
-
-        File file = Paths.get(resource.toURI()).toFile();
-        logger.info("Config file: {}", file.getAbsolutePath());
-        return file.getAbsolutePath();
+  @NotNull
+  private String getConfigFile(String resourcePath) throws URISyntaxException {
+    URL resource = getClass().getClassLoader().getResource(resourcePath);
+    if (resource == null) {
+      throw new IllegalArgumentException("file not found!");
     }
 
-    @Test
-    void test_monitor_with_full_config() throws Exception {
-        logger.info("\n\n\n\n\n\nRunning test: test_monitor_with_full_config");
-        TestResultMetricExporter testExporter = new TestResultMetricExporter();
-        MetricWriteHelper metricWriteHelper = new OpenTelemetryMetricWriteHelper(testExporter);
-        String configFile = getConfigFile("conf/test-config.yml");
+    File file = Paths.get(resource.toURI()).toFile();
+    logger.info("Config file: {}", file.getAbsolutePath());
+    return file.getAbsolutePath();
+  }
 
-        TestWMQMonitor monitor = new TestWMQMonitor(configFile, metricWriteHelper);
-        monitor.testrun();
+  @Test
+  void test_monitor_with_full_config() throws Exception {
+    logger.info("\n\n\n\n\n\nRunning test: test_monitor_with_full_config");
+    TestResultMetricExporter testExporter = new TestResultMetricExporter();
+    MetricWriteHelper metricWriteHelper = new OpenTelemetryMetricWriteHelper(testExporter);
+    String configFile = getConfigFile("conf/test-config.yml");
 
-    }
+    TestWMQMonitor monitor = new TestWMQMonitor(configFile, metricWriteHelper);
+    monitor.testrun();
+  }
 
-    @Test
-    void test_wmqmonitor() throws Exception {
-        logger.info("\n\n\n\n\n\nRunning test: test_wmqmonitor");
-        TestResultMetricExporter testExporter = new TestResultMetricExporter();
-        MetricWriteHelper metricWriteHelper = new OpenTelemetryMetricWriteHelper(testExporter);
-        String configFile = getConfigFile("conf/test-queuemgr-config.yml");
+  @Test
+  void test_wmqmonitor() throws Exception {
+    logger.info("\n\n\n\n\n\nRunning test: test_wmqmonitor");
+    TestResultMetricExporter testExporter = new TestResultMetricExporter();
+    MetricWriteHelper metricWriteHelper = new OpenTelemetryMetricWriteHelper(testExporter);
+    String configFile = getConfigFile("conf/test-queuemgr-config.yml");
 
-        TestWMQMonitor monitor = new TestWMQMonitor(configFile, metricWriteHelper);
-        monitor.testrun();
-    }
+    TestWMQMonitor monitor = new TestWMQMonitor(configFile, metricWriteHelper);
+    monitor.testrun();
+  }
 }

--- a/src/main/java/com/appdynamics/extensions/opentelemetry/Config.java
+++ b/src/main/java/com/appdynamics/extensions/opentelemetry/Config.java
@@ -13,67 +13,67 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.appdynamics.extensions.opentelemetry;
+
+import static io.opentelemetry.exporter.otlp.internal.OtlpConfigUtil.DATA_TYPE_METRICS;
 
 import io.opentelemetry.exporter.otlp.internal.OtlpConfigUtil;
 import io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporter;
 import io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporterBuilder;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
-
 import java.util.HashMap;
 import java.util.Map;
 
-import static io.opentelemetry.exporter.otlp.internal.OtlpConfigUtil.DATA_TYPE_METRICS;
-
-/**
- * Utilities reading configuration and create domain objects
- */
+/** Utilities reading configuration and create domain objects */
 class Config {
 
-    static OtlpGrpcMetricExporter createOtlpGrpcMetricsExporter(Map<String, ?> config) {
-        OtlpGrpcMetricExporterBuilder builder = OtlpGrpcMetricExporter.builder();
+  static OtlpGrpcMetricExporter createOtlpGrpcMetricsExporter(Map<String, ?> config) {
+    OtlpGrpcMetricExporterBuilder builder = OtlpGrpcMetricExporter.builder();
 
-        Map<String, String> props = new HashMap<>();
-        if (config.get("otlpExporter") instanceof Map) {
-            Map otlpConfig = (Map) config.get("otlpExporter");
-            for (Object key : otlpConfig.keySet()) {
-                if (key instanceof String && otlpConfig.get(key) instanceof String) {
-                    props.put((String) key, (String) otlpConfig.get(key));
-                }
-            }
+    Map<String, String> props = new HashMap<>();
+    if (config.get("otlpExporter") instanceof Map) {
+      Map otlpConfig = (Map) config.get("otlpExporter");
+      for (Object key : otlpConfig.keySet()) {
+        if (key instanceof String && otlpConfig.get(key) instanceof String) {
+          props.put((String) key, (String) otlpConfig.get(key));
         }
-
-        OtlpConfigUtil.configureOtlpExporterBuilder(
-                DATA_TYPE_METRICS,
-                DefaultConfigProperties.create(props),
-                builder::setEndpoint,
-                builder::addHeader,
-                builder::setCompression,
-                builder::setTimeout,
-                builder::setTrustedCertificates,
-                builder::setClientTls,
-                builder::setRetryPolicy,
-                builder::setMemoryMode);
-
-        return builder.build();
+      }
     }
 
-    static void setUpSSLConnection(Map<String, ?> config) {
-        if (config.get("sslConnection") instanceof Map) {
-            Map otlpConfig = (Map) config.get("sslConnection");
+    OtlpConfigUtil.configureOtlpExporterBuilder(
+        DATA_TYPE_METRICS,
+        DefaultConfigProperties.create(props),
+        builder::setEndpoint,
+        builder::addHeader,
+        builder::setCompression,
+        builder::setTimeout,
+        builder::setTrustedCertificates,
+        builder::setClientTls,
+        builder::setRetryPolicy,
+        builder::setMemoryMode);
 
-            getConfigValueAndSetSystemProperty(otlpConfig, "keyStorePath", "javax.net.ssl.keyStore");
-            getConfigValueAndSetSystemProperty(otlpConfig, "keyStorePassword", "javax.net.ssl.keyStorePassword");
-            getConfigValueAndSetSystemProperty(otlpConfig, "trustStorePath", "javax.net.ssl.trustStorePath");
-            getConfigValueAndSetSystemProperty(otlpConfig, "trustStorePassword", "javax.net.ssl.trustStorePassword");
-        }
-    }
+    return builder.build();
+  }
 
-    private static void getConfigValueAndSetSystemProperty(Map otlpConfig, String configKey, String systemKey) {
-        Object configValue = otlpConfig.get(configKey);
-        if (configValue instanceof String && !((String) configValue).trim().isEmpty()) {
-            System.setProperty(systemKey, (String) configValue);
-        }
+  static void setUpSSLConnection(Map<String, ?> config) {
+    if (config.get("sslConnection") instanceof Map) {
+      Map otlpConfig = (Map) config.get("sslConnection");
+
+      getConfigValueAndSetSystemProperty(otlpConfig, "keyStorePath", "javax.net.ssl.keyStore");
+      getConfigValueAndSetSystemProperty(
+          otlpConfig, "keyStorePassword", "javax.net.ssl.keyStorePassword");
+      getConfigValueAndSetSystemProperty(
+          otlpConfig, "trustStorePath", "javax.net.ssl.trustStorePath");
+      getConfigValueAndSetSystemProperty(
+          otlpConfig, "trustStorePassword", "javax.net.ssl.trustStorePassword");
     }
+  }
+
+  private static void getConfigValueAndSetSystemProperty(
+      Map otlpConfig, String configKey, String systemKey) {
+    Object configValue = otlpConfig.get(configKey);
+    if (configValue instanceof String && !((String) configValue).trim().isEmpty()) {
+      System.setProperty(systemKey, (String) configValue);
+    }
+  }
 }

--- a/src/main/java/com/appdynamics/extensions/opentelemetry/MQOtelTranslator.java
+++ b/src/main/java/com/appdynamics/extensions/opentelemetry/MQOtelTranslator.java
@@ -28,9 +28,6 @@ import io.opentelemetry.sdk.metrics.internal.data.ImmutableGaugeData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableLongPointData;
 import io.opentelemetry.sdk.metrics.internal.data.ImmutableMetricData;
 import io.opentelemetry.sdk.resources.Resource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -38,246 +35,321 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class MQOtelTranslator {
 
-    public static final Logger logger = LoggerFactory.getLogger(MQOtelTranslator.class);
+  public static final Logger logger = LoggerFactory.getLogger(MQOtelTranslator.class);
 
-    private static final long SCRAPE_PERIOD_NS = 60L * 1000 * 1000 * 1000;
-    private static final Splitter PIPE_SPLITTER = Splitter.on('|').trimResults();
+  private static final long SCRAPE_PERIOD_NS = 60L * 1000 * 1000 * 1000;
+  private static final Splitter PIPE_SPLITTER = Splitter.on('|').trimResults();
 
-    private static class Mapping {
-        private final Map<String, String> nameMappings;
-        private final Function<List<String>, Attributes> attributeMappingFunction;
+  private static class Mapping {
+    private final Map<String, String> nameMappings;
+    private final Function<List<String>, Attributes> attributeMappingFunction;
 
-        Mapping(Map<String, String> nameMappings, Function<List<String>, Attributes> attributeMappingFunction) {
-            this.nameMappings = nameMappings;
-            this.attributeMappingFunction = attributeMappingFunction;
-        }
+    Mapping(
+        Map<String, String> nameMappings,
+        Function<List<String>, Attributes> attributeMappingFunction) {
+      this.nameMappings = nameMappings;
+      this.attributeMappingFunction = attributeMappingFunction;
     }
+  }
 
-    private static final Mapping queueMgrMetricNameMappings = new Mapping(new HashMap<String, String>() {{
-        put("Status", "mq.manager.status");
-        put("ConnectionCount", "mq.manager.connection.count");
-    }}, segments -> {
-        AttributesBuilder builder = Attributes.builder();
-        builder.put("queue.manager", segments.get(segments.size() - 2));
-        return builder.build();
-    });
-
-    //Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Queues|DEV.DEAD.LETTER.QUEUE|local|UncommittedMsgs
-    //Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Queues|DEV.QUEUE.1|local|UncommittedMsgs
-    //Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Queues|DEV.QUEUE.2|local|UncommittedMsgs
-    //Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Queues|DEV.QUEUE.3|local|UncommittedMsgs
-    //Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Queues|DEV.DEAD.LETTER.QUEUE|local|Max Queue Depth
-    //Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Queues|DEV.DEAD.LETTER.QUEUE|local|Current Queue Depth
-    //Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Queues|DEV.DEAD.LETTER.QUEUE|local|Open Input Count
-    //Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Queues|DEV.DEAD.LETTER.QUEUE|local|Open Output Count
-    //Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Queues|DEV.QUEUE.1|local|Max Queue Depth
-    //Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Queues|DEV.QUEUE.1|local|Current Queue Depth
-    //Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Queues|DEV.QUEUE.1|local|Open Input Count
-    //Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Queues|DEV.QUEUE.1|local|Open Output Count
-    //Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Queues|DEV.QUEUE.2|local|Max Queue Depth
-    //Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Queues|DEV.QUEUE.2|local|Current Queue Depth
-    //Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Queues|DEV.QUEUE.2|local|Open Input Count
-    //Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Queues|DEV.QUEUE.2|local|Open Output Count
-    //Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Queues|DEV.QUEUE.3|local|Max Queue Depth
-    //Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Queues|DEV.QUEUE.3|local|Current Queue Depth
-    //Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Queues|DEV.QUEUE.3|local|Open Input Count
-    //Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Queues|DEV.QUEUE.3|local|Open Output Count
-    //Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Queues|DEV.DEAD.LETTER.QUEUE|local|OnQTime_1
-    //Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Queues|DEV.DEAD.LETTER.QUEUE|local|OnQTime_2
-    //Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Queues|DEV.DEAD.LETTER.QUEUE|local|Current maximum queue file size
-    //Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Queues|DEV.DEAD.LETTER.QUEUE|local|Current queue file size
-    private static final Mapping queueMetricNameMappings = new Mapping(new HashMap<String, String>() {{
-        put("Max Queue Depth", "mq.max.queue.depth");
-        put("Current Queue Depth", "mq.queue.depth");
-        put("Open Input Count", "mq.open.input.count");
-        put("Open Output Count", "mq.open.output.count");
-        put("OldestMsgAge", "mq.oldest.msg.age");
-        put("OnQTime", "mq.onqtime");
-        put("OnQTime_1", "mq.onqtime.1");
-        put("OnQTime_2", "mq.onqtime.2");
-        put("UncommittedMsgs", "mq.uncommitted.msgs");
-        put("HighQDepth", "mq.high.queue.depth");
-        put("MsgDeqCount", "mq.message.deq.count");
-        put("MsgEnqCount", "mq.message.enq.count");
-        put("Current maximum queue file size", "mq.current.max.queue.filesize");
-        put("Current queue file size", "mq.current.queue.filesize");
-        put("Uncommitted Messages", "mq.uncommitted.messages");
-        put("Service Interval Event", "mq.service.interval.event");
-        put("Service Interval", "mq.service.interval");
-    }},
-            segments -> {
-                AttributesBuilder builder = Attributes.builder();
-                builder.put("queue.manager", segments.get(segments.size() - 5));
-                builder.put("queue.name", segments.get(segments.size() - 3));
-                builder.put("queue.type", segments.get(segments.size() - 2));
-                return builder.build();
-            });
-
-    //Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Channels|CLOUD.ADMIN.SVRCONN|Status
-    //Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Channels|CLOUD.ADMIN.SVRCONN|Messages
-    //Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Channels|CLOUD.ADMIN.SVRCONN|Buffers Sent
-    //Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Channels|CLOUD.ADMIN.SVRCONN|Byte Sent
-    //Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Channels|CLOUD.ADMIN.SVRCONN|Buffers Received
-    //Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Channels|CLOUD.ADMIN.SVRCONN|Byte Received
-    //Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Listeners|CLOUD.LISTENER.TCP|Status
-    //Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Channels|CLOUD.ADMIN.SVRCONN|Current Sharing Conversations
-    private static final Mapping channelMetricNameMappings = new Mapping(new HashMap<String, String>() {{
-        put("Messages", "mq.messages");
-        put("Status", "mq.status");
-        put("Byte Sent", "mq.byte.sent");
-        put("Byte Received", "mq.byte.received");
-        put("Buffers Sent", "mq.buffers.sent");
-        put("Buffers Received", "mq.buffers.received");
-        put("Current Sharing Conversations", "mq.current.sharing.conversations");
-        put("Max Sharing Conversations", "mq.max.sharing.conversations");
-        put("Max Instances", "mq.max.instances");
-        put("Max Instances per Client", "mq.instances.per.client");
-        put("Message Retry Count", "mq.message.retry.count");
-        put("Message Received Count", "mq.message.received.count");
-        put("Message Sent", "mq.message.sent.count");
-    }}, segments -> {
-        AttributesBuilder builder = Attributes.builder();
-        builder.put("queue.manager", segments.get(segments.size() - 4));
-        builder.put("channel.name", segments.get(segments.size() - 2));
-        return builder.build();
-    });
-
-    private static final Mapping listenerMetricNameMappings = new Mapping(new HashMap<String, String>() {{
-        put("Status", "mq.status");
-    }}, segments -> {
-        AttributesBuilder builder = Attributes.builder();
-        builder.put("queue.manager", segments.get(segments.size() - 4));
-        builder.put("channel.name", segments.get(segments.size() - 2));
-        return builder.build();
-    });
-
-    //Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Topics|dev|Publish Count
-    //Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Topics|dev|Subscription Count
-    //Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Topics|dev/|Publish Count
-    //Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Topics|dev/|Subscription Count
-    private static final Mapping topicMetricNameMappings = new Mapping(new HashMap<String, String>() {{
-        put("Publish Count", "mq.publish.count");
-        put("Subscription Count", "mq.subscription.count");
-    }}, segments -> {
-        AttributesBuilder builder = Attributes.builder();
-        builder.put("queue.manager", segments.get(segments.size() - 4));
-        builder.put("topic.name", segments.get(segments.size() - 2));
-        return builder.build();
-    });
-
-    //Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Channels|ActiveChannelsCount
-    private static final Mapping channelsNameMapping = new Mapping(new HashMap<String, String>() {{
-        put("ActiveChannelsCount", "mq.active.channels");
-    }},
-            segments -> {
-                AttributesBuilder builder = Attributes.builder();
-                builder.put("queue.manager", segments.get(segments.size() - 3));
-                return builder.build();
-            });
-
-    //Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Status
-    //Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|ConnectionCount
-    //Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|HeartBeat
-    private static final Mapping websphereMQNameMappings = new Mapping(new HashMap<String, String>() {{
-        put("Status", "mq.manager.status");
-        put("ConnectionCount", "mq.connection.count");
-        put("HeartBeat", "mq.heartbeat");
-        put("Restart Log Size", "mq.restart.log.size");
-        put("Reusable Log Size", "mq.reusable.log.size");
-        put("Archive Log Size", "mq.archive.log.size");
-        put("Statistics Interval", "mq.manager.statistics.interval");
-        put("Max Handles", "mq.manager.max.handles");
-    }},
-            segments -> {
-                AttributesBuilder builder = Attributes.builder();
-                builder.put("queue.manager", segments.get(segments.size() - 2));
-                return builder.build();
-            });
-
-    private static final Map<String, Mapping> nameMappings = new HashMap<String, Mapping>() {{
-        put("Queue Manager", queueMgrMetricNameMappings);
-        put("Queues", queueMetricNameMappings);
-        put("Channels", channelMetricNameMappings);
-        put("ChannelsGlobal", channelsNameMapping);
-        put("Listeners", listenerMetricNameMappings);
-        put("Topics", topicMetricNameMappings);
-        put("WebsphereMQ", websphereMQNameMappings);
-    }};
-
-    public MQOtelTranslator() {
-    }
-
-    public Collection<MetricData> translate(List<Metric> metricList) {
-        AssertUtils.assertNotNull(metricList, "Metrics List cannot be null");
-        Resource res = Resource.empty();
-        InstrumentationScopeInfo scopeInfo = InstrumentationScopeInfo.create("websphere/mq");
-        List<MetricData> metrics = new ArrayList<>();
-        for (Metric metric : metricList) {
-            Instant now = Instant.now();
-            long endTime = now.getEpochSecond() * 1_000_000_000 + now.getNano();
-            long startingTime = endTime - SCRAPE_PERIOD_NS;
-
-            ConversionResult result = convertMetricInfo(metric);
-            if (result == null) {
-                continue;
+  private static final Mapping queueMgrMetricNameMappings =
+      new Mapping(
+          new HashMap<String, String>() {
+            {
+              put("Status", "mq.manager.status");
+              put("ConnectionCount", "mq.manager.connection.count");
             }
+          },
+          segments -> {
+            AttributesBuilder builder = Attributes.builder();
+            builder.put("queue.manager", segments.get(segments.size() - 2));
+            return builder.build();
+          });
 
-            LongPointData pointData = ImmutableLongPointData.create(startingTime, endTime, result.attributes, Long.parseLong(metric.getMetricValue()));
-            MetricData otelMetricData = ImmutableMetricData.createLongGauge(
-                    res,
-                    scopeInfo,
-                    result.metricName,
-                    metric.getMetricPath(),
-                    "1",
-                    ImmutableGaugeData.create(Collections.singleton(pointData)));
-
-            metrics.add(otelMetricData);
-            logger.debug("\nTranslating Metric: {} \nto Otel: {}\n", metric, otelMetricData);
-        }
-        return metrics;
-    }
-
-    ConversionResult convertMetricInfo(Metric metric) {
-        String metricPath = metric.getMetricPath();
-        List<String> splitList = new ArrayList<>(PIPE_SPLITTER.splitToList(metricPath));
-        Mapping mappings;
-        if (metricPath.endsWith("Channels|ActiveChannelsCount")) {
-            mappings = nameMappings.get("ChannelsGlobal");
-        } else {
-            mappings = nameMappings.get(splitList.get(splitList.size() - 3));
-            if (mappings == null) {
-                mappings = nameMappings.get(splitList.get(splitList.size() - 4));
+  // Server|Component:atoulme|Custom
+  // Metrics|WebsphereMQ|mq1|Queues|DEV.DEAD.LETTER.QUEUE|local|UncommittedMsgs
+  // Server|Component:atoulme|Custom
+  // Metrics|WebsphereMQ|mq1|Queues|DEV.QUEUE.1|local|UncommittedMsgs
+  // Server|Component:atoulme|Custom
+  // Metrics|WebsphereMQ|mq1|Queues|DEV.QUEUE.2|local|UncommittedMsgs
+  // Server|Component:atoulme|Custom
+  // Metrics|WebsphereMQ|mq1|Queues|DEV.QUEUE.3|local|UncommittedMsgs
+  // Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Queues|DEV.DEAD.LETTER.QUEUE|local|Max
+  // Queue Depth
+  // Server|Component:atoulme|Custom
+  // Metrics|WebsphereMQ|mq1|Queues|DEV.DEAD.LETTER.QUEUE|local|Current Queue Depth
+  // Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Queues|DEV.DEAD.LETTER.QUEUE|local|Open
+  // Input Count
+  // Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Queues|DEV.DEAD.LETTER.QUEUE|local|Open
+  // Output Count
+  // Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Queues|DEV.QUEUE.1|local|Max Queue
+  // Depth
+  // Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Queues|DEV.QUEUE.1|local|Current Queue
+  // Depth
+  // Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Queues|DEV.QUEUE.1|local|Open Input
+  // Count
+  // Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Queues|DEV.QUEUE.1|local|Open Output
+  // Count
+  // Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Queues|DEV.QUEUE.2|local|Max Queue
+  // Depth
+  // Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Queues|DEV.QUEUE.2|local|Current Queue
+  // Depth
+  // Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Queues|DEV.QUEUE.2|local|Open Input
+  // Count
+  // Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Queues|DEV.QUEUE.2|local|Open Output
+  // Count
+  // Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Queues|DEV.QUEUE.3|local|Max Queue
+  // Depth
+  // Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Queues|DEV.QUEUE.3|local|Current Queue
+  // Depth
+  // Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Queues|DEV.QUEUE.3|local|Open Input
+  // Count
+  // Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Queues|DEV.QUEUE.3|local|Open Output
+  // Count
+  // Server|Component:atoulme|Custom
+  // Metrics|WebsphereMQ|mq1|Queues|DEV.DEAD.LETTER.QUEUE|local|OnQTime_1
+  // Server|Component:atoulme|Custom
+  // Metrics|WebsphereMQ|mq1|Queues|DEV.DEAD.LETTER.QUEUE|local|OnQTime_2
+  // Server|Component:atoulme|Custom
+  // Metrics|WebsphereMQ|mq1|Queues|DEV.DEAD.LETTER.QUEUE|local|Current maximum queue file size
+  // Server|Component:atoulme|Custom
+  // Metrics|WebsphereMQ|mq1|Queues|DEV.DEAD.LETTER.QUEUE|local|Current queue file size
+  private static final Mapping queueMetricNameMappings =
+      new Mapping(
+          new HashMap<String, String>() {
+            {
+              put("Max Queue Depth", "mq.max.queue.depth");
+              put("Current Queue Depth", "mq.queue.depth");
+              put("Open Input Count", "mq.open.input.count");
+              put("Open Output Count", "mq.open.output.count");
+              put("OldestMsgAge", "mq.oldest.msg.age");
+              put("OnQTime", "mq.onqtime");
+              put("OnQTime_1", "mq.onqtime.1");
+              put("OnQTime_2", "mq.onqtime.2");
+              put("UncommittedMsgs", "mq.uncommitted.msgs");
+              put("HighQDepth", "mq.high.queue.depth");
+              put("MsgDeqCount", "mq.message.deq.count");
+              put("MsgEnqCount", "mq.message.enq.count");
+              put("Current maximum queue file size", "mq.current.max.queue.filesize");
+              put("Current queue file size", "mq.current.queue.filesize");
+              put("Uncommitted Messages", "mq.uncommitted.messages");
+              put("Service Interval Event", "mq.service.interval.event");
+              put("Service Interval", "mq.service.interval");
             }
-        }
+          },
+          segments -> {
+            AttributesBuilder builder = Attributes.builder();
+            builder.put("queue.manager", segments.get(segments.size() - 5));
+            builder.put("queue.name", segments.get(segments.size() - 3));
+            builder.put("queue.type", segments.get(segments.size() - 2));
+            return builder.build();
+          });
 
-        if (mappings == null) {
-            logger.warn("No mapping found for {} with segment {}", metricPath, splitList.get(splitList.size() - 3));
-            return null;
-        }
-        String metricName = mappings.nameMappings.get(splitList.get(splitList.size() - 1));
-        if (metricName == null) {
-            logger.warn("Unknown metric path {} for mappings {} with segment {} (known keys {})", metricPath, splitList.get(splitList.size() - 3), splitList.get(splitList.size() - 1), mappings.nameMappings.keySet().toArray());
-            return null;
-        }
+  // Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Channels|CLOUD.ADMIN.SVRCONN|Status
+  // Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Channels|CLOUD.ADMIN.SVRCONN|Messages
+  // Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Channels|CLOUD.ADMIN.SVRCONN|Buffers
+  // Sent
+  // Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Channels|CLOUD.ADMIN.SVRCONN|Byte Sent
+  // Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Channels|CLOUD.ADMIN.SVRCONN|Buffers
+  // Received
+  // Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Channels|CLOUD.ADMIN.SVRCONN|Byte
+  // Received
+  // Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Listeners|CLOUD.LISTENER.TCP|Status
+  // Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Channels|CLOUD.ADMIN.SVRCONN|Current
+  // Sharing Conversations
+  private static final Mapping channelMetricNameMappings =
+      new Mapping(
+          new HashMap<String, String>() {
+            {
+              put("Messages", "mq.messages");
+              put("Status", "mq.status");
+              put("Byte Sent", "mq.byte.sent");
+              put("Byte Received", "mq.byte.received");
+              put("Buffers Sent", "mq.buffers.sent");
+              put("Buffers Received", "mq.buffers.received");
+              put("Current Sharing Conversations", "mq.current.sharing.conversations");
+              put("Max Sharing Conversations", "mq.max.sharing.conversations");
+              put("Max Instances", "mq.max.instances");
+              put("Max Instances per Client", "mq.instances.per.client");
+              put("Message Retry Count", "mq.message.retry.count");
+              put("Message Received Count", "mq.message.received.count");
+              put("Message Sent", "mq.message.sent.count");
+            }
+          },
+          segments -> {
+            AttributesBuilder builder = Attributes.builder();
+            builder.put("queue.manager", segments.get(segments.size() - 4));
+            builder.put("channel.name", segments.get(segments.size() - 2));
+            return builder.build();
+          });
 
-        Attributes attr = mappings.attributeMappingFunction.apply(splitList);
+  private static final Mapping listenerMetricNameMappings =
+      new Mapping(
+          new HashMap<String, String>() {
+            {
+              put("Status", "mq.status");
+            }
+          },
+          segments -> {
+            AttributesBuilder builder = Attributes.builder();
+            builder.put("queue.manager", segments.get(segments.size() - 4));
+            builder.put("channel.name", segments.get(segments.size() - 2));
+            return builder.build();
+          });
 
-        return new ConversionResult(metricName, attr);
+  // Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Topics|dev|Publish Count
+  // Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Topics|dev|Subscription Count
+  // Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Topics|dev/|Publish Count
+  // Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Topics|dev/|Subscription Count
+  private static final Mapping topicMetricNameMappings =
+      new Mapping(
+          new HashMap<String, String>() {
+            {
+              put("Publish Count", "mq.publish.count");
+              put("Subscription Count", "mq.subscription.count");
+            }
+          },
+          segments -> {
+            AttributesBuilder builder = Attributes.builder();
+            builder.put("queue.manager", segments.get(segments.size() - 4));
+            builder.put("topic.name", segments.get(segments.size() - 2));
+            return builder.build();
+          });
+
+  // Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Channels|ActiveChannelsCount
+  private static final Mapping channelsNameMapping =
+      new Mapping(
+          new HashMap<String, String>() {
+            {
+              put("ActiveChannelsCount", "mq.active.channels");
+            }
+          },
+          segments -> {
+            AttributesBuilder builder = Attributes.builder();
+            builder.put("queue.manager", segments.get(segments.size() - 3));
+            return builder.build();
+          });
+
+  // Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|Status
+  // Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|ConnectionCount
+  // Server|Component:atoulme|Custom Metrics|WebsphereMQ|mq1|HeartBeat
+  private static final Mapping websphereMQNameMappings =
+      new Mapping(
+          new HashMap<String, String>() {
+            {
+              put("Status", "mq.manager.status");
+              put("ConnectionCount", "mq.connection.count");
+              put("HeartBeat", "mq.heartbeat");
+              put("Restart Log Size", "mq.restart.log.size");
+              put("Reusable Log Size", "mq.reusable.log.size");
+              put("Archive Log Size", "mq.archive.log.size");
+              put("Statistics Interval", "mq.manager.statistics.interval");
+              put("Max Handles", "mq.manager.max.handles");
+            }
+          },
+          segments -> {
+            AttributesBuilder builder = Attributes.builder();
+            builder.put("queue.manager", segments.get(segments.size() - 2));
+            return builder.build();
+          });
+
+  private static final Map<String, Mapping> nameMappings =
+      new HashMap<String, Mapping>() {
+        {
+          put("Queue Manager", queueMgrMetricNameMappings);
+          put("Queues", queueMetricNameMappings);
+          put("Channels", channelMetricNameMappings);
+          put("ChannelsGlobal", channelsNameMapping);
+          put("Listeners", listenerMetricNameMappings);
+          put("Topics", topicMetricNameMappings);
+          put("WebsphereMQ", websphereMQNameMappings);
+        }
+      };
+
+  public MQOtelTranslator() {}
+
+  public Collection<MetricData> translate(List<Metric> metricList) {
+    AssertUtils.assertNotNull(metricList, "Metrics List cannot be null");
+    Resource res = Resource.empty();
+    InstrumentationScopeInfo scopeInfo = InstrumentationScopeInfo.create("websphere/mq");
+    List<MetricData> metrics = new ArrayList<>();
+    for (Metric metric : metricList) {
+      Instant now = Instant.now();
+      long endTime = now.getEpochSecond() * 1_000_000_000 + now.getNano();
+      long startingTime = endTime - SCRAPE_PERIOD_NS;
+
+      ConversionResult result = convertMetricInfo(metric);
+      if (result == null) {
+        continue;
+      }
+
+      LongPointData pointData =
+          ImmutableLongPointData.create(
+              startingTime, endTime, result.attributes, Long.parseLong(metric.getMetricValue()));
+      MetricData otelMetricData =
+          ImmutableMetricData.createLongGauge(
+              res,
+              scopeInfo,
+              result.metricName,
+              metric.getMetricPath(),
+              "1",
+              ImmutableGaugeData.create(Collections.singleton(pointData)));
+
+      metrics.add(otelMetricData);
+      logger.debug("\nTranslating Metric: {} \nto Otel: {}\n", metric, otelMetricData);
+    }
+    return metrics;
+  }
+
+  ConversionResult convertMetricInfo(Metric metric) {
+    String metricPath = metric.getMetricPath();
+    List<String> splitList = new ArrayList<>(PIPE_SPLITTER.splitToList(metricPath));
+    Mapping mappings;
+    if (metricPath.endsWith("Channels|ActiveChannelsCount")) {
+      mappings = nameMappings.get("ChannelsGlobal");
+    } else {
+      mappings = nameMappings.get(splitList.get(splitList.size() - 3));
+      if (mappings == null) {
+        mappings = nameMappings.get(splitList.get(splitList.size() - 4));
+      }
     }
 
+    if (mappings == null) {
+      logger.warn(
+          "No mapping found for {} with segment {}",
+          metricPath,
+          splitList.get(splitList.size() - 3));
+      return null;
+    }
+    String metricName = mappings.nameMappings.get(splitList.get(splitList.size() - 1));
+    if (metricName == null) {
+      logger.warn(
+          "Unknown metric path {} for mappings {} with segment {} (known keys {})",
+          metricPath,
+          splitList.get(splitList.size() - 3),
+          splitList.get(splitList.size() - 1),
+          mappings.nameMappings.keySet().toArray());
+      return null;
+    }
+
+    Attributes attr = mappings.attributeMappingFunction.apply(splitList);
+
+    return new ConversionResult(metricName, attr);
+  }
 }
-
 
 class ConversionResult {
 
-    String metricName;
-    Attributes attributes;
+  String metricName;
+  Attributes attributes;
 
-    ConversionResult(String name, Attributes attributes) {
-        this.metricName = name;
-        this.attributes = attributes;
-    }
+  ConversionResult(String name, Attributes attributes) {
+    this.metricName = name;
+    this.attributes = attributes;
+  }
 }

--- a/src/main/java/com/appdynamics/extensions/opentelemetry/Main.java
+++ b/src/main/java/com/appdynamics/extensions/opentelemetry/Main.java
@@ -21,7 +21,6 @@ import com.appdynamics.extensions.yml.YmlReader;
 import com.singularity.ee.agent.systemagent.api.TaskExecutionContext;
 import com.singularity.ee.agent.systemagent.api.exception.TaskExecutionException;
 import io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporter;
-
 import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
@@ -31,45 +30,53 @@ import java.util.concurrent.TimeUnit;
 
 public class Main {
 
-    public static void main(String[] args) {
-        if (args.length == 0) {
-            System.err.println("Usage: Main <config-file>");
-            System.exit(1);
-        }
-
-        String configFile = args[0];
-        Map<String, ?> config = YmlReader.readFromFileAsMap(new File(configFile));
-
-        Config.setUpSSLConnection(config);
-
-        OtlpGrpcMetricExporter exporter = Config.createOtlpGrpcMetricsExporter(config);
-
-        WMQMonitor monitor = new WMQMonitor(new OpenTelemetryMetricWriteHelper(exporter));
-        TaskExecutionContext taskExecCtx = new TaskExecutionContext();
-
-        int numberOfThreads = 1;
-        int taskDelaySeconds = 60;
-        int initialDelaySeconds = 10;
-        if (config.get("taskSchedule") instanceof Map) {
-            Map taskSchedule = (Map) config.get("taskSchedule");
-            numberOfThreads = YmlUtils.getInt(taskSchedule.get("numberOfThreads"), numberOfThreads);
-            taskDelaySeconds = YmlUtils.getInt(taskSchedule.get("taskDelaySeconds"), taskDelaySeconds);
-            initialDelaySeconds = YmlUtils.getInt(taskSchedule.get("initialDelaySeconds"), initialDelaySeconds);
-        }
-        final ScheduledExecutorService service = Executors.newScheduledThreadPool(numberOfThreads);
-        service.scheduleAtFixedRate(() -> {
-            try {
-                Map<String, String> taskArguments = new HashMap<>();
-                taskArguments.put("config-file", configFile);
-                monitor.execute(taskArguments, taskExecCtx);
-            } catch (TaskExecutionException e) {
-                throw new RuntimeException(e);
-            }
-        }, initialDelaySeconds, taskDelaySeconds, TimeUnit.SECONDS);
-
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            service.shutdown();
-            exporter.shutdown();
-        }));
+  public static void main(String[] args) {
+    if (args.length == 0) {
+      System.err.println("Usage: Main <config-file>");
+      System.exit(1);
     }
+
+    String configFile = args[0];
+    Map<String, ?> config = YmlReader.readFromFileAsMap(new File(configFile));
+
+    Config.setUpSSLConnection(config);
+
+    OtlpGrpcMetricExporter exporter = Config.createOtlpGrpcMetricsExporter(config);
+
+    WMQMonitor monitor = new WMQMonitor(new OpenTelemetryMetricWriteHelper(exporter));
+    TaskExecutionContext taskExecCtx = new TaskExecutionContext();
+
+    int numberOfThreads = 1;
+    int taskDelaySeconds = 60;
+    int initialDelaySeconds = 10;
+    if (config.get("taskSchedule") instanceof Map) {
+      Map taskSchedule = (Map) config.get("taskSchedule");
+      numberOfThreads = YmlUtils.getInt(taskSchedule.get("numberOfThreads"), numberOfThreads);
+      taskDelaySeconds = YmlUtils.getInt(taskSchedule.get("taskDelaySeconds"), taskDelaySeconds);
+      initialDelaySeconds =
+          YmlUtils.getInt(taskSchedule.get("initialDelaySeconds"), initialDelaySeconds);
+    }
+    final ScheduledExecutorService service = Executors.newScheduledThreadPool(numberOfThreads);
+    service.scheduleAtFixedRate(
+        () -> {
+          try {
+            Map<String, String> taskArguments = new HashMap<>();
+            taskArguments.put("config-file", configFile);
+            monitor.execute(taskArguments, taskExecCtx);
+          } catch (TaskExecutionException e) {
+            throw new RuntimeException(e);
+          }
+        },
+        initialDelaySeconds,
+        taskDelaySeconds,
+        TimeUnit.SECONDS);
+
+    Runtime.getRuntime()
+        .addShutdownHook(
+            new Thread(
+                () -> {
+                  service.shutdown();
+                  exporter.shutdown();
+                }));
+  }
 }

--- a/src/main/java/com/appdynamics/extensions/opentelemetry/OpenTelemetryMetricWriteHelper.java
+++ b/src/main/java/com/appdynamics/extensions/opentelemetry/OpenTelemetryMetricWriteHelper.java
@@ -20,17 +20,17 @@ import com.appdynamics.extensions.metrics.Metric;
 import com.appdynamics.extensions.metrics.transformers.Transformer;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.math.BigDecimal;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class OpenTelemetryMetricWriteHelper extends MetricWriteHelper {
 
-  private static final Logger logger = LoggerFactory.getLogger(OpenTelemetryMetricWriteHelper.class);
+  private static final Logger logger =
+      LoggerFactory.getLogger(OpenTelemetryMetricWriteHelper.class);
 
   private final MetricExporter exporter;
 
@@ -41,11 +41,12 @@ public class OpenTelemetryMetricWriteHelper extends MetricWriteHelper {
   @Override
   public void printMetric(String metricPath, BigDecimal value, String metricType) {
     String metricName = metricPath.substring(metricPath.lastIndexOf('|'));
-    transformAndPrintMetrics(Collections.singletonList(new Metric(metricName, value.toString(), metricPath)));
+    transformAndPrintMetrics(
+        Collections.singletonList(new Metric(metricName, value.toString(), metricPath)));
   }
 
-    @Override
-    public void transformAndPrintMetrics(List<Metric> metrics) {
+  @Override
+  public void transformAndPrintMetrics(List<Metric> metrics) {
     Transformer transformer = new Transformer(metrics);
     transformer.transform();
     MQOtelTranslator mqOtelTransformer = new MQOtelTranslator();

--- a/src/main/java/com/appdynamics/extensions/webspheremq/WMQContext.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/WMQContext.java
@@ -13,9 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.appdynamics.extensions.webspheremq;
-
 
 import com.appdynamics.extensions.util.CryptoUtils;
 import com.appdynamics.extensions.util.StringUtils;
@@ -24,114 +22,113 @@ import com.appdynamics.extensions.webspheremq.config.QueueManager;
 import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
 import com.ibm.mq.constants.CMQC;
+import java.util.Hashtable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Hashtable;
-
 /**
- * Takes care of websphere mq connection, authentication, SSL, Cipher spec, certificate based authorization.<br>
+ * Takes care of websphere mq connection, authentication, SSL, Cipher spec, certificate based
+ * authorization.<br>
  * It also validates the arguments passed for various scenarios.
  */
 public class WMQContext {
 
-	public static final Logger logger = LoggerFactory.getLogger(WMQContext.class);
-	private final QueueManager queueManager;
-	private final String encryptionKey;
+  public static final Logger logger = LoggerFactory.getLogger(WMQContext.class);
+  private final QueueManager queueManager;
+  private final String encryptionKey;
 
-	public WMQContext(QueueManager queueManager, String encryptionKey) {
-		this.queueManager = queueManager;
-		this.encryptionKey = encryptionKey;
-		validateArgs();
-	}
+  public WMQContext(QueueManager queueManager, String encryptionKey) {
+    this.queueManager = queueManager;
+    this.encryptionKey = encryptionKey;
+    validateArgs();
+  }
 
-	@SuppressWarnings({ "rawtypes", "unchecked" })
-	public Hashtable getMQEnvironment() {
-		Hashtable env = new Hashtable();
-		addEnvProperty(env, CMQC.HOST_NAME_PROPERTY, queueManager.getHost());
-		addEnvProperty(env, CMQC.PORT_PROPERTY, queueManager.getPort());
-		addEnvProperty(env, CMQC.CHANNEL_PROPERTY, queueManager.getChannelName());
-		addEnvProperty(env, CMQC.USER_ID_PROPERTY, queueManager.getUsername());
-		addEnvProperty(env, CMQC.PASSWORD_PROPERTY, getPassword());
-		addEnvProperty(env, CMQC.SSL_CERT_STORE_PROPERTY, queueManager.getSslKeyRepository());
-		addEnvProperty(env, CMQC.SSL_CIPHER_SUITE_PROPERTY, queueManager.getCipherSuite());
-		//TODO: investigate on CIPHER_SPEC property No Available in MQ 7.5 Jar
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  public Hashtable getMQEnvironment() {
+    Hashtable env = new Hashtable();
+    addEnvProperty(env, CMQC.HOST_NAME_PROPERTY, queueManager.getHost());
+    addEnvProperty(env, CMQC.PORT_PROPERTY, queueManager.getPort());
+    addEnvProperty(env, CMQC.CHANNEL_PROPERTY, queueManager.getChannelName());
+    addEnvProperty(env, CMQC.USER_ID_PROPERTY, queueManager.getUsername());
+    addEnvProperty(env, CMQC.PASSWORD_PROPERTY, getPassword());
+    addEnvProperty(env, CMQC.SSL_CERT_STORE_PROPERTY, queueManager.getSslKeyRepository());
+    addEnvProperty(env, CMQC.SSL_CIPHER_SUITE_PROPERTY, queueManager.getCipherSuite());
+    // TODO: investigate on CIPHER_SPEC property No Available in MQ 7.5 Jar
 
-		if (Constants.TRANSPORT_TYPE_CLIENT.equalsIgnoreCase(queueManager.getTransportType())) {
-			addEnvProperty(env, CMQC.TRANSPORT_PROPERTY, CMQC.TRANSPORT_MQSERIES_CLIENT);
-		}
-		else if (Constants.TRANSPORT_TYPE_BINGINGS.equalsIgnoreCase(queueManager.getTransportType())) {
-			addEnvProperty(env, CMQC.TRANSPORT_PROPERTY, CMQC.TRANSPORT_MQSERIES_BINDINGS);
-		}
-		else {
-			addEnvProperty(env, CMQC.TRANSPORT_PROPERTY, CMQC.TRANSPORT_MQSERIES);
-		}
+    if (Constants.TRANSPORT_TYPE_CLIENT.equalsIgnoreCase(queueManager.getTransportType())) {
+      addEnvProperty(env, CMQC.TRANSPORT_PROPERTY, CMQC.TRANSPORT_MQSERIES_CLIENT);
+    } else if (Constants.TRANSPORT_TYPE_BINGINGS.equalsIgnoreCase(
+        queueManager.getTransportType())) {
+      addEnvProperty(env, CMQC.TRANSPORT_PROPERTY, CMQC.TRANSPORT_MQSERIES_BINDINGS);
+    } else {
+      addEnvProperty(env, CMQC.TRANSPORT_PROPERTY, CMQC.TRANSPORT_MQSERIES);
+    }
 
-        if (logger.isDebugEnabled()) {
-            logger.debug(String.format("Transport property is %s", env.get(CMQC.TRANSPORT_PROPERTY)));
+    if (logger.isDebugEnabled()) {
+      logger.debug(String.format("Transport property is %s", env.get(CMQC.TRANSPORT_PROPERTY)));
+    }
+    return env;
+  }
+
+  @SuppressWarnings({"unused", "unchecked"})
+  private void addEnvProperty(Hashtable env, String propName, Object propVal) {
+    if (null != propVal) {
+      if (propVal instanceof String) {
+        String propString = (String) propVal;
+        if (Strings.isNullOrEmpty(propString)) {
+          return;
         }
-		return env;
-	}
+      }
+      env.put(propName, propVal);
+    }
+  }
 
-	@SuppressWarnings({ "unused", "unchecked" })
-	private void addEnvProperty(Hashtable env, String propName, Object propVal) {
-		if (null != propVal) {
-			if(propVal instanceof String){
-				String propString = (String)propVal;
-				if(Strings.isNullOrEmpty(propString)){
-					return;
-				}
-			}
-			env.put(propName, propVal);
-		}
-	}
+  private void validateArgs() {
+    boolean validArgs = true;
+    StringBuilder errorMsg = new StringBuilder();
+    if (queueManager == null) {
+      validArgs = false;
+      errorMsg.append("Queue manager cannot be null");
+    } else {
+      if (Constants.TRANSPORT_TYPE_CLIENT.equalsIgnoreCase(queueManager.getTransportType())) {
+        if (!StringUtils.hasText(queueManager.getHost())) {
+          validArgs = false;
+          errorMsg.append("Host cannot be null or empty for client type connection. ");
+        }
+        if (queueManager.getPort() == -1) {
+          validArgs = false;
+          errorMsg.append("port should be set for client type connection. ");
+        }
+        if (!StringUtils.hasText(queueManager.getChannelName())) {
+          validArgs = false;
+          errorMsg.append("Channel cannot be null or empty for client type connection. ");
+        }
+      }
+      if (Constants.TRANSPORT_TYPE_BINGINGS.equalsIgnoreCase(queueManager.getTransportType())) {
+        if (!StringUtils.hasText(queueManager.getName())) {
+          validArgs = false;
+          errorMsg.append("queuemanager cannot be null or empty for bindings type connection. ");
+        }
+      }
+    }
 
-	private void validateArgs() {
-		boolean validArgs = true;
-		StringBuilder errorMsg = new StringBuilder();
-		if (queueManager == null) {
-			validArgs = false;
-			errorMsg.append("Queue manager cannot be null");
-		} else {
-			if (Constants.TRANSPORT_TYPE_CLIENT.equalsIgnoreCase(queueManager.getTransportType())) {
-				if (!StringUtils.hasText(queueManager.getHost())) {
-					validArgs = false;
-					errorMsg.append("Host cannot be null or empty for client type connection. ");
-				}
-				if (queueManager.getPort() == -1) {
-					validArgs = false;
-					errorMsg.append("port should be set for client type connection. ");
-				}
-				if (!StringUtils.hasText(queueManager.getChannelName())) {
-					validArgs = false;
-					errorMsg.append("Channel cannot be null or empty for client type connection. ");
-				}
-			}
-			if (Constants.TRANSPORT_TYPE_BINGINGS.equalsIgnoreCase(queueManager.getTransportType())) {
-				if (!StringUtils.hasText(queueManager.getName())) {
-					validArgs = false;
-					errorMsg.append("queuemanager cannot be null or empty for bindings type connection. ");
-				}
-			}
-		}
+    if (!validArgs) {
+      throw new IllegalArgumentException(errorMsg.toString());
+    }
+  }
 
-		if (!validArgs) {
-			throw new IllegalArgumentException(errorMsg.toString());
-		}
-	}
-
-	private String getPassword() {
-		String password = queueManager.getPassword();
-		if (!Strings.isNullOrEmpty(password)) {
-			return password;
-		}
-		String encryptedPassword = queueManager.getEncryptedPassword();
-		if (!Strings.isNullOrEmpty(this.encryptionKey) && !Strings.isNullOrEmpty(encryptedPassword)) {
-			java.util.Map<String, String> cryptoMap = Maps.newHashMap();
-			cryptoMap.put(com.appdynamics.extensions.Constants.ENCRYPTED_PASSWORD, encryptedPassword);
-			cryptoMap.put(com.appdynamics.extensions.Constants.ENCRYPTION_KEY, this.encryptionKey);
-			return CryptoUtils.getPassword(cryptoMap);
-		}
-		return null;
-	}
+  private String getPassword() {
+    String password = queueManager.getPassword();
+    if (!Strings.isNullOrEmpty(password)) {
+      return password;
+    }
+    String encryptedPassword = queueManager.getEncryptedPassword();
+    if (!Strings.isNullOrEmpty(this.encryptionKey) && !Strings.isNullOrEmpty(encryptedPassword)) {
+      java.util.Map<String, String> cryptoMap = Maps.newHashMap();
+      cryptoMap.put(com.appdynamics.extensions.Constants.ENCRYPTED_PASSWORD, encryptedPassword);
+      cryptoMap.put(com.appdynamics.extensions.Constants.ENCRYPTION_KEY, this.encryptionKey);
+      return CryptoUtils.getPassword(cryptoMap);
+    }
+    return null;
+  }
 }

--- a/src/main/java/com/appdynamics/extensions/webspheremq/WMQMonitor.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/WMQMonitor.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.appdynamics.extensions.webspheremq;
 
 import com.appdynamics.extensions.ABaseMonitor;
@@ -26,106 +25,122 @@ import com.appdynamics.extensions.webspheremq.config.QueueManager;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
+import java.util.List;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.List;
-import java.util.Map;
-
 public class WMQMonitor extends ABaseMonitor {
 
-	public static final Logger logger = LoggerFactory.getLogger(WMQMonitor.class);
+  public static final Logger logger = LoggerFactory.getLogger(WMQMonitor.class);
 
-	private final MetricWriteHelper overrideHelper;
+  private final MetricWriteHelper overrideHelper;
 
-	public WMQMonitor() {
-		this(null);
-	}
+  public WMQMonitor() {
+    this(null);
+  }
 
-	public WMQMonitor(MetricWriteHelper overrideHelper) {
-		this.overrideHelper = overrideHelper;
-	}
+  public WMQMonitor(MetricWriteHelper overrideHelper) {
+    this.overrideHelper = overrideHelper;
+  }
 
-	protected String getDefaultMetricPrefix() {
-		return "Custom Metrics|WMQMonitor|";
-	}
+  protected String getDefaultMetricPrefix() {
+    return "Custom Metrics|WMQMonitor|";
+  }
 
-	public String getMonitorName() {
-		return "WMQMonitor";
-	}
+  public String getMonitorName() {
+    return "WMQMonitor";
+  }
 
-	protected void doRun(TasksExecutionServiceProvider tasksExecutionServiceProvider) {
-		List<Map> queueManagers = (List<Map>) this.getContextConfiguration().getConfigYml().get("queueManagers");
-		AssertUtils.assertNotNull(queueManagers, "The 'queueManagers' section in config.yml is not initialised");
-		ObjectMapper mapper = new ObjectMapper();
-		// we override this helper to pass in our opentelemetry helper instead.
-		if (this.overrideHelper != null) {
-			tasksExecutionServiceProvider = new TasksExecutionServiceProvider(this, this.overrideHelper);
-		}
-		for (Map queueManager : queueManagers) {
-			QueueManager qManager = mapper.convertValue(queueManager, QueueManager.class);
-			WMQMonitorTask wmqTask = new WMQMonitorTask(tasksExecutionServiceProvider, this.getContextConfiguration(), qManager);
-			tasksExecutionServiceProvider.submit((String) queueManager.get("name"), wmqTask);
-		}
-	}
+  protected void doRun(TasksExecutionServiceProvider tasksExecutionServiceProvider) {
+    List<Map> queueManagers =
+        (List<Map>) this.getContextConfiguration().getConfigYml().get("queueManagers");
+    AssertUtils.assertNotNull(
+        queueManagers, "The 'queueManagers' section in config.yml is not initialised");
+    ObjectMapper mapper = new ObjectMapper();
+    // we override this helper to pass in our opentelemetry helper instead.
+    if (this.overrideHelper != null) {
+      tasksExecutionServiceProvider = new TasksExecutionServiceProvider(this, this.overrideHelper);
+    }
+    for (Map queueManager : queueManagers) {
+      QueueManager qManager = mapper.convertValue(queueManager, QueueManager.class);
+      WMQMonitorTask wmqTask =
+          new WMQMonitorTask(
+              tasksExecutionServiceProvider, this.getContextConfiguration(), qManager);
+      tasksExecutionServiceProvider.submit((String) queueManager.get("name"), wmqTask);
+    }
+  }
 
-	@Override
-	protected List<Map<String, ?>> getServers() {
-		List<Map<String, ?>> queueManagers = (List<Map<String, ?>>) getContextConfiguration().getConfigYml().get("queueManagers");
-		AssertUtils.assertNotNull(queueManagers, "The 'queueManagers' section in config.yml is not initialised");
-		return queueManagers;
-	}
+  @Override
+  protected List<Map<String, ?>> getServers() {
+    List<Map<String, ?>> queueManagers =
+        (List<Map<String, ?>>) getContextConfiguration().getConfigYml().get("queueManagers");
+    AssertUtils.assertNotNull(
+        queueManagers, "The 'queueManagers' section in config.yml is not initialised");
+    return queueManagers;
+  }
 
-	@Override
-	protected void initializeMoreStuff(Map<String, String> args) {
-		super.initializeMoreStuff(args);
-		Map<String, ?> configProperties = this.getContextConfiguration().getConfigYml();
-		Map<String, String> sslConnection = (Map<String, String>) configProperties.get("sslConnection");
+  @Override
+  protected void initializeMoreStuff(Map<String, String> args) {
+    super.initializeMoreStuff(args);
+    Map<String, ?> configProperties = this.getContextConfiguration().getConfigYml();
+    Map<String, String> sslConnection = (Map<String, String>) configProperties.get("sslConnection");
 
-		if (sslConnection != null ) {
-			String encryptionKey = (String) configProperties.get("encryptionKey");
-			logger.debug("Encryption key from config.yml set for ssl connection is {}", encryptionKey);
+    if (sslConnection != null) {
+      String encryptionKey = (String) configProperties.get("encryptionKey");
+      logger.debug("Encryption key from config.yml set for ssl connection is {}", encryptionKey);
 
-			String trustStorePath = sslConnection.get("trustStorePath");
-			if (!Strings.isNullOrEmpty(trustStorePath)) {
-				System.setProperty("javax.net.ssl.trustStore",trustStorePath);
-				logger.debug("System property set for javax.net.ssl.trustStore is {}", trustStorePath);
-				String trustStorePassword = getPassword(sslConnection.get("trustStorePassword"), sslConnection.get("trustStoreEncryptedPassword"), encryptionKey);
-				if (!Strings.isNullOrEmpty(trustStorePassword)) {
-					System.setProperty("javax.net.ssl.trustStorePassword", trustStorePassword);
-					logger.debug("System property set for javax.net.ssl.trustStorePassword is xxxxx");
-				}
-			} else {
-				logger.debug("trustStorePath is not set in config.yml, ignoring setting trustStorePath as system property");
-			}
+      String trustStorePath = sslConnection.get("trustStorePath");
+      if (!Strings.isNullOrEmpty(trustStorePath)) {
+        System.setProperty("javax.net.ssl.trustStore", trustStorePath);
+        logger.debug("System property set for javax.net.ssl.trustStore is {}", trustStorePath);
+        String trustStorePassword =
+            getPassword(
+                sslConnection.get("trustStorePassword"),
+                sslConnection.get("trustStoreEncryptedPassword"),
+                encryptionKey);
+        if (!Strings.isNullOrEmpty(trustStorePassword)) {
+          System.setProperty("javax.net.ssl.trustStorePassword", trustStorePassword);
+          logger.debug("System property set for javax.net.ssl.trustStorePassword is xxxxx");
+        }
+      } else {
+        logger.debug(
+            "trustStorePath is not set in config.yml, ignoring setting trustStorePath as system property");
+      }
 
-			String keyStorePath = sslConnection.get("keyStorePath");
-			if (!Strings.isNullOrEmpty(keyStorePath)) {
-				System.setProperty("javax.net.ssl.keyStore", keyStorePath);
-				logger.debug("System property set for javax.net.ssl.keyStore is {}", keyStorePath);
-				String keyStorePassword = getPassword(sslConnection.get("keyStorePassword"), sslConnection.get("keyStoreEncryptedPassword"), encryptionKey);
-				if (!Strings.isNullOrEmpty(keyStorePassword)) {
-					System.setProperty("javax.net.ssl.keyStorePassword",keyStorePassword);
-					logger.debug("System property set for javax.net.ssl.keyStorePassword is xxxxx");
-				}
-			} else {
-				logger.debug("keyStorePath is not set in config.yml, ignoring setting keyStorePath as system property");
-			}
-		} else {
-			logger.debug("ssl truststore and keystore are not configured in config.yml, if SSL is enabled, pass them as jvm args");
-		}
-	}
+      String keyStorePath = sslConnection.get("keyStorePath");
+      if (!Strings.isNullOrEmpty(keyStorePath)) {
+        System.setProperty("javax.net.ssl.keyStore", keyStorePath);
+        logger.debug("System property set for javax.net.ssl.keyStore is {}", keyStorePath);
+        String keyStorePassword =
+            getPassword(
+                sslConnection.get("keyStorePassword"),
+                sslConnection.get("keyStoreEncryptedPassword"),
+                encryptionKey);
+        if (!Strings.isNullOrEmpty(keyStorePassword)) {
+          System.setProperty("javax.net.ssl.keyStorePassword", keyStorePassword);
+          logger.debug("System property set for javax.net.ssl.keyStorePassword is xxxxx");
+        }
+      } else {
+        logger.debug(
+            "keyStorePath is not set in config.yml, ignoring setting keyStorePath as system property");
+      }
+    } else {
+      logger.debug(
+          "ssl truststore and keystore are not configured in config.yml, if SSL is enabled, pass them as jvm args");
+    }
+  }
 
-	private String getPassword(String password, String encryptedPassword, String encryptionKey) {
-		if (!Strings.isNullOrEmpty(password)) {
-			return password;
-		}
-		if (!Strings.isNullOrEmpty(encryptionKey) && !Strings.isNullOrEmpty(encryptedPassword)) {
-			Map<String, String> cryptoMap = Maps.newHashMap();
-			cryptoMap.put(Constants.ENCRYPTED_PASSWORD, encryptedPassword);
-			cryptoMap.put(Constants.ENCRYPTION_KEY, encryptionKey);
-			return CryptoUtils.getPassword(cryptoMap);
-		}
-		return null;
-	}
+  private String getPassword(String password, String encryptedPassword, String encryptionKey) {
+    if (!Strings.isNullOrEmpty(password)) {
+      return password;
+    }
+    if (!Strings.isNullOrEmpty(encryptionKey) && !Strings.isNullOrEmpty(encryptedPassword)) {
+      Map<String, String> cryptoMap = Maps.newHashMap();
+      cryptoMap.put(Constants.ENCRYPTED_PASSWORD, encryptedPassword);
+      cryptoMap.put(Constants.ENCRYPTION_KEY, encryptionKey);
+      return CryptoUtils.getPassword(cryptoMap);
+    }
+    return null;
+  }
 }

--- a/src/main/java/com/appdynamics/extensions/webspheremq/WMQMonitorTask.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/WMQMonitorTask.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.appdynamics.extensions.webspheremq;
 
 import com.appdynamics.extensions.AMonitorTaskRunnable;
@@ -32,247 +31,341 @@ import com.ibm.mq.MQQueueManager;
 import com.ibm.mq.headers.MQDataException;
 import com.ibm.mq.headers.pcf.PCFMessageAgent;
 import com.singularity.ee.agent.systemagent.api.exception.TaskExecutionException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-/**
- * Encapsulates all metrics collection for all artifacts related to a queue manager.
- */
+/** Encapsulates all metrics collection for all artifacts related to a queue manager. */
 public class WMQMonitorTask implements AMonitorTaskRunnable {
 
-	public static final Logger logger = LoggerFactory.getLogger(WMQMonitorTask.class);
-	private final QueueManager queueManager;
-	private MonitorContextConfiguration monitorContextConfig;
-	private Map<String, ?> configMap;
-	private MetricWriteHelper metricWriteHelper;
+  public static final Logger logger = LoggerFactory.getLogger(WMQMonitorTask.class);
+  private final QueueManager queueManager;
+  private MonitorContextConfiguration monitorContextConfig;
+  private Map<String, ?> configMap;
+  private MetricWriteHelper metricWriteHelper;
 
-	public WMQMonitorTask(TasksExecutionServiceProvider tasksExecutionServiceProvider,
-						  MonitorContextConfiguration monitorContextConfig,
-						  QueueManager queueManager) {
-		this.monitorContextConfig = monitorContextConfig;
-		this.queueManager = queueManager;
-		this.configMap = monitorContextConfig.getConfigYml();
-		this.metricWriteHelper = tasksExecutionServiceProvider.getMetricWriteHelper();
-	}
+  public WMQMonitorTask(
+      TasksExecutionServiceProvider tasksExecutionServiceProvider,
+      MonitorContextConfiguration monitorContextConfig,
+      QueueManager queueManager) {
+    this.monitorContextConfig = monitorContextConfig;
+    this.queueManager = queueManager;
+    this.configMap = monitorContextConfig.getConfigYml();
+    this.metricWriteHelper = tasksExecutionServiceProvider.getMetricWriteHelper();
+  }
 
-	public void run() {
-		String queueManagerTobeDisplayed = WMQUtil.getQueueManagerNameFromConfig(queueManager);
-		logger.debug("WMQMonitor thread for queueManager {} started.", queueManagerTobeDisplayed);
-		long startTime = System.currentTimeMillis();
-		MQQueueManager ibmQueueManager = null;
-		PCFMessageAgent agent = null;
-		BigDecimal heartBeatMetricValue = BigDecimal.ZERO;
-		// encryptionKey is a global setting, which we need to inject to allow decrypting the queue manager password.
-		String encryptionKey = (String) configMap.get("encryptionKey");
-		try {
-			WMQContext auth = new WMQContext(queueManager, encryptionKey);
-			Hashtable env = auth.getMQEnvironment();
-			try {
-                ibmQueueManager = new MQQueueManager(queueManager.getName(), env);
-			} catch (MQException mqe) {
-                logger.error(mqe.getMessage(), mqe);
-                throw new TaskExecutionException(mqe.getMessage());
-			}
-			logger.debug("MQQueueManager connection initiated for queueManager {} in thread {}", queueManagerTobeDisplayed, Thread.currentThread().getName());
-			heartBeatMetricValue = BigDecimal.ONE;
-			agent = initPCFMesageAgent(ibmQueueManager);
-			extractAndReportMetrics(ibmQueueManager, agent);
-		} catch (Exception e) {
-			logger.error("Error in run of " + Thread.currentThread().getName(), e);
-		} finally {
-			cleanUp(ibmQueueManager, agent);
-			metricWriteHelper.printMetric(
-					StringUtils.concatMetricPath(monitorContextConfig.getMetricPrefix(), queueManagerTobeDisplayed, "HeartBeat"),
-					heartBeatMetricValue,
-					"AVG.AVG.IND"
-			);
-			long endTime = System.currentTimeMillis() - startTime;
-			logger.debug("WMQMonitor thread for queueManager {} ended. Time taken = {} ms", queueManagerTobeDisplayed, endTime);
-		}
-	}
+  public void run() {
+    String queueManagerTobeDisplayed = WMQUtil.getQueueManagerNameFromConfig(queueManager);
+    logger.debug("WMQMonitor thread for queueManager {} started.", queueManagerTobeDisplayed);
+    long startTime = System.currentTimeMillis();
+    MQQueueManager ibmQueueManager = null;
+    PCFMessageAgent agent = null;
+    BigDecimal heartBeatMetricValue = BigDecimal.ZERO;
+    // encryptionKey is a global setting, which we need to inject to allow decrypting the queue
+    // manager password.
+    String encryptionKey = (String) configMap.get("encryptionKey");
+    try {
+      WMQContext auth = new WMQContext(queueManager, encryptionKey);
+      Hashtable env = auth.getMQEnvironment();
+      try {
+        ibmQueueManager = new MQQueueManager(queueManager.getName(), env);
+      } catch (MQException mqe) {
+        logger.error(mqe.getMessage(), mqe);
+        throw new TaskExecutionException(mqe.getMessage());
+      }
+      logger.debug(
+          "MQQueueManager connection initiated for queueManager {} in thread {}",
+          queueManagerTobeDisplayed,
+          Thread.currentThread().getName());
+      heartBeatMetricValue = BigDecimal.ONE;
+      agent = initPCFMesageAgent(ibmQueueManager);
+      extractAndReportMetrics(ibmQueueManager, agent);
+    } catch (Exception e) {
+      logger.error("Error in run of " + Thread.currentThread().getName(), e);
+    } finally {
+      cleanUp(ibmQueueManager, agent);
+      metricWriteHelper.printMetric(
+          StringUtils.concatMetricPath(
+              monitorContextConfig.getMetricPrefix(), queueManagerTobeDisplayed, "HeartBeat"),
+          heartBeatMetricValue,
+          "AVG.AVG.IND");
+      long endTime = System.currentTimeMillis() - startTime;
+      logger.debug(
+          "WMQMonitor thread for queueManager {} ended. Time taken = {} ms",
+          queueManagerTobeDisplayed,
+          endTime);
+    }
+  }
 
-	private PCFMessageAgent initPCFMesageAgent(MQQueueManager ibmQueueManager) {
-		PCFMessageAgent agent = null;
-		try {
-			if(!Strings.isNullOrEmpty(queueManager.getModelQueueName()) && !Strings.isNullOrEmpty(queueManager.getReplyQueuePrefix())){
-				logger.debug("Initializing the PCF agent for model queue and reply queue prefix.");
-				agent = new PCFMessageAgent();
-				agent.setModelQueueName(queueManager.getModelQueueName());
-				agent.setReplyQueuePrefix(queueManager.getReplyQueuePrefix());
-				logger.debug("Connecting to queueManager to set the modelQueueName and replyQueuePrefix.");
-				agent.connect(ibmQueueManager);
-			}
-			else{
-				agent = new PCFMessageAgent(ibmQueueManager);
-			}
-			if(queueManager.getCcsid() != Integer.MIN_VALUE){
-				agent.setCharacterSet(queueManager.getCcsid());
-			}
+  private PCFMessageAgent initPCFMesageAgent(MQQueueManager ibmQueueManager) {
+    PCFMessageAgent agent = null;
+    try {
+      if (!Strings.isNullOrEmpty(queueManager.getModelQueueName())
+          && !Strings.isNullOrEmpty(queueManager.getReplyQueuePrefix())) {
+        logger.debug("Initializing the PCF agent for model queue and reply queue prefix.");
+        agent = new PCFMessageAgent();
+        agent.setModelQueueName(queueManager.getModelQueueName());
+        agent.setReplyQueuePrefix(queueManager.getReplyQueuePrefix());
+        logger.debug("Connecting to queueManager to set the modelQueueName and replyQueuePrefix.");
+        agent.connect(ibmQueueManager);
+      } else {
+        agent = new PCFMessageAgent(ibmQueueManager);
+      }
+      if (queueManager.getCcsid() != Integer.MIN_VALUE) {
+        agent.setCharacterSet(queueManager.getCcsid());
+      }
 
-			if(queueManager.getEncoding() != Integer.MIN_VALUE){
-				agent.setEncoding(queueManager.getEncoding());
-			}
-			logger.debug("Initialized PCFMessageAgent for queueManager {} in thread {}", agent.getQManagerName(), Thread.currentThread().getName());
-		} catch (MQDataException mqe) {
-			logger.error(mqe.getMessage(), mqe);
-		}
-		return agent;
-	}
+      if (queueManager.getEncoding() != Integer.MIN_VALUE) {
+        agent.setEncoding(queueManager.getEncoding());
+      }
+      logger.debug(
+          "Initialized PCFMessageAgent for queueManager {} in thread {}",
+          agent.getQManagerName(),
+          Thread.currentThread().getName());
+    } catch (MQDataException mqe) {
+      logger.error(mqe.getMessage(), mqe);
+    }
+    return agent;
+  }
 
-	private void extractAndReportMetrics(MQQueueManager mqQueueManager, PCFMessageAgent agent) {
-		Map<String, Map<String, WMQMetricOverride>> metricsMap = WMQUtil.getMetricsToReportFromConfigYml((List<Map>) configMap.get("mqMetrics"));
+  private void extractAndReportMetrics(MQQueueManager mqQueueManager, PCFMessageAgent agent) {
+    Map<String, Map<String, WMQMetricOverride>> metricsMap =
+        WMQUtil.getMetricsToReportFromConfigYml((List<Map>) configMap.get("mqMetrics"));
 
-		CountDownLatch countDownLatch = new CountDownLatch(metricsMap.size());
+    CountDownLatch countDownLatch = new CountDownLatch(metricsMap.size());
 
-		Map<String, WMQMetricOverride> qMgrMetricsToReport = metricsMap.get(Constants.METRIC_TYPE_QUEUE_MANAGER);
-		if (qMgrMetricsToReport != null) {
-			Map<String, Map<String, WMQMetricOverride>> metricsByCommand = new HashMap<>();
-			for (String key : qMgrMetricsToReport.keySet()) {
-				WMQMetricOverride wmqOverride = qMgrMetricsToReport.get(key);
-				String cmd = wmqOverride.getIbmCommand() == null ? "MQCMD_INQUIRE_Q_MGR_STATUS" : wmqOverride.getIbmCommand();
-				metricsByCommand.putIfAbsent(cmd, new HashMap<>());
-				metricsByCommand.get(cmd).put(key, wmqOverride);
-			}
-			Map<String, WMQMetricOverride> queueManagerMetricsToReport = metricsByCommand.get("MQCMD_INQUIRE_Q_MGR_STATUS");
-			if (queueManagerMetricsToReport != null) {
-				MetricCreator metricCreator = new MetricCreator(monitorContextConfig.getMetricPrefix(), queueManager);
-				MetricsCollectorContext context = new MetricsCollectorContext(queueManagerMetricsToReport, queueManager, agent, metricWriteHelper);
-				MetricsPublisher qMgrMetricsCollector = new QueueManagerMetricsCollector(context, metricCreator);
-                Runnable job = new MetricsPublisherJob(qMgrMetricsCollector, countDownLatch);
-                monitorContextConfig.getContext().getExecutorService().execute("QueueManagerMetricsCollector", job);
-			}
-			Map<String, WMQMetricOverride> inquireMetricsToReport = metricsByCommand.get("MQCMD_INQUIRE_Q_MGR");
-			if (inquireMetricsToReport != null) {
-				MetricCreator metricCreator = new MetricCreator(monitorContextConfig.getMetricPrefix(), queueManager, InquireQueueManagerCmdCollector.ARTIFACT);
-				MetricsCollectorContext context = new MetricsCollectorContext(inquireMetricsToReport, queueManager, agent, metricWriteHelper);
-				MetricsPublisher inquireQueueMgrMetricsCollector = new InquireQueueManagerCmdCollector(context, metricCreator);
-                Runnable job = new MetricsPublisherJob(inquireQueueMgrMetricsCollector, countDownLatch);
-                monitorContextConfig.getContext().getExecutorService().execute("InquireQueueManagerCmdCollector", job);
-			}
-		} else {
-			logger.warn("No queue manager metrics to report");
-		}
-
-		Map<String, WMQMetricOverride> channelMetricsToReport = metricsMap.get(Constants.METRIC_TYPE_CHANNEL);
-		if (channelMetricsToReport != null) {
-			Map<String, Map<String, WMQMetricOverride>> metricsByCommand = new HashMap<>();
-			for (String key : channelMetricsToReport.keySet()) {
-				WMQMetricOverride wmqOverride = channelMetricsToReport.get(key);
-				String cmd = wmqOverride.getIbmCommand() == null ? "MQCMD_INQUIRE_CHANNEL_STATUS" : wmqOverride.getIbmCommand();
-				metricsByCommand.putIfAbsent(cmd, new HashMap<>());
-				metricsByCommand.get(cmd).put(key, wmqOverride);
-			}
-			if (metricsByCommand.get("MQCMD_INQUIRE_CHANNEL_STATUS") != null) {
-				Map<String, WMQMetricOverride> metricsToReport = metricsByCommand.get("MQCMD_INQUIRE_CHANNEL_STATUS");
-				MetricCreator metricCreator = new MetricCreator(monitorContextConfig.getMetricPrefix(), queueManager, ChannelMetricsCollector.ARTIFACT);
-				MetricsCollectorContext context = new MetricsCollectorContext(metricsToReport, queueManager, agent, metricWriteHelper);
-				MetricsPublisher channelMetricsCollector = new ChannelMetricsCollector(context, metricCreator);
-				Runnable job = new MetricsPublisherJob(channelMetricsCollector, countDownLatch);
-				monitorContextConfig.getContext().getExecutorService().execute("ChannelMetricsCollector", job);
-			}
-			if (metricsByCommand.get("MQCMD_INQUIRE_CHANNEL") != null) {
-				MetricCreator metricCreator = new MetricCreator(monitorContextConfig.getMetricPrefix(), queueManager, InquireChannelCmdCollector.ARTIFACT);
-				Map<String, WMQMetricOverride> metricsToReport = metricsByCommand.get("MQCMD_INQUIRE_CHANNEL");
-				MetricsCollectorContext context = new MetricsCollectorContext(metricsToReport, queueManager, agent, metricWriteHelper);
-				MetricsPublisher inquireChannelMetricsCollector =
-						new InquireChannelCmdCollector(context, metricCreator);
-				Runnable job = new MetricsPublisherJob(inquireChannelMetricsCollector, countDownLatch);
-				monitorContextConfig.getContext().getExecutorService().execute("InquireChannelCmdCollector", job);
-			}
-		} else {
-			logger.warn("No channel metrics to report");
-		}
-
-		Map<String, WMQMetricOverride> queueMetricsToReport = metricsMap.get(Constants.METRIC_TYPE_QUEUE);
-		if (queueMetricsToReport != null) {
-			QueueCollectorSharedState sharedState = QueueCollectorSharedState.getInstance();
-			MetricsCollectorContext collectorContext = new MetricsCollectorContext(queueMetricsToReport, queueManager, agent, metricWriteHelper);
-			JobSubmitterContext jobSubmitterContext = new JobSubmitterContext(monitorContextConfig, countDownLatch, collectorContext);
-			MetricsPublisher queueMetricsCollector =
-					new QueueMetricsCollector(queueMetricsToReport, sharedState, jobSubmitterContext);
-			Runnable job = new MetricsPublisherJob(queueMetricsCollector, countDownLatch);
-			monitorContextConfig.getContext().getExecutorService().execute("QueueMetricsCollector", job);
-		} else {
-			logger.warn("No queue metrics to report");
-		}
-
-		Map<String, WMQMetricOverride> listenerMetricsToReport = metricsMap.get(Constants.METRIC_TYPE_LISTENER);
-		if (listenerMetricsToReport != null) {
-			MetricCreator metricCreator = new MetricCreator(monitorContextConfig.getMetricPrefix(), queueManager, ListenerMetricsCollector.ARTIFACT);
-			MetricsCollectorContext context = new MetricsCollectorContext(listenerMetricsToReport, queueManager, agent, metricWriteHelper);
-			MetricsPublisher listenerMetricsCollector = new ListenerMetricsCollector(context, metricCreator);
-			Runnable job = new MetricsPublisherJob(listenerMetricsCollector, countDownLatch);
-			monitorContextConfig.getContext().getExecutorService().execute("ListenerMetricsCollector", job);
-		} else {
-			logger.warn("No listener metrics to report");
-		}
-
-		Map<String, WMQMetricOverride> topicMetricsToReport = metricsMap.get(Constants.METRIC_TYPE_TOPIC);
-		if (topicMetricsToReport != null) {
-			MetricsCollectorContext collectorContext = new MetricsCollectorContext(topicMetricsToReport, queueManager, agent, metricWriteHelper);
-			JobSubmitterContext jobSubmitterContext = new JobSubmitterContext(monitorContextConfig, countDownLatch, collectorContext);
-			MetricsPublisher topicsMetricsCollector = new TopicMetricsCollector(jobSubmitterContext);
-			Runnable job = new MetricsPublisherJob(topicsMetricsCollector, countDownLatch);
-			monitorContextConfig.getContext().getExecutorService().execute("TopicMetricsCollector", job);
-		} else {
-			logger.warn("No topic metrics to report");
-		}
-
-		Map<String, WMQMetricOverride> configurationMetricsToReport = metricsMap.get(Constants.METRIC_TYPE_CONFIGURATION);
-		if (configurationMetricsToReport != null) {
-			MetricCreator metricCreator = new MetricCreator(monitorContextConfig.getMetricPrefix(), queueManager);
-			ReadConfigurationEventQueueCollector configurationEventQueueCollector = new ReadConfigurationEventQueueCollector(configurationMetricsToReport, this.monitorContextConfig, agent, mqQueueManager, queueManager, metricWriteHelper, metricCreator);
-            Runnable job = new MetricsPublisherJob(configurationEventQueueCollector, countDownLatch);
-            monitorContextConfig.getContext().getExecutorService().execute("ReadConfigurationEventQueueCollector", job);
-		} else {
-			logger.warn("No configuration queue metrics to report");
-		}
-
-		try {
-			countDownLatch.await();
-		} catch (InterruptedException e) {
-			logger.error("Error while the thread {} is waiting ", Thread.currentThread().getName(), e);
-		}
-
+    Map<String, WMQMetricOverride> qMgrMetricsToReport =
+        metricsMap.get(Constants.METRIC_TYPE_QUEUE_MANAGER);
+    if (qMgrMetricsToReport != null) {
+      Map<String, Map<String, WMQMetricOverride>> metricsByCommand = new HashMap<>();
+      for (String key : qMgrMetricsToReport.keySet()) {
+        WMQMetricOverride wmqOverride = qMgrMetricsToReport.get(key);
+        String cmd =
+            wmqOverride.getIbmCommand() == null
+                ? "MQCMD_INQUIRE_Q_MGR_STATUS"
+                : wmqOverride.getIbmCommand();
+        metricsByCommand.putIfAbsent(cmd, new HashMap<>());
+        metricsByCommand.get(cmd).put(key, wmqOverride);
+      }
+      Map<String, WMQMetricOverride> queueManagerMetricsToReport =
+          metricsByCommand.get("MQCMD_INQUIRE_Q_MGR_STATUS");
+      if (queueManagerMetricsToReport != null) {
+        MetricCreator metricCreator =
+            new MetricCreator(monitorContextConfig.getMetricPrefix(), queueManager);
+        MetricsCollectorContext context =
+            new MetricsCollectorContext(
+                queueManagerMetricsToReport, queueManager, agent, metricWriteHelper);
+        MetricsPublisher qMgrMetricsCollector =
+            new QueueManagerMetricsCollector(context, metricCreator);
+        Runnable job = new MetricsPublisherJob(qMgrMetricsCollector, countDownLatch);
+        monitorContextConfig
+            .getContext()
+            .getExecutorService()
+            .execute("QueueManagerMetricsCollector", job);
+      }
+      Map<String, WMQMetricOverride> inquireMetricsToReport =
+          metricsByCommand.get("MQCMD_INQUIRE_Q_MGR");
+      if (inquireMetricsToReport != null) {
+        MetricCreator metricCreator =
+            new MetricCreator(
+                monitorContextConfig.getMetricPrefix(),
+                queueManager,
+                InquireQueueManagerCmdCollector.ARTIFACT);
+        MetricsCollectorContext context =
+            new MetricsCollectorContext(
+                inquireMetricsToReport, queueManager, agent, metricWriteHelper);
+        MetricsPublisher inquireQueueMgrMetricsCollector =
+            new InquireQueueManagerCmdCollector(context, metricCreator);
+        Runnable job = new MetricsPublisherJob(inquireQueueMgrMetricsCollector, countDownLatch);
+        monitorContextConfig
+            .getContext()
+            .getExecutorService()
+            .execute("InquireQueueManagerCmdCollector", job);
+      }
+    } else {
+      logger.warn("No queue manager metrics to report");
     }
 
-	/**
-	 * Destroy the agent and disconnect from queue manager
-	 *
-	 */
-	private void cleanUp(MQQueueManager ibmQueueManager, PCFMessageAgent agent) {
-		// Disconnect the agent.
+    Map<String, WMQMetricOverride> channelMetricsToReport =
+        metricsMap.get(Constants.METRIC_TYPE_CHANNEL);
+    if (channelMetricsToReport != null) {
+      Map<String, Map<String, WMQMetricOverride>> metricsByCommand = new HashMap<>();
+      for (String key : channelMetricsToReport.keySet()) {
+        WMQMetricOverride wmqOverride = channelMetricsToReport.get(key);
+        String cmd =
+            wmqOverride.getIbmCommand() == null
+                ? "MQCMD_INQUIRE_CHANNEL_STATUS"
+                : wmqOverride.getIbmCommand();
+        metricsByCommand.putIfAbsent(cmd, new HashMap<>());
+        metricsByCommand.get(cmd).put(key, wmqOverride);
+      }
+      if (metricsByCommand.get("MQCMD_INQUIRE_CHANNEL_STATUS") != null) {
+        Map<String, WMQMetricOverride> metricsToReport =
+            metricsByCommand.get("MQCMD_INQUIRE_CHANNEL_STATUS");
+        MetricCreator metricCreator =
+            new MetricCreator(
+                monitorContextConfig.getMetricPrefix(),
+                queueManager,
+                ChannelMetricsCollector.ARTIFACT);
+        MetricsCollectorContext context =
+            new MetricsCollectorContext(metricsToReport, queueManager, agent, metricWriteHelper);
+        MetricsPublisher channelMetricsCollector =
+            new ChannelMetricsCollector(context, metricCreator);
+        Runnable job = new MetricsPublisherJob(channelMetricsCollector, countDownLatch);
+        monitorContextConfig
+            .getContext()
+            .getExecutorService()
+            .execute("ChannelMetricsCollector", job);
+      }
+      if (metricsByCommand.get("MQCMD_INQUIRE_CHANNEL") != null) {
+        MetricCreator metricCreator =
+            new MetricCreator(
+                monitorContextConfig.getMetricPrefix(),
+                queueManager,
+                InquireChannelCmdCollector.ARTIFACT);
+        Map<String, WMQMetricOverride> metricsToReport =
+            metricsByCommand.get("MQCMD_INQUIRE_CHANNEL");
+        MetricsCollectorContext context =
+            new MetricsCollectorContext(metricsToReport, queueManager, agent, metricWriteHelper);
+        MetricsPublisher inquireChannelMetricsCollector =
+            new InquireChannelCmdCollector(context, metricCreator);
+        Runnable job = new MetricsPublisherJob(inquireChannelMetricsCollector, countDownLatch);
+        monitorContextConfig
+            .getContext()
+            .getExecutorService()
+            .execute("InquireChannelCmdCollector", job);
+      }
+    } else {
+      logger.warn("No channel metrics to report");
+    }
 
-		if (agent != null) {
-			try {
-				String qMgrName = agent.getQManagerName();
-				agent.disconnect();
-				logger.debug("PCFMessageAgent disconnected for queueManager {} in thread {}", qMgrName, Thread.currentThread().getName());
-			} catch (Exception e) {
-				logger.error("Error occurred  while disconnecting PCFMessageAgent for queueManager {} in thread {}", queueManager.getName(), Thread.currentThread().getName(), e);
-			}
-		}
+    Map<String, WMQMetricOverride> queueMetricsToReport =
+        metricsMap.get(Constants.METRIC_TYPE_QUEUE);
+    if (queueMetricsToReport != null) {
+      QueueCollectorSharedState sharedState = QueueCollectorSharedState.getInstance();
+      MetricsCollectorContext collectorContext =
+          new MetricsCollectorContext(queueMetricsToReport, queueManager, agent, metricWriteHelper);
+      JobSubmitterContext jobSubmitterContext =
+          new JobSubmitterContext(monitorContextConfig, countDownLatch, collectorContext);
+      MetricsPublisher queueMetricsCollector =
+          new QueueMetricsCollector(queueMetricsToReport, sharedState, jobSubmitterContext);
+      Runnable job = new MetricsPublisherJob(queueMetricsCollector, countDownLatch);
+      monitorContextConfig.getContext().getExecutorService().execute("QueueMetricsCollector", job);
+    } else {
+      logger.warn("No queue metrics to report");
+    }
 
-		// Disconnect queue manager
-		if (ibmQueueManager != null) {
-			try {
-				ibmQueueManager.disconnect();
-				//logger.debug("Connection disconnected for queue manager {} in thread {}", ibmQueueManager.getName(), Thread.currentThread().getName());
-			} catch (Exception e) {
-				logger.error("Error occurred while disconnecting queueManager {} in thread {}", queueManager.getName(), Thread.currentThread().getName(), e);
-			}
-		}
-	}
+    Map<String, WMQMetricOverride> listenerMetricsToReport =
+        metricsMap.get(Constants.METRIC_TYPE_LISTENER);
+    if (listenerMetricsToReport != null) {
+      MetricCreator metricCreator =
+          new MetricCreator(
+              monitorContextConfig.getMetricPrefix(),
+              queueManager,
+              ListenerMetricsCollector.ARTIFACT);
+      MetricsCollectorContext context =
+          new MetricsCollectorContext(
+              listenerMetricsToReport, queueManager, agent, metricWriteHelper);
+      MetricsPublisher listenerMetricsCollector =
+          new ListenerMetricsCollector(context, metricCreator);
+      Runnable job = new MetricsPublisherJob(listenerMetricsCollector, countDownLatch);
+      monitorContextConfig
+          .getContext()
+          .getExecutorService()
+          .execute("ListenerMetricsCollector", job);
+    } else {
+      logger.warn("No listener metrics to report");
+    }
 
-	public void onTaskComplete() {
-		logger.info("WebSphereMQ monitor thread completed for queueManager: {}", WMQUtil.getQueueManagerNameFromConfig(queueManager));
-	}
+    Map<String, WMQMetricOverride> topicMetricsToReport =
+        metricsMap.get(Constants.METRIC_TYPE_TOPIC);
+    if (topicMetricsToReport != null) {
+      MetricsCollectorContext collectorContext =
+          new MetricsCollectorContext(topicMetricsToReport, queueManager, agent, metricWriteHelper);
+      JobSubmitterContext jobSubmitterContext =
+          new JobSubmitterContext(monitorContextConfig, countDownLatch, collectorContext);
+      MetricsPublisher topicsMetricsCollector = new TopicMetricsCollector(jobSubmitterContext);
+      Runnable job = new MetricsPublisherJob(topicsMetricsCollector, countDownLatch);
+      monitorContextConfig.getContext().getExecutorService().execute("TopicMetricsCollector", job);
+    } else {
+      logger.warn("No topic metrics to report");
+    }
 
+    Map<String, WMQMetricOverride> configurationMetricsToReport =
+        metricsMap.get(Constants.METRIC_TYPE_CONFIGURATION);
+    if (configurationMetricsToReport != null) {
+      MetricCreator metricCreator =
+          new MetricCreator(monitorContextConfig.getMetricPrefix(), queueManager);
+      ReadConfigurationEventQueueCollector configurationEventQueueCollector =
+          new ReadConfigurationEventQueueCollector(
+              configurationMetricsToReport,
+              this.monitorContextConfig,
+              agent,
+              mqQueueManager,
+              queueManager,
+              metricWriteHelper,
+              metricCreator);
+      Runnable job = new MetricsPublisherJob(configurationEventQueueCollector, countDownLatch);
+      monitorContextConfig
+          .getContext()
+          .getExecutorService()
+          .execute("ReadConfigurationEventQueueCollector", job);
+    } else {
+      logger.warn("No configuration queue metrics to report");
+    }
+
+    try {
+      countDownLatch.await();
+    } catch (InterruptedException e) {
+      logger.error("Error while the thread {} is waiting ", Thread.currentThread().getName(), e);
+    }
+  }
+
+  /** Destroy the agent and disconnect from queue manager */
+  private void cleanUp(MQQueueManager ibmQueueManager, PCFMessageAgent agent) {
+    // Disconnect the agent.
+
+    if (agent != null) {
+      try {
+        String qMgrName = agent.getQManagerName();
+        agent.disconnect();
+        logger.debug(
+            "PCFMessageAgent disconnected for queueManager {} in thread {}",
+            qMgrName,
+            Thread.currentThread().getName());
+      } catch (Exception e) {
+        logger.error(
+            "Error occurred  while disconnecting PCFMessageAgent for queueManager {} in thread {}",
+            queueManager.getName(),
+            Thread.currentThread().getName(),
+            e);
+      }
+    }
+
+    // Disconnect queue manager
+    if (ibmQueueManager != null) {
+      try {
+        ibmQueueManager.disconnect();
+        // logger.debug("Connection disconnected for queue manager {} in thread {}",
+        // ibmQueueManager.getName(), Thread.currentThread().getName());
+      } catch (Exception e) {
+        logger.error(
+            "Error occurred while disconnecting queueManager {} in thread {}",
+            queueManager.getName(),
+            Thread.currentThread().getName(),
+            e);
+      }
+    }
+  }
+
+  public void onTaskComplete() {
+    logger.info(
+        "WebSphereMQ monitor thread completed for queueManager: {}",
+        WMQUtil.getQueueManagerNameFromConfig(queueManager));
+  }
 }

--- a/src/main/java/com/appdynamics/extensions/webspheremq/common/Constants.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/common/Constants.java
@@ -13,17 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.appdynamics.extensions.webspheremq.common;
 
 public class Constants {
-	public static final String METRIC_TYPE_QUEUE_MANAGER = "queueMgrMetrics";
-	public static final String METRIC_TYPE_QUEUE = "queueMetrics";
-	public static final String METRIC_TYPE_CHANNEL = "channelMetrics";
-	public static final String METRIC_TYPE_LISTENER = "listenerMetrics";
-	public static final String METRIC_TYPE_TOPIC = "topicMetrics";
-	public static final String METRIC_TYPE_CONFIGURATION = "configurationMetrics";
-	
-	public static final String TRANSPORT_TYPE_CLIENT = "Client";
-	public static final String TRANSPORT_TYPE_BINGINGS = "Bindings";
+  public static final String METRIC_TYPE_QUEUE_MANAGER = "queueMgrMetrics";
+  public static final String METRIC_TYPE_QUEUE = "queueMetrics";
+  public static final String METRIC_TYPE_CHANNEL = "channelMetrics";
+  public static final String METRIC_TYPE_LISTENER = "listenerMetrics";
+  public static final String METRIC_TYPE_TOPIC = "topicMetrics";
+  public static final String METRIC_TYPE_CONFIGURATION = "configurationMetrics";
+
+  public static final String TRANSPORT_TYPE_CLIENT = "Client";
+  public static final String TRANSPORT_TYPE_BINGINGS = "Bindings";
 }

--- a/src/main/java/com/appdynamics/extensions/webspheremq/common/WMQUtil.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/common/WMQUtil.java
@@ -13,76 +13,82 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.appdynamics.extensions.webspheremq.common;
 
 import com.appdynamics.extensions.webspheremq.config.QueueManager;
 import com.appdynamics.extensions.webspheremq.config.WMQMetricOverride;
 import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
+import java.util.List;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.List;
-import java.util.Map;
-
 public class WMQUtil {
-    public static final Logger logger = LoggerFactory.getLogger(WMQUtil.class);
-    /**
-     * Returns master data structure, this map will contain only those metrics which are configured in the yaml config file.<br>
-     * It contains metric type as key and a map of metric and WMQMetricOverride as value,<br>
-     *    Map <metric type, Map<metric name, WMQMetricOverride> >
-     * EntrySet of internal map implicitly represents metrics to be reported.
-     */
-    public static Map<String, Map<String, WMQMetricOverride>> getMetricsToReportFromConfigYml(List<Map> mqMetrics) {
-        Map<String, Map<String, WMQMetricOverride>> metricsMap = Maps.newHashMap();
-        //
-        // mqMetrics represents "mqMetrics:" defined in config yaml.
-        //    i.e:  - metricsType: "..." \ metrics: \ include: \
-        //                           <the metric name>:  alias: "" ibmConstant: "com.ibm.mq.constants.CMQCFC.MQIACF_Q_MGR_STATUS"
-        //                           ibmCommand="MQCMD_" aggregationType: "" timeRollUpType: "" clusterRollUpType:"" clusterRollUpType=""
-        //
-        for (Map mqMetric : mqMetrics) {
-            String metricType = (String) mqMetric.get("metricsType");
-            List includeMetrics = (List) ((Map) mqMetric.get("metrics")).get("include");
-            Map<String, WMQMetricOverride> metricToReport = Maps.newHashMap();
-            if (includeMetrics != null) {
-                metricToReport = gatherMetricNamesByApplyingIncludeFilter(includeMetrics);
-            }
-            metricsMap.put(metricType, metricToReport);
-        }
-        return metricsMap;
-    }
+  public static final Logger logger = LoggerFactory.getLogger(WMQUtil.class);
 
-    private static Map<String, WMQMetricOverride> gatherMetricNamesByApplyingIncludeFilter(List includeMetrics) {
-        Map<String, WMQMetricOverride> overrideMap = Maps.newHashMap();
-        for (Object inc : includeMetrics) {
-            Map metric = (Map) inc;
-            // Get the First Entry which is the metric
-            Map.Entry firstEntry = (Map.Entry) metric.entrySet().iterator().next();
-            String metricName = firstEntry.getKey().toString();
-            Map<String, ?> metricPropsMap = (Map<String, ?>) metric.get(metricName);
-            WMQMetricOverride override = new WMQMetricOverride();
-            override.setIbmCommand((String) metricPropsMap.get("ibmCommand"));
-            override.setIbmConstant((String) metricPropsMap.get("ibmConstant"));
-            override.setMetricProperties(metricPropsMap);
-            if (override.getConstantValue() == -1) {
-                // Only add the metric which is valid, if constant value
-                // resolutes to -1 then it is invalid.
-                logger.warn("{} is not a valid valid metric, this metric will not be processed", override.getIbmConstant());
-            } else {
-                overrideMap.put(metricName, override);
-            }
-            logger.debug("Override Definition: {}", override);
-        }
-        return overrideMap;
+  /**
+   * Returns master data structure, this map will contain only those metrics which are configured in
+   * the yaml config file.<br>
+   * It contains metric type as key and a map of metric and WMQMetricOverride as value,<br>
+   * Map <metric type, Map<metric name, WMQMetricOverride> > EntrySet of internal map implicitly
+   * represents metrics to be reported.
+   */
+  public static Map<String, Map<String, WMQMetricOverride>> getMetricsToReportFromConfigYml(
+      List<Map> mqMetrics) {
+    Map<String, Map<String, WMQMetricOverride>> metricsMap = Maps.newHashMap();
+    //
+    // mqMetrics represents "mqMetrics:" defined in config yaml.
+    //    i.e:  - metricsType: "..." \ metrics: \ include: \
+    //                           <the metric name>:  alias: "" ibmConstant:
+    // "com.ibm.mq.constants.CMQCFC.MQIACF_Q_MGR_STATUS"
+    //                           ibmCommand="MQCMD_" aggregationType: "" timeRollUpType: ""
+    // clusterRollUpType:"" clusterRollUpType=""
+    //
+    for (Map mqMetric : mqMetrics) {
+      String metricType = (String) mqMetric.get("metricsType");
+      List includeMetrics = (List) ((Map) mqMetric.get("metrics")).get("include");
+      Map<String, WMQMetricOverride> metricToReport = Maps.newHashMap();
+      if (includeMetrics != null) {
+        metricToReport = gatherMetricNamesByApplyingIncludeFilter(includeMetrics);
+      }
+      metricsMap.put(metricType, metricToReport);
     }
+    return metricsMap;
+  }
 
-    public static String getQueueManagerNameFromConfig(QueueManager queueManager) {
-        if (!Strings.isNullOrEmpty(queueManager.getDisplayName())) {
-            return queueManager.getDisplayName();
-        } else {
-            return queueManager.getName();
-        }
+  private static Map<String, WMQMetricOverride> gatherMetricNamesByApplyingIncludeFilter(
+      List includeMetrics) {
+    Map<String, WMQMetricOverride> overrideMap = Maps.newHashMap();
+    for (Object inc : includeMetrics) {
+      Map metric = (Map) inc;
+      // Get the First Entry which is the metric
+      Map.Entry firstEntry = (Map.Entry) metric.entrySet().iterator().next();
+      String metricName = firstEntry.getKey().toString();
+      Map<String, ?> metricPropsMap = (Map<String, ?>) metric.get(metricName);
+      WMQMetricOverride override = new WMQMetricOverride();
+      override.setIbmCommand((String) metricPropsMap.get("ibmCommand"));
+      override.setIbmConstant((String) metricPropsMap.get("ibmConstant"));
+      override.setMetricProperties(metricPropsMap);
+      if (override.getConstantValue() == -1) {
+        // Only add the metric which is valid, if constant value
+        // resolutes to -1 then it is invalid.
+        logger.warn(
+            "{} is not a valid valid metric, this metric will not be processed",
+            override.getIbmConstant());
+      } else {
+        overrideMap.put(metricName, override);
+      }
+      logger.debug("Override Definition: {}", override);
     }
+    return overrideMap;
+  }
+
+  public static String getQueueManagerNameFromConfig(QueueManager queueManager) {
+    if (!Strings.isNullOrEmpty(queueManager.getDisplayName())) {
+      return queueManager.getDisplayName();
+    } else {
+      return queueManager.getName();
+    }
+  }
 }

--- a/src/main/java/com/appdynamics/extensions/webspheremq/config/ExcludeFilters.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/config/ExcludeFilters.java
@@ -13,80 +13,81 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.appdynamics.extensions.webspheremq.config;
 
 import com.appdynamics.extensions.webspheremq.metricscollector.FilterType;
 import com.google.common.base.Strings;
-
 import java.util.HashSet;
 import java.util.Set;
 
 public class ExcludeFilters {
 
-	private String type;
-	private Set<String> values = new HashSet<>();
+  private String type;
+  private Set<String> values = new HashSet<>();
 
-	public String getType() {
-		return type;
-	}
-	public void setType(String type) {
-		this.type = type;
-	}
-	public Set<String> getValues() {
-		return values;
-	}
-	public void setValues(Set<String> values) {
-		this.values = values;
-	}
+  public String getType() {
+    return type;
+  }
 
-	public static boolean isExcluded(String resourceName, Set<ExcludeFilters> excludeFilters) {
-		if(excludeFilters == null){
-			return false;
-		}
-		for(ExcludeFilters filter : excludeFilters){
-			if(filter.isExcluded(resourceName)){
-				return true;
-			}
-		}
-		return false;
-	}
+  public void setType(String type) {
+    this.type = type;
+  }
 
-	public boolean isExcluded(String resourceName) {
-		if (Strings.isNullOrEmpty(resourceName)) {
-			return true;
-		}
-		switch (FilterType.valueOf(type)){
-			case CONTAINS:
-				for (String filterValue : values) {
-					if (resourceName.contains(filterValue)) {
-						return true;
-					}
-				}
-				break;
-			case STARTSWITH:
-				for (String filterValue : values) {
-					if (resourceName.startsWith(filterValue)) {
-						return true;
-					}
-				}
-				break;
-			case NONE:
-				return false;
-			case EQUALS:
-				for (String filterValue : values) {
-					if (resourceName.equals(filterValue)) {
-						return true;
-					}
-				}
-				break;
-			case ENDSWITH:
-				for (String filterValue : values) {
-					if (resourceName.endsWith(filterValue)) {
-						return true;
-					}
-				}
-		}
-		return false;
-	}
+  public Set<String> getValues() {
+    return values;
+  }
+
+  public void setValues(Set<String> values) {
+    this.values = values;
+  }
+
+  public static boolean isExcluded(String resourceName, Set<ExcludeFilters> excludeFilters) {
+    if (excludeFilters == null) {
+      return false;
+    }
+    for (ExcludeFilters filter : excludeFilters) {
+      if (filter.isExcluded(resourceName)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  public boolean isExcluded(String resourceName) {
+    if (Strings.isNullOrEmpty(resourceName)) {
+      return true;
+    }
+    switch (FilterType.valueOf(type)) {
+      case CONTAINS:
+        for (String filterValue : values) {
+          if (resourceName.contains(filterValue)) {
+            return true;
+          }
+        }
+        break;
+      case STARTSWITH:
+        for (String filterValue : values) {
+          if (resourceName.startsWith(filterValue)) {
+            return true;
+          }
+        }
+        break;
+      case NONE:
+        return false;
+      case EQUALS:
+        for (String filterValue : values) {
+          if (resourceName.equals(filterValue)) {
+            return true;
+          }
+        }
+        break;
+      case ENDSWITH:
+        for (String filterValue : values) {
+          if (resourceName.endsWith(filterValue)) {
+            return true;
+          }
+        }
+    }
+    return false;
+  }
 }

--- a/src/main/java/com/appdynamics/extensions/webspheremq/config/QueueManager.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/config/QueueManager.java
@@ -13,245 +13,241 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.appdynamics.extensions.webspheremq.config;
 
 import java.util.List;
 
 public class QueueManager {
 
-	private String displayName;
-	private String host;
-	private int port = -1;
-	private String name;
-	private String channelName;
-	private String transportType;
-	private String username;
-	private String password;
-	private String sslKeyRepository;
-	private int ccsid = Integer.MIN_VALUE;
-	private int encoding = Integer.MIN_VALUE;
-	private String cipherSuite;
-	private String cipherSpec;
-	private String encryptedPassword;
-	private String replyQueuePrefix;
-	private String modelQueueName;
-	private String configurationQueueName = "SYSTEM.ADMIN.CONFIG.EVENT";
-	private long consumeConfigurationEventInterval;
-	private boolean refreshQueueManagerConfigurationEnabled;
+  private String displayName;
+  private String host;
+  private int port = -1;
+  private String name;
+  private String channelName;
+  private String transportType;
+  private String username;
+  private String password;
+  private String sslKeyRepository;
+  private int ccsid = Integer.MIN_VALUE;
+  private int encoding = Integer.MIN_VALUE;
+  private String cipherSuite;
+  private String cipherSpec;
+  private String encryptedPassword;
+  private String replyQueuePrefix;
+  private String modelQueueName;
+  private String configurationQueueName = "SYSTEM.ADMIN.CONFIG.EVENT";
+  private long consumeConfigurationEventInterval;
+  private boolean refreshQueueManagerConfigurationEnabled;
 
-	private ResourceFilters queueFilters;
-	private ResourceFilters channelFilters;
-	private ResourceFilters listenerFilters;
-	private ResourceFilters topicFilters;
+  private ResourceFilters queueFilters;
+  private ResourceFilters channelFilters;
+  private ResourceFilters listenerFilters;
+  private ResourceFilters topicFilters;
 
+  List<String> writeStatsDirectory;
 
-	List<String> writeStatsDirectory;
+  public String getDisplayName() {
+    return displayName;
+  }
 
-	public String getDisplayName() {
-		return displayName;
-	}
+  public void setDisplayName(String displayName) {
+    this.displayName = displayName;
+  }
 
-	public void setDisplayName(String displayName) {
-		this.displayName = displayName;
-	}
+  public String getHost() {
+    return host;
+  }
 
-	public String getHost() {
-		return host;
-	}
+  public void setHost(String host) {
+    this.host = host;
+  }
 
-	public void setHost(String host) {
-		this.host = host;
-	}
+  public int getPort() {
+    return port;
+  }
 
-	public int getPort() {
-		return port;
-	}
+  public void setPort(int port) {
+    this.port = port;
+  }
 
-	public void setPort(int port) {
-		this.port = port;
-	}
+  public String getName() {
+    return name;
+  }
 
-	public String getName() {
-		return name;
-	}
+  public void setName(String name) {
+    this.name = name;
+  }
 
-	public void setName(String name) {
-		this.name = name;
-	}
+  public String getChannelName() {
+    return channelName;
+  }
 
-	public String getChannelName() {
-		return channelName;
-	}
+  public void setChannelName(String channelName) {
+    this.channelName = channelName;
+  }
 
-	public void setChannelName(String channelName) {
-		this.channelName = channelName;
-	}
+  public String getTransportType() {
+    return transportType;
+  }
 
-	public String getTransportType() {
-		return transportType;
-	}
+  public void setTransportType(String transportType) {
+    this.transportType = transportType;
+  }
 
-	public void setTransportType(String transportType) {
-		this.transportType = transportType;
-	}
+  public String getUsername() {
+    return username;
+  }
 
-	public String getUsername() {
-		return username;
-	}
+  public void setUsername(String username) {
+    this.username = username;
+  }
 
-	public void setUsername(String username) {
-		this.username = username;
-	}
+  public String getPassword() {
+    return password;
+  }
 
-	public String getPassword() {
-		return password;
-	}
+  public void setPassword(String password) {
+    this.password = password;
+  }
 
-	public void setPassword(String password) {
-		this.password = password;
-	}
+  public ResourceFilters getQueueFilters() {
+    if (queueFilters == null) {
+      return new ResourceFilters();
+    }
+    return queueFilters;
+  }
 
+  public void setQueueFilters(ResourceFilters queueFilters) {
+    this.queueFilters = queueFilters;
+  }
 
-	public ResourceFilters getQueueFilters() {
-		if(queueFilters == null){
-			return new ResourceFilters();
-		}
-		return queueFilters;
-	}
+  public List<String> getWriteStatsDirectory() {
+    return writeStatsDirectory;
+  }
 
-	public void setQueueFilters(ResourceFilters queueFilters) {
-		this.queueFilters = queueFilters;
-	}
+  public void setWriteStatsDirectory(List<String> writeStatsDirectory) {
+    this.writeStatsDirectory = writeStatsDirectory;
+  }
 
+  public String getSslKeyRepository() {
+    return sslKeyRepository;
+  }
 
-	public List<String> getWriteStatsDirectory() {
-		return writeStatsDirectory;
-	}
+  public void setSslKeyRepository(String sslKeyRepository) {
+    this.sslKeyRepository = sslKeyRepository;
+  }
 
-	public void setWriteStatsDirectory(List<String> writeStatsDirectory) {
-		this.writeStatsDirectory = writeStatsDirectory;
-	}
+  public String getCipherSuite() {
+    return cipherSuite;
+  }
 
+  public void setCipherSuite(String cipherSuite) {
+    this.cipherSuite = cipherSuite;
+  }
 
-	public String getSslKeyRepository() {
-		return sslKeyRepository;
-	}
+  public String getCipherSpec() {
+    return cipherSpec;
+  }
 
-	public void setSslKeyRepository(String sslKeyRepository) {
-		this.sslKeyRepository = sslKeyRepository;
-	}
+  public void setCipherSpec(String cipherSpec) {
+    this.cipherSpec = cipherSpec;
+  }
 
-	public String getCipherSuite() {
-		return cipherSuite;
-	}
+  public ResourceFilters getChannelFilters() {
+    if (channelFilters == null) {
+      return new ResourceFilters();
+    }
+    return channelFilters;
+  }
 
-	public void setCipherSuite(String cipherSuite) {
-		this.cipherSuite = cipherSuite;
-	}
+  public void setChannelFilters(ResourceFilters channelFilters) {
+    this.channelFilters = channelFilters;
+  }
 
-	public String getCipherSpec() {
-		return cipherSpec;
-	}
+  public String getEncryptedPassword() {
+    return encryptedPassword;
+  }
 
-	public void setCipherSpec(String cipherSpec) {
-		this.cipherSpec = cipherSpec;
-	}
+  public void setEncryptedPassword(String encryptedPassword) {
+    this.encryptedPassword = encryptedPassword;
+  }
 
-	public ResourceFilters getChannelFilters() {
-		if(channelFilters == null){
-			return new ResourceFilters();
-		}
-		return channelFilters;
-	}
+  public String getReplyQueuePrefix() {
+    return replyQueuePrefix;
+  }
 
-	public void setChannelFilters(ResourceFilters channelFilters) {
-		this.channelFilters = channelFilters;
-	}
+  public void setReplyQueuePrefix(String replyQueuePrefix) {
+    this.replyQueuePrefix = replyQueuePrefix;
+  }
 
-	public String getEncryptedPassword() {
-		return encryptedPassword;
-	}
+  public String getModelQueueName() {
+    return modelQueueName;
+  }
 
-	public void setEncryptedPassword(String encryptedPassword) {
-		this.encryptedPassword = encryptedPassword;
-	}
+  public void setModelQueueName(String modelQueueName) {
+    this.modelQueueName = modelQueueName;
+  }
 
-	public String getReplyQueuePrefix() {
-		return replyQueuePrefix;
-	}
+  public ResourceFilters getListenerFilters() {
+    if (listenerFilters == null) {
+      return new ResourceFilters();
+    }
+    return listenerFilters;
+  }
 
-	public void setReplyQueuePrefix(String replyQueuePrefix) {
-		this.replyQueuePrefix = replyQueuePrefix;
-	}
+  public void setListenerFilters(ResourceFilters listenerFilters) {
+    this.listenerFilters = listenerFilters;
+  }
 
-	public String getModelQueueName() {
-		return modelQueueName;
-	}
+  public int getCcsid() {
+    return ccsid;
+  }
 
-	public void setModelQueueName(String modelQueueName) {
-		this.modelQueueName = modelQueueName;
-	}
+  public void setCcsid(int ccsid) {
+    this.ccsid = ccsid;
+  }
 
-	public ResourceFilters getListenerFilters() {
-		if(listenerFilters == null){
-			return new ResourceFilters();
-		}
-		return listenerFilters;
-	}
+  public int getEncoding() {
+    return encoding;
+  }
 
-	public void setListenerFilters(ResourceFilters listenerFilters) {
-		this.listenerFilters = listenerFilters;
-	}
+  public void setEncoding(int encoding) {
+    this.encoding = encoding;
+  }
 
-	public int getCcsid() {
-		return ccsid;
-	}
+  public ResourceFilters getTopicFilters() {
+    if (topicFilters == null) {
+      return new ResourceFilters();
+    }
+    return topicFilters;
+  }
 
-	public void setCcsid(int ccsid) {
-		this.ccsid = ccsid;
-	}
+  public void setTopicFilters(ResourceFilters topicFilters) {
+    this.topicFilters = topicFilters;
+  }
 
-	public int getEncoding() {
-		return encoding;
-	}
+  public String getConfigurationQueueName() {
+    return this.configurationQueueName;
+  }
 
-	public void setEncoding(int encoding) {
-		this.encoding = encoding;
-	}
+  public void setConfigurationQueueName(String configurationQueueName) {
+    this.configurationQueueName = configurationQueueName;
+  }
 
-	public ResourceFilters getTopicFilters() {
-		if(topicFilters == null){
-			return new ResourceFilters();
-		}
-		return topicFilters;
-	}
+  public long getConsumeConfigurationEventInterval() {
+    return this.consumeConfigurationEventInterval;
+  }
 
-	public void setTopicFilters(ResourceFilters topicFilters) {
-		this.topicFilters = topicFilters;
-	}
+  public void setConsumeConfigurationEventInterval(long consumeConfigurationEventInterval) {
+    this.consumeConfigurationEventInterval = consumeConfigurationEventInterval;
+  }
 
-	public String getConfigurationQueueName() {
-		return this.configurationQueueName;
-	}
+  public boolean isRefreshQueueManagerConfigurationEnabled() {
+    return refreshQueueManagerConfigurationEnabled;
+  }
 
-	public void setConfigurationQueueName(String configurationQueueName) {
-		this.configurationQueueName = configurationQueueName;
-	}
-
-	public long getConsumeConfigurationEventInterval() {
-		return this.consumeConfigurationEventInterval;
-	}
-
-	public void setConsumeConfigurationEventInterval(long consumeConfigurationEventInterval) {
-		this.consumeConfigurationEventInterval = consumeConfigurationEventInterval;
-	}
-
-	public boolean isRefreshQueueManagerConfigurationEnabled() {
-		return refreshQueueManagerConfigurationEnabled;
-	}
-
-	public void setRefreshQueueManagerConfigurationEnabled(boolean refreshQueueManagerConfigurationEnabled) {
-		this.refreshQueueManagerConfigurationEnabled = refreshQueueManagerConfigurationEnabled;
-	}
+  public void setRefreshQueueManagerConfigurationEnabled(
+      boolean refreshQueueManagerConfigurationEnabled) {
+    this.refreshQueueManagerConfigurationEnabled = refreshQueueManagerConfigurationEnabled;
+  }
 }

--- a/src/main/java/com/appdynamics/extensions/webspheremq/config/ResourceFilters.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/config/ResourceFilters.java
@@ -20,22 +20,22 @@ import java.util.Set;
 
 public class ResourceFilters {
 
-    private Set<String> include = new HashSet<>();
-    private Set<ExcludeFilters> exclude = new HashSet<>();
+  private Set<String> include = new HashSet<>();
+  private Set<ExcludeFilters> exclude = new HashSet<>();
 
-    public Set<String> getInclude() {
-        return include;
-    }
+  public Set<String> getInclude() {
+    return include;
+  }
 
-    public void setInclude(Set<String> include) {
-        this.include = include;
-    }
+  public void setInclude(Set<String> include) {
+    this.include = include;
+  }
 
-    public Set<ExcludeFilters> getExclude() {
-        return exclude;
-    }
+  public Set<ExcludeFilters> getExclude() {
+    return exclude;
+  }
 
-    public void setExclude(Set<ExcludeFilters> exclude) {
-        this.exclude = exclude;
-    }
+  public void setExclude(Set<ExcludeFilters> exclude) {
+    this.exclude = exclude;
+  }
 }

--- a/src/main/java/com/appdynamics/extensions/webspheremq/config/WMQMetricOverride.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/config/WMQMetricOverride.java
@@ -13,82 +13,87 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.appdynamics.extensions.webspheremq.config;
 
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Map;
-
 /**
- * Represents an override for WebSphere MQ metrics with custom properties.
- * This class provides functionality to specify and manage IBM constants,
- * commands, and associated metric properties for WebSphere MQ configuration.
+ * Represents an override for WebSphere MQ metrics with custom properties. This class provides
+ * functionality to specify and manage IBM constants, commands, and associated metric properties for
+ * WebSphere MQ configuration.
  */
 public class WMQMetricOverride {
 
-	String ibmConstant;
-	String ibmCommand;
-	int constantValue = -1;
-	Map<String, ?> metricProperties;
+  String ibmConstant;
+  String ibmCommand;
+  int constantValue = -1;
+  Map<String, ?> metricProperties;
 
-	public static final Logger logger = LoggerFactory.getLogger(WMQMetricOverride.class);
+  public static final Logger logger = LoggerFactory.getLogger(WMQMetricOverride.class);
 
-	public String getIbmConstant() {
-		return ibmConstant;
-	}
+  public String getIbmConstant() {
+    return ibmConstant;
+  }
 
-	public void setIbmConstant(String ibmConstant) {
-		this.ibmConstant = ibmConstant;
-	}
+  public void setIbmConstant(String ibmConstant) {
+    this.ibmConstant = ibmConstant;
+  }
 
-	public String getIbmCommand() {
-		return ibmCommand;
-	}
+  public String getIbmCommand() {
+    return ibmCommand;
+  }
 
-	public Map<String, ?> getMetricProperties() {
-		return metricProperties;
-	}
+  public Map<String, ?> getMetricProperties() {
+    return metricProperties;
+  }
 
-	public void setMetricProperties(Map<String, ?> metricProperties) {
-		this.metricProperties = metricProperties;
-	}
+  public void setMetricProperties(Map<String, ?> metricProperties) {
+    this.metricProperties = metricProperties;
+  }
 
-	public void setIbmCommand(String ibmCommand) {
-		this.ibmCommand = ibmCommand;
-	}
+  public void setIbmCommand(String ibmCommand) {
+    this.ibmCommand = ibmCommand;
+  }
 
-	public int getConstantValue() {
-		if (constantValue == -1) {
-			int lastPacSeparatorDotIdx = getIbmConstant().lastIndexOf('.');
-			if (lastPacSeparatorDotIdx != -1) {
-				String declaredField = getIbmConstant().substring(lastPacSeparatorDotIdx + 1);
-				String classStr = getIbmConstant().substring(0, lastPacSeparatorDotIdx);
-				Class clazz;
-				try {
-					clazz = Class.forName(classStr);
-					constantValue = (Integer) clazz.getDeclaredField(declaredField).get(Integer.class);
-				} catch (Exception e) {
-					logger.warn(e.getMessage());
-					logger.warn("ibmConstant {} is not a valid constant defaulting constant value to -1", getIbmConstant());
-				}
-			}
-		}
-		return constantValue;
-	}
-
-	public void setConstantValue(int constantValue) {
-		this.constantValue = constantValue;
-	}
-
-    @Override
-    public String toString() {
-        return "[" +
-                "IbmConstant=" + getIbmConstant() + "," +
-                "IbmCommand=" + getIbmCommand() + "," +
-                "ConstantVal=" + getConstantValue() + "," +
-                "]";
+  public int getConstantValue() {
+    if (constantValue == -1) {
+      int lastPacSeparatorDotIdx = getIbmConstant().lastIndexOf('.');
+      if (lastPacSeparatorDotIdx != -1) {
+        String declaredField = getIbmConstant().substring(lastPacSeparatorDotIdx + 1);
+        String classStr = getIbmConstant().substring(0, lastPacSeparatorDotIdx);
+        Class clazz;
+        try {
+          clazz = Class.forName(classStr);
+          constantValue = (Integer) clazz.getDeclaredField(declaredField).get(Integer.class);
+        } catch (Exception e) {
+          logger.warn(e.getMessage());
+          logger.warn(
+              "ibmConstant {} is not a valid constant defaulting constant value to -1",
+              getIbmConstant());
+        }
+      }
     }
+    return constantValue;
+  }
 
+  public void setConstantValue(int constantValue) {
+    this.constantValue = constantValue;
+  }
+
+  @Override
+  public String toString() {
+    return "["
+        + "IbmConstant="
+        + getIbmConstant()
+        + ","
+        + "IbmCommand="
+        + getIbmCommand()
+        + ","
+        + "ConstantVal="
+        + getConstantValue()
+        + ","
+        + "]";
+  }
 }

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/ChannelMetricsCollector.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/ChannelMetricsCollector.java
@@ -13,8 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.appdynamics.extensions.webspheremq.metricscollector;
+
+import static com.ibm.mq.constants.CMQC.MQRC_SELECTOR_ERROR;
+import static com.ibm.mq.constants.CMQCFC.MQRCCF_CHL_STATUS_NOT_FOUND;
 
 import com.appdynamics.extensions.metrics.Metric;
 import com.appdynamics.extensions.webspheremq.config.ExcludeFilters;
@@ -24,108 +26,124 @@ import com.ibm.mq.constants.CMQCFC;
 import com.ibm.mq.headers.pcf.PCFException;
 import com.ibm.mq.headers.pcf.PCFMessage;
 import com.singularity.ee.agent.systemagent.api.exception.TaskExecutionException;
+import java.util.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.*;
-
-import static com.ibm.mq.constants.CMQC.MQRC_SELECTOR_ERROR;
-import static com.ibm.mq.constants.CMQCFC.MQRCCF_CHL_STATUS_NOT_FOUND;
-
-/**
- * This class is responsible for channel metric collection.
- */
+/** This class is responsible for channel metric collection. */
 public final class ChannelMetricsCollector implements MetricsPublisher {
 
-	public static final Logger logger = LoggerFactory.getLogger(ChannelMetricsCollector.class);
-	public static final String ARTIFACT = "Channels";
-	private final MetricCreator metricCreator;
-	private final MetricsCollectorContext context;
+  public static final Logger logger = LoggerFactory.getLogger(ChannelMetricsCollector.class);
+  public static final String ARTIFACT = "Channels";
+  private final MetricCreator metricCreator;
+  private final MetricsCollectorContext context;
 
-	/*
-	 * The Channel Status values are mentioned here http://www.ibm.com/support/knowledgecenter/SSFKSJ_7.5.0/com.ibm.mq.ref.dev.doc/q090880_.htm
-	 */
-	public ChannelMetricsCollector(MetricsCollectorContext context, MetricCreator metricCreator) {
-        this.context = context;
-		this.metricCreator = metricCreator;
+  /*
+   * The Channel Status values are mentioned here http://www.ibm.com/support/knowledgecenter/SSFKSJ_7.5.0/com.ibm.mq.ref.dev.doc/q090880_.htm
+   */
+  public ChannelMetricsCollector(MetricsCollectorContext context, MetricCreator metricCreator) {
+    this.context = context;
+    this.metricCreator = metricCreator;
+  }
+
+  @Override
+  public void publishMetrics() throws TaskExecutionException {
+    long entryTime = System.currentTimeMillis();
+
+    if (context.hasNoMetricsToReport()) {
+      logger.debug(
+          "Channel metrics to report from the config is null or empty, nothing to publish");
+      return;
     }
 
-	@Override
-	public void publishMetrics() throws TaskExecutionException {
-		long entryTime = System.currentTimeMillis();
+    int[] attrs =
+        context.buildIntAttributesArray(CMQCFC.MQCACH_CHANNEL_NAME, CMQCFC.MQCACH_CONNECTION_NAME);
+    if (logger.isDebugEnabled()) {
+      logger.debug(
+          "Attributes being sent along PCF agent request to query channel metrics: {}",
+          Arrays.toString(attrs));
+    }
 
-		if (context.hasNoMetricsToReport()) {
-			logger.debug("Channel metrics to report from the config is null or empty, nothing to publish");
-			return;
-		}
+    Set<String> channelGenericNames = context.getChannelIncludeFilterNames();
 
-		int[] attrs = context.buildIntAttributesArray(CMQCFC.MQCACH_CHANNEL_NAME, CMQCFC.MQCACH_CONNECTION_NAME);
-		if (logger.isDebugEnabled()) {
-            logger.debug("Attributes being sent along PCF agent request to query channel metrics: {}", Arrays.toString(attrs));
-		}
+    //
+    // The MQCMD_INQUIRE_CHANNEL_STATUS command queries the current operational status of channels.
+    // This includes information about whether a channel is running, stopped, or in another state,
+    // as well as details about the channel’s performance and usage.
+    List<String> activeChannels = Lists.newArrayList();
+    for (String channelGenericName : channelGenericNames) {
+      PCFMessage request = new PCFMessage(CMQCFC.MQCMD_INQUIRE_CHANNEL_STATUS);
+      request.addParameter(CMQCFC.MQCACH_CHANNEL_NAME, channelGenericName);
+      request.addParameter(CMQCFC.MQIACH_CHANNEL_INSTANCE_TYPE, CMQC.MQOT_CURRENT_CHANNEL);
+      request.addParameter(CMQCFC.MQIACH_CHANNEL_INSTANCE_ATTRS, attrs);
+      try {
+        logger.debug(
+            "sending PCF agent request to query metrics for generic channel {}",
+            channelGenericName);
+        long startTime = System.currentTimeMillis();
+        PCFMessage[] response = context.send(request);
+        long endTime = System.currentTimeMillis() - startTime;
+        logger.debug(
+            "PCF agent queue metrics query response for generic queue {} received in {} milliseconds",
+            channelGenericName,
+            endTime);
+        if (response == null || response.length <= 0) {
+          logger.debug(
+              "Unexpected Error while PCFMessage.send(), response is either null or empty");
+          return;
+        }
+        for (PCFMessage pcfMessage : response) {
+          String channelName =
+              pcfMessage.getStringParameterValue(CMQCFC.MQCACH_CHANNEL_NAME).trim();
+          Set<ExcludeFilters> excludeFilters = context.getChannelExcludeFilters();
+          if (!ExcludeFilters.isExcluded(
+              channelName, excludeFilters)) { // check for exclude filters
+            logger.debug("Pulling out metrics for channel name {}", channelName);
+            List<Metric> responseMetrics = Lists.newArrayList();
+            context.forEachMetric(
+                (metrickey, wmqOverride) -> {
+                  int metricVal = pcfMessage.getIntParameterValue(wmqOverride.getConstantValue());
+                  Metric metric =
+                      metricCreator.createMetric(
+                          metrickey, metricVal, wmqOverride, channelName, metrickey);
+                  responseMetrics.add(metric);
+                  if ("Status".equals(metrickey) && metricVal == 3) {
+                    activeChannels.add(channelName);
+                  }
+                });
+            context.transformAndPrintMetrics(responseMetrics);
+          } else {
+            logger.debug("Channel name {} is excluded.", channelName);
+          }
+        }
+      } catch (PCFException pcfe) {
+        if (pcfe.getReason() == MQRCCF_CHL_STATUS_NOT_FOUND) {
+          String errorMsg = "Channel- " + channelGenericName + " :";
+          errorMsg +=
+              "Could not collect channel information as channel is stopped or inactive: Reason '3065'\n";
+          errorMsg +=
+              "If the channel type is MQCHT_RECEIVER, MQCHT_SVRCONN or MQCHT_CLUSRCVR, then the only action is to enable the channel, not start it.";
+          logger.error(errorMsg, pcfe);
+        } else if (pcfe.getReason() == MQRC_SELECTOR_ERROR) {
+          logger.error(
+              "Invalid metrics passed while collecting channel metrics, check config.yaml: Reason '2067'",
+              pcfe);
+        }
+      } catch (Exception e) {
+        logger.error(
+            "Unexpected Error occurred while collecting metrics for channel " + channelGenericName,
+            e);
+      }
+    }
 
-		Set<String> channelGenericNames = context.getChannelIncludeFilterNames();
+    logger.info(
+        "Active Channels in queueManager {} are {}", context.getQueueManagerName(), activeChannels);
+    Metric activeChannelsCountMetric =
+        metricCreator.createMetric(
+            "ActiveChannelsCount", activeChannels.size(), null, "ActiveChannelsCount");
+    context.transformAndPrintMetric(activeChannelsCountMetric);
 
-		//
- 		// The MQCMD_INQUIRE_CHANNEL_STATUS command queries the current operational status of channels.
-		// This includes information about whether a channel is running, stopped, or in another state,
-		// as well as details about the channel’s performance and usage.
-		List<String> activeChannels = Lists.newArrayList();
-		for(String channelGenericName : channelGenericNames){
-			PCFMessage request = new PCFMessage(CMQCFC.MQCMD_INQUIRE_CHANNEL_STATUS);
-			request.addParameter(CMQCFC.MQCACH_CHANNEL_NAME, channelGenericName);
-			request.addParameter(CMQCFC.MQIACH_CHANNEL_INSTANCE_TYPE, CMQC.MQOT_CURRENT_CHANNEL);
-			request.addParameter(CMQCFC.MQIACH_CHANNEL_INSTANCE_ATTRS, attrs);
-			try {
-				logger.debug("sending PCF agent request to query metrics for generic channel {}", channelGenericName);
-				long startTime = System.currentTimeMillis();
-				PCFMessage[] response = context.send(request);
-				long endTime = System.currentTimeMillis() - startTime;
-				logger.debug("PCF agent queue metrics query response for generic queue {} received in {} milliseconds", channelGenericName, endTime);
-				if (response == null || response.length <= 0) {
-					logger.debug("Unexpected Error while PCFMessage.send(), response is either null or empty");
-					return;
-				}
-                for (PCFMessage pcfMessage : response) {
-                    String channelName = pcfMessage.getStringParameterValue(CMQCFC.MQCACH_CHANNEL_NAME).trim();
-                    Set<ExcludeFilters> excludeFilters = context.getChannelExcludeFilters();
-                    if (!ExcludeFilters.isExcluded(channelName, excludeFilters)) { //check for exclude filters
-                        logger.debug("Pulling out metrics for channel name {}", channelName);
-						List<Metric> responseMetrics = Lists.newArrayList();
-						context.forEachMetric((metrickey,wmqOverride) -> {
-							int metricVal = pcfMessage.getIntParameterValue(wmqOverride.getConstantValue());
-							Metric metric = metricCreator.createMetric(metrickey, metricVal, wmqOverride, channelName, metrickey);
-							responseMetrics.add(metric);
-							if ("Status".equals(metrickey) && metricVal == 3) {
-								activeChannels.add(channelName);
-							}
-						});
-						context.transformAndPrintMetrics(responseMetrics);
-					} else {
-                        logger.debug("Channel name {} is excluded.", channelName);
-                    }
-                }
-			}
-			catch (PCFException pcfe) {
-				if (pcfe.getReason() == MQRCCF_CHL_STATUS_NOT_FOUND) {
-					String errorMsg = "Channel- " + channelGenericName + " :";
-					errorMsg += "Could not collect channel information as channel is stopped or inactive: Reason '3065'\n";
-					errorMsg += "If the channel type is MQCHT_RECEIVER, MQCHT_SVRCONN or MQCHT_CLUSRCVR, then the only action is to enable the channel, not start it.";
-					logger.error(errorMsg, pcfe);
-				} else if (pcfe.getReason() == MQRC_SELECTOR_ERROR) {
-					logger.error("Invalid metrics passed while collecting channel metrics, check config.yaml: Reason '2067'",pcfe);
-				}
-			} catch (Exception e) {
-				logger.error("Unexpected Error occurred while collecting metrics for channel " + channelGenericName, e);
-			}
-		}
-
-		logger.info("Active Channels in queueManager {} are {}", context.getQueueManagerName(), activeChannels);
-		Metric activeChannelsCountMetric = metricCreator.createMetric("ActiveChannelsCount", activeChannels.size(), null, "ActiveChannelsCount");
-		context.transformAndPrintMetric(activeChannelsCountMetric);
-
-		long exitTime = System.currentTimeMillis() - entryTime;
-		logger.debug("Time taken to publish metrics for all channels is {} milliseconds", exitTime);
-
-	}
+    long exitTime = System.currentTimeMillis() - entryTime;
+    logger.debug("Time taken to publish metrics for all channels is {} milliseconds", exitTime);
+  }
 }

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/FilterType.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/FilterType.java
@@ -1,5 +1,24 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.appdynamics.extensions.webspheremq.metricscollector;
 
 public enum FilterType {
-    STARTSWITH, EQUALS, ENDSWITH, CONTAINS, NONE
+  STARTSWITH,
+  EQUALS,
+  ENDSWITH,
+  CONTAINS,
+  NONE
 }

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/InquireChannelCmdCollector.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/InquireChannelCmdCollector.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.appdynamics.extensions.webspheremq.metricscollector;
 
 import com.appdynamics.extensions.logging.ExtensionsLoggerFactory;
@@ -26,91 +25,103 @@ import com.ibm.mq.headers.pcf.MQCFIL;
 import com.ibm.mq.headers.pcf.PCFException;
 import com.ibm.mq.headers.pcf.PCFMessage;
 import com.singularity.ee.agent.systemagent.api.exception.TaskExecutionException;
-import org.slf4j.Logger;
-
 import java.util.List;
 import java.util.Set;
+import org.slf4j.Logger;
 
-/**
- * This class is responsible for channel inquiry metric collection.
- */
+/** This class is responsible for channel inquiry metric collection. */
 public final class InquireChannelCmdCollector implements MetricsPublisher {
 
-	public static final Logger logger = ExtensionsLoggerFactory.getLogger(InquireChannelCmdCollector.class);
-	public static final String ARTIFACT = "Channels";
-	private final MetricCreator metricCreator;
-	private final MetricsCollectorContext context;
+  public static final Logger logger =
+      ExtensionsLoggerFactory.getLogger(InquireChannelCmdCollector.class);
+  public static final String ARTIFACT = "Channels";
+  private final MetricCreator metricCreator;
+  private final MetricsCollectorContext context;
 
-	public InquireChannelCmdCollector(MetricsCollectorContext context, MetricCreator metricCreator) {
-        this.metricCreator = metricCreator;
-        this.context = context;
+  public InquireChannelCmdCollector(MetricsCollectorContext context, MetricCreator metricCreator) {
+    this.metricCreator = metricCreator;
+    this.context = context;
+  }
+
+  @Override
+  public void publishMetrics() throws TaskExecutionException {
+    long entryTime = System.currentTimeMillis();
+
+    if (context.hasNoMetricsToReport()) {
+      logger.debug(
+          "Channel metrics to report from the config is null or empty, nothing to publish");
+      return;
     }
 
+    Set<String> channelGenericNames = context.getChannelIncludeFilterNames();
 
-	@Override
-	public void publishMetrics() throws TaskExecutionException {
-		long entryTime = System.currentTimeMillis();
+    for (String channelGenericName : channelGenericNames) {
+      PCFMessage request = new PCFMessage(CMQCFC.MQCMD_INQUIRE_CHANNEL);
+      request.addParameter(CMQCFC.MQCACH_CHANNEL_NAME, channelGenericName);
+      request.addParameter(
+          new MQCFIL(MQConstants.MQIACF_CHANNEL_ATTRS, new int[] {MQConstants.MQIACF_ALL}));
+      try {
+        logger.debug(
+            "sending PCF agent request to query metrics for generic channel {}",
+            channelGenericName);
+        long startTime = System.currentTimeMillis();
+        PCFMessage[] response = context.send(request);
+        long endTime = System.currentTimeMillis() - startTime;
+        logger.debug(
+            "PCF agent queue metrics query response for generic queue {} received in {} milliseconds",
+            channelGenericName,
+            endTime);
+        if (response == null || response.length <= 0) {
+          logger.warn("Unexpected Error while PCFMessage.send(), response is either null or empty");
+          return;
+        }
+        for (PCFMessage pcfMessage : response) {
+          String channelName =
+              pcfMessage.getStringParameterValue(CMQCFC.MQCACH_CHANNEL_NAME).trim();
+          Set<ExcludeFilters> excludeFilters = context.getChannelExcludeFilters();
+          if (!ExcludeFilters.isExcluded(
+              channelName, excludeFilters)) { // check for exclude filters
+            logger.debug("Pulling out metrics for channel name {}", channelName);
+            List<Metric> responseMetrics = Lists.newArrayList();
+            context.forEachMetric(
+                (metrickey, wmqOverride) -> {
+                  if (pcfMessage.getParameter(wmqOverride.getConstantValue()) == null) {
+                    logger.debug("Missing property {} on {}", metrickey, channelName);
+                    return;
+                  }
+                  int metricVal = pcfMessage.getIntParameterValue(wmqOverride.getConstantValue());
+                  Metric metric =
+                      metricCreator.createMetric(
+                          metrickey, metricVal, wmqOverride, channelName, metrickey);
+                  responseMetrics.add(metric);
+                });
+            context.transformAndPrintMetrics(responseMetrics);
+          } else {
+            logger.debug("Channel name {} is excluded.", channelName);
+          }
+        }
+      } catch (PCFException pcfe) {
+        if (pcfe.getReason() == MQConstants.MQRCCF_CHL_STATUS_NOT_FOUND) {
+          String errorMsg = "Channel- " + channelGenericName + " :";
+          errorMsg +=
+              "Could not collect channel information as channel is stopped or inactive: Reason '3065'\n";
+          errorMsg +=
+              "If the channel type is MQCHT_RECEIVER, MQCHT_SVRCONN or MQCHT_CLUSRCVR, then the only action is to enable the channel, not start it.";
+          logger.error(errorMsg, pcfe);
+        } else if (pcfe.getReason() == MQConstants.MQRC_SELECTOR_ERROR) {
+          logger.error(
+              "Invalid metrics passed while collecting channel metrics, check config.yaml: Reason '2067'",
+              pcfe);
+        }
+        logger.error(pcfe.getMessage(), pcfe);
+      } catch (Exception e) {
+        logger.error(
+            "Unexpected Error occoured while collecting metrics for channel " + channelGenericName,
+            e);
+      }
+    }
 
-		if (context.hasNoMetricsToReport()) {
-			logger.debug("Channel metrics to report from the config is null or empty, nothing to publish");
-			return;
-		}
-
-		Set<String> channelGenericNames = context.getChannelIncludeFilterNames();
-
-		for(String channelGenericName : channelGenericNames){
-			PCFMessage request = new PCFMessage(CMQCFC.MQCMD_INQUIRE_CHANNEL);
-			request.addParameter(CMQCFC.MQCACH_CHANNEL_NAME, channelGenericName);
-			request.addParameter(new MQCFIL(MQConstants.MQIACF_CHANNEL_ATTRS, new int[] {MQConstants.MQIACF_ALL}));
-			try {
-				logger.debug("sending PCF agent request to query metrics for generic channel {}", channelGenericName);
-				long startTime = System.currentTimeMillis();
-				PCFMessage[] response = context.send(request);
-				long endTime = System.currentTimeMillis() - startTime;
-				logger.debug("PCF agent queue metrics query response for generic queue {} received in {} milliseconds", channelGenericName, endTime);
-				if (response == null || response.length <= 0) {
-					logger.warn("Unexpected Error while PCFMessage.send(), response is either null or empty");
-					return;
-				}
-                for (PCFMessage pcfMessage : response) {
-                    String channelName = pcfMessage.getStringParameterValue(CMQCFC.MQCACH_CHANNEL_NAME).trim();
-                    Set<ExcludeFilters> excludeFilters = context.getChannelExcludeFilters();
-                    if (!ExcludeFilters.isExcluded(channelName, excludeFilters)) { //check for exclude filters
-                        logger.debug("Pulling out metrics for channel name {}", channelName);
-						List<Metric> responseMetrics = Lists.newArrayList();
-						context.forEachMetric((metrickey,wmqOverride) -> {
-							if (pcfMessage.getParameter(wmqOverride.getConstantValue()) == null) {
-								logger.debug("Missing property {} on {}", metrickey, channelName);
-								return;
-							}
-							int metricVal = pcfMessage.getIntParameterValue(wmqOverride.getConstantValue());
-							Metric metric = metricCreator.createMetric(metrickey, metricVal, wmqOverride, channelName, metrickey);
-							responseMetrics.add(metric);
-
-						});
-						context.transformAndPrintMetrics(responseMetrics);
-                    } else {
-                        logger.debug("Channel name {} is excluded.", channelName);
-                    }
-                }
-			}
-			catch (PCFException pcfe) {
-				if (pcfe.getReason() == MQConstants.MQRCCF_CHL_STATUS_NOT_FOUND) {
-					String errorMsg = "Channel- " + channelGenericName + " :";
-					errorMsg += "Could not collect channel information as channel is stopped or inactive: Reason '3065'\n";
-					errorMsg += "If the channel type is MQCHT_RECEIVER, MQCHT_SVRCONN or MQCHT_CLUSRCVR, then the only action is to enable the channel, not start it.";
-					logger.error(errorMsg,pcfe);
-				} else if (pcfe.getReason() == MQConstants.MQRC_SELECTOR_ERROR) {
-					logger.error("Invalid metrics passed while collecting channel metrics, check config.yaml: Reason '2067'",pcfe);
-				}
-				logger.error(pcfe.getMessage(), pcfe);
-			} catch (Exception e) {
-				logger.error("Unexpected Error occoured while collecting metrics for channel " + channelGenericName, e);
-			}
-		}
-
-		long exitTime = System.currentTimeMillis() - entryTime;
-		logger.debug("Time taken to publish metrics for all channels is {} milliseconds", exitTime);
-
-	}
+    long exitTime = System.currentTimeMillis() - entryTime;
+    logger.debug("Time taken to publish metrics for all channels is {} milliseconds", exitTime);
+  }
 }

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/InquireQCmdCollector.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/InquireQCmdCollector.java
@@ -13,55 +13,59 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.appdynamics.extensions.webspheremq.metricscollector;
 
 import com.ibm.mq.constants.CMQC;
 import com.ibm.mq.constants.CMQCFC;
-import com.ibm.mq.headers.pcf.PCFException;
 import com.ibm.mq.headers.pcf.PCFMessage;
 import com.singularity.ee.agent.systemagent.api.exception.TaskExecutionException;
+import java.util.Arrays;
+import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Arrays;
-import java.util.Set;
-
 final class InquireQCmdCollector implements MetricsPublisher {
 
-    private static final Logger logger = LoggerFactory.getLogger(InquireQCmdCollector.class);
-    static final String COMMAND = "MQCMD_INQUIRE_Q";
-    private final MetricsCollectorContext context;
-    private final QueueCollectionBuddy queueBuddy;
+  private static final Logger logger = LoggerFactory.getLogger(InquireQCmdCollector.class);
+  static final String COMMAND = "MQCMD_INQUIRE_Q";
+  private final MetricsCollectorContext context;
+  private final QueueCollectionBuddy queueBuddy;
 
-    public InquireQCmdCollector(MetricsCollectorContext context, QueueCollectionBuddy queueBuddy){
-        this.context = context;
-        this.queueBuddy = queueBuddy;
+  public InquireQCmdCollector(MetricsCollectorContext context, QueueCollectionBuddy queueBuddy) {
+    this.context = context;
+    this.queueBuddy = queueBuddy;
+  }
+
+  @Override
+  public void publishMetrics() throws TaskExecutionException {
+    logger.info("Collecting metrics for command {}", COMMAND);
+    /*
+     * attrs = { CMQC.MQCA_Q_NAME, CMQC.MQIA_CURRENT_Q_DEPTH, CMQC.MQIA_MAX_Q_DEPTH, CMQC.MQIA_OPEN_INPUT_COUNT, CMQC.MQIA_OPEN_OUTPUT_COUNT };
+     */
+    long entryTime = System.currentTimeMillis();
+
+    int[] attrs =
+        context.buildIntAttributesArray(CMQC.MQCA_Q_NAME, CMQC.MQIA_USAGE, CMQC.MQIA_Q_TYPE);
+    logger.debug(
+        "Attributes being sent along PCF agent request to query queue metrics: {} for command {}",
+        Arrays.toString(attrs),
+        COMMAND);
+
+    Set<String> queueGenericNames = context.getQueueIncludeFilterNames();
+    for (String queueGenericName : queueGenericNames) {
+      // list of all metrics extracted through MQCMD_INQUIRE_Q is mentioned here
+      // https://www.ibm.com/support/knowledgecenter/SSFKSJ_7.5.0/com.ibm.mq.ref.adm.doc/q087810_.htm
+      PCFMessage request = new PCFMessage(CMQCFC.MQCMD_INQUIRE_Q);
+      request.addParameter(CMQC.MQCA_Q_NAME, queueGenericName);
+      request.addParameter(CMQC.MQIA_Q_TYPE, CMQC.MQQT_ALL);
+      request.addParameter(CMQCFC.MQIACF_Q_ATTRS, attrs);
+
+      queueBuddy.processPCFRequestAndPublishQMetrics(request, queueGenericName);
     }
-
-    @Override
-    public void publishMetrics() throws TaskExecutionException {
-        logger.info("Collecting metrics for command {}", COMMAND);
-		/*
-		 * attrs = { CMQC.MQCA_Q_NAME, CMQC.MQIA_CURRENT_Q_DEPTH, CMQC.MQIA_MAX_Q_DEPTH, CMQC.MQIA_OPEN_INPUT_COUNT, CMQC.MQIA_OPEN_OUTPUT_COUNT };
-		 */
-        long entryTime = System.currentTimeMillis();
-
-
-        int[] attrs = context.buildIntAttributesArray(CMQC.MQCA_Q_NAME, CMQC.MQIA_USAGE, CMQC.MQIA_Q_TYPE);
-        logger.debug("Attributes being sent along PCF agent request to query queue metrics: {} for command {}",Arrays.toString(attrs),COMMAND);
-
-        Set<String> queueGenericNames = context.getQueueIncludeFilterNames();
-        for(String queueGenericName : queueGenericNames){
-            // list of all metrics extracted through MQCMD_INQUIRE_Q is mentioned here https://www.ibm.com/support/knowledgecenter/SSFKSJ_7.5.0/com.ibm.mq.ref.adm.doc/q087810_.htm
-            PCFMessage request = new PCFMessage(CMQCFC.MQCMD_INQUIRE_Q);
-            request.addParameter(CMQC.MQCA_Q_NAME, queueGenericName);
-            request.addParameter(CMQC.MQIA_Q_TYPE, CMQC.MQQT_ALL);
-            request.addParameter(CMQCFC.MQIACF_Q_ATTRS, attrs);
-
-            queueBuddy.processPCFRequestAndPublishQMetrics(request, queueGenericName);
-        }
-        long exitTime = System.currentTimeMillis() - entryTime;
-        logger.debug("Time taken to publish metrics for all queues is {} milliseconds for command {}", exitTime,COMMAND);
-    }
+    long exitTime = System.currentTimeMillis() - entryTime;
+    logger.debug(
+        "Time taken to publish metrics for all queues is {} milliseconds for command {}",
+        exitTime,
+        COMMAND);
+  }
 }

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/InquireQStatusCmdCollector.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/InquireQStatusCmdCollector.java
@@ -13,84 +13,83 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.appdynamics.extensions.webspheremq.metricscollector;
 
 import com.ibm.mq.constants.CMQC;
 import com.ibm.mq.constants.CMQCFC;
-import com.ibm.mq.headers.pcf.PCFException;
 import com.ibm.mq.headers.pcf.PCFMessage;
 import com.singularity.ee.agent.systemagent.api.exception.TaskExecutionException;
+import java.util.Arrays;
+import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Arrays;
-import java.util.Set;
-
 /**
- * The InquireQStatusCmdCollector class is responsible for collecting and publishing
- * queue metrics using the IBM MQ command `MQCMD_INQUIRE_Q_STATUS`. It extends the
- * QueueMetricsCollector class and implements the Runnable interface, enabling
- * execution within a separate thread.
- * <p>
- * This class interacts with PCF (Programmable Command Formats) messages to
- * query queue metrics based on the configuration provided. It retrieves status information
- * about a queue, such as:
- * 	•	The number of messages on the queue
- * 	•	Open handles (how many apps have it open)
- * 	•	Whether the queue is in use for input/output
- * 	•	Last get/put timestamps
- * 	•	And other real-time statistics
- * <p>
- * Thread Safety:
- * This class is thread-safe, as it operates independently with state shared only
+ * The InquireQStatusCmdCollector class is responsible for collecting and publishing queue metrics
+ * using the IBM MQ command `MQCMD_INQUIRE_Q_STATUS`. It extends the QueueMetricsCollector class and
+ * implements the Runnable interface, enabling execution within a separate thread.
+ *
+ * <p>This class interacts with PCF (Programmable Command Formats) messages to query queue metrics
+ * based on the configuration provided. It retrieves status information about a queue, such as: •
+ * The number of messages on the queue • Open handles (how many apps have it open) • Whether the
+ * queue is in use for input/output • Last get/put timestamps • And other real-time statistics
+ *
+ * <p>Thread Safety: This class is thread-safe, as it operates independently with state shared only
  * through immutable or synchronized structures where necessary.
- * <p>
- * Usage:
- * - Instantiate this class by providing an existing QueueMetricsCollector instance,
- *   a map of metrics to report, and shared state.
- * - Invoke the run method to execute the queue metrics collection process.
+ *
+ * <p>Usage: - Instantiate this class by providing an existing QueueMetricsCollector instance, a map
+ * of metrics to report, and shared state. - Invoke the run method to execute the queue metrics
+ * collection process.
  */
 final class InquireQStatusCmdCollector implements MetricsPublisher {
 
-    private static final Logger logger = LoggerFactory.getLogger(InquireQStatusCmdCollector.class);
+  private static final Logger logger = LoggerFactory.getLogger(InquireQStatusCmdCollector.class);
 
-    static final String COMMAND = "MQCMD_INQUIRE_Q_STATUS";
-    private final MetricsCollectorContext context;
-    private final QueueCollectionBuddy queueBuddy;
+  static final String COMMAND = "MQCMD_INQUIRE_Q_STATUS";
+  private final MetricsCollectorContext context;
+  private final QueueCollectionBuddy queueBuddy;
 
-    InquireQStatusCmdCollector(MetricsCollectorContext context, QueueCollectionBuddy queueBuddy) {
-        this.context = context;
-        this.queueBuddy = queueBuddy;
+  InquireQStatusCmdCollector(MetricsCollectorContext context, QueueCollectionBuddy queueBuddy) {
+    this.context = context;
+    this.queueBuddy = queueBuddy;
+  }
+
+  @Override
+  public void publishMetrics() throws TaskExecutionException {
+    logger.info("Collecting metrics for command {}", COMMAND);
+    long entryTime = System.currentTimeMillis();
+
+    if (context.hasNoMetricsToReport()) {
+      logger.debug(
+          "Queue metrics to report from the config is null or empty, nothing to publish for command {}",
+          COMMAND);
+      return;
     }
 
-    @Override
-    public void publishMetrics() throws TaskExecutionException {
-        logger.info("Collecting metrics for command {}", COMMAND);
-        long entryTime = System.currentTimeMillis();
-
-        if (context.hasNoMetricsToReport()) {
-            logger.debug("Queue metrics to report from the config is null or empty, nothing to publish for command {}", COMMAND);
-            return;
-        }
-
-        //
-        // attrs = { CMQC.MQCA_Q_NAME, MQIACF_OLDEST_MSG_AGE, MQIACF_Q_TIME_INDICATOR };
-        //
-        int[] attrs = context.buildIntAttributesArray(CMQC.MQCA_Q_NAME);
-        if (logger.isDebugEnabled()) {
-            logger.debug("Attributes being sent along PCF agent request to query queue metrics: {} for command {}", Arrays.toString(attrs), COMMAND);
-        }
-
-        Set<String> queueGenericNames = context.getQueueIncludeFilterNames();
-        for(String queueGenericName : queueGenericNames){
-            // list of all metrics extracted through MQCMD_INQUIRE_Q_STATUS is mentioned here https://www.ibm.com/support/knowledgecenter/SSFKSJ_8.0.0/com.ibm.mq.ref.adm.doc/q087880_.htm
-            PCFMessage request = new PCFMessage(CMQCFC.MQCMD_INQUIRE_Q_STATUS);
-            request.addParameter(CMQC.MQCA_Q_NAME, queueGenericName);
-            request.addParameter(CMQCFC.MQIACF_Q_STATUS_ATTRS, attrs);
-            queueBuddy.processPCFRequestAndPublishQMetrics(request, queueGenericName);
-        }
-        long exitTime = System.currentTimeMillis() - entryTime;
-        logger.debug("Time taken to publish metrics for all queues is {} milliseconds for command {}", exitTime,COMMAND);
+    //
+    // attrs = { CMQC.MQCA_Q_NAME, MQIACF_OLDEST_MSG_AGE, MQIACF_Q_TIME_INDICATOR };
+    //
+    int[] attrs = context.buildIntAttributesArray(CMQC.MQCA_Q_NAME);
+    if (logger.isDebugEnabled()) {
+      logger.debug(
+          "Attributes being sent along PCF agent request to query queue metrics: {} for command {}",
+          Arrays.toString(attrs),
+          COMMAND);
     }
+
+    Set<String> queueGenericNames = context.getQueueIncludeFilterNames();
+    for (String queueGenericName : queueGenericNames) {
+      // list of all metrics extracted through MQCMD_INQUIRE_Q_STATUS is mentioned here
+      // https://www.ibm.com/support/knowledgecenter/SSFKSJ_8.0.0/com.ibm.mq.ref.adm.doc/q087880_.htm
+      PCFMessage request = new PCFMessage(CMQCFC.MQCMD_INQUIRE_Q_STATUS);
+      request.addParameter(CMQC.MQCA_Q_NAME, queueGenericName);
+      request.addParameter(CMQCFC.MQIACF_Q_STATUS_ATTRS, attrs);
+      queueBuddy.processPCFRequestAndPublishQMetrics(request, queueGenericName);
+    }
+    long exitTime = System.currentTimeMillis() - entryTime;
+    logger.debug(
+        "Time taken to publish metrics for all queues is {} milliseconds for command {}",
+        exitTime,
+        COMMAND);
+  }
 }

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/InquireTStatusCmdCollector.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/InquireTStatusCmdCollector.java
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.appdynamics.extensions.webspheremq.metricscollector;
 
 import com.appdynamics.extensions.metrics.Metric;
@@ -27,100 +26,131 @@ import com.ibm.mq.headers.pcf.PCFException;
 import com.ibm.mq.headers.pcf.PCFMessage;
 import com.ibm.mq.headers.pcf.PCFParameter;
 import com.singularity.ee.agent.systemagent.api.exception.TaskExecutionException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.util.List;
 import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 final class InquireTStatusCmdCollector implements MetricsPublisher {
 
-    private static final Logger logger = LoggerFactory.getLogger(InquireTStatusCmdCollector.class);
-    static final String ARTIFACT = "Topics";
-    private final MetricCreator metricCreator;
+  private static final Logger logger = LoggerFactory.getLogger(InquireTStatusCmdCollector.class);
+  static final String ARTIFACT = "Topics";
+  private final MetricCreator metricCreator;
 
-    static final String COMMAND = "MQCMD_INQUIRE_TOPIC_STATUS";
-    private final MetricsCollectorContext context;
+  static final String COMMAND = "MQCMD_INQUIRE_TOPIC_STATUS";
+  private final MetricsCollectorContext context;
 
-    public InquireTStatusCmdCollector(MetricsCollectorContext context, MetricCreator metricCreator) {
-        this.context = context;
-        this.metricCreator = metricCreator;
+  public InquireTStatusCmdCollector(MetricsCollectorContext context, MetricCreator metricCreator) {
+    this.context = context;
+    this.metricCreator = metricCreator;
+  }
+
+  @Override
+  public void publishMetrics() throws TaskExecutionException {
+    logger.info("Collecting metrics for command {}", COMMAND);
+    long entryTime = System.currentTimeMillis();
+
+    if (context.hasNoMetricsToReport()) {
+      logger.debug(
+          "Topic metrics to report from the config is null or empty, nothing to publish for command {}",
+          COMMAND);
+      return;
+    }
+    Set<String> topicGenericNames = context.getTopicIncludeFilterNames();
+    //  to query the current status of topics, which is essential for monitoring and managing the
+    // publish/subscribe environment in IBM MQ.
+    for (String topicGenericName : topicGenericNames) {
+      // Request:
+      // https://www.ibm.com/support/knowledgecenter/SSFKSJ_8.0.0/com.ibm.mq.ref.adm.doc/q088140_.htm
+      // list of all metrics extracted through MQCMD_INQUIRE_TOPIC_STATUS is mentioned here
+      // https://www.ibm.com/support/knowledgecenter/SSFKSJ_8.0.0/com.ibm.mq.ref.adm.doc/q088150_.htm
+      PCFMessage request = new PCFMessage(CMQCFC.MQCMD_INQUIRE_TOPIC_STATUS);
+      request.addParameter(CMQC.MQCA_TOPIC_STRING, topicGenericName);
+
+      try {
+        processPCFRequestAndPublishQMetrics(topicGenericName, request, COMMAND);
+      } catch (PCFException pcfe) {
+        logger.error(
+            "PCFException caught while collecting metric for Queue: {} for command {}",
+            topicGenericName,
+            COMMAND,
+            pcfe);
+        PCFMessage[] msgs = (PCFMessage[]) pcfe.exceptionSource;
+        for (PCFMessage msg : msgs) {
+          logger.error(msg.toString());
+        }
+        // Don't throw exception as it will stop queue metric colloection
+      } catch (Exception mqe) {
+        logger.error("MQException caught", mqe);
+        // Dont throw exception as it will stop queuemetric colloection
+      }
+    }
+    long exitTime = System.currentTimeMillis() - entryTime;
+    logger.debug(
+        "Time taken to publish metrics for all queues is {} milliseconds for command {}",
+        exitTime,
+        COMMAND);
+  }
+
+  private void processPCFRequestAndPublishQMetrics(
+      String topicGenericName, PCFMessage request, String command)
+      throws IOException, MQDataException {
+    logger.debug(
+        "sending PCF agent request to topic metrics for generic topic {} for command {}",
+        topicGenericName,
+        command);
+    long startTime = System.currentTimeMillis();
+    PCFMessage[] response = context.send(request);
+    long endTime = System.currentTimeMillis() - startTime;
+    logger.debug(
+        "PCF agent topic metrics query response for generic topic {} for command {} received in {} milliseconds",
+        topicGenericName,
+        command,
+        endTime);
+    if (response == null || response.length <= 0) {
+      logger.debug(
+          "Unexpected Error while PCFMessage.send() for command {}, response is either null or empty",
+          command);
+      return;
     }
 
-    @Override
-    public void publishMetrics() throws TaskExecutionException {
-        logger.info("Collecting metrics for command {}", COMMAND);
-        long entryTime = System.currentTimeMillis();
-
-        if (context.hasNoMetricsToReport()) {
-            logger.debug("Topic metrics to report from the config is null or empty, nothing to publish for command {}", COMMAND);
-            return;
-        }
-        Set<String> topicGenericNames = context.getTopicIncludeFilterNames();
-        //  to query the current status of topics, which is essential for monitoring and managing the publish/subscribe environment in IBM MQ.
-        for (String topicGenericName : topicGenericNames) {
-            // Request: https://www.ibm.com/support/knowledgecenter/SSFKSJ_8.0.0/com.ibm.mq.ref.adm.doc/q088140_.htm
-            // list of all metrics extracted through MQCMD_INQUIRE_TOPIC_STATUS is mentioned here https://www.ibm.com/support/knowledgecenter/SSFKSJ_8.0.0/com.ibm.mq.ref.adm.doc/q088150_.htm
-            PCFMessage request = new PCFMessage(CMQCFC.MQCMD_INQUIRE_TOPIC_STATUS);
-            request.addParameter(CMQC.MQCA_TOPIC_STRING, topicGenericName);
-
-            try {
-                processPCFRequestAndPublishQMetrics(topicGenericName, request, COMMAND);
-            } catch (PCFException pcfe) {
-                logger.error("PCFException caught while collecting metric for Queue: {} for command {}", topicGenericName, COMMAND, pcfe);
-                PCFMessage[] msgs = (PCFMessage[]) pcfe.exceptionSource;
-                for (PCFMessage msg : msgs) {
-                    logger.error(msg.toString());
-                }
-                // Don't throw exception as it will stop queue metric colloection
-            } catch (Exception mqe) {
-                logger.error("MQException caught", mqe);
-                // Dont throw exception as it will stop queuemetric colloection
-            }
-        }
-        long exitTime = System.currentTimeMillis() - entryTime;
-        logger.debug("Time taken to publish metrics for all queues is {} milliseconds for command {}", exitTime, COMMAND);
+    for (PCFMessage pcfMessage : response) {
+      String topicString = pcfMessage.getStringParameterValue(CMQC.MQCA_TOPIC_STRING).trim();
+      Set<ExcludeFilters> excludeFilters = context.getTopicExcludeFilters();
+      if (!ExcludeFilters.isExcluded(topicString, excludeFilters)) { // check for exclude filters
+        logger.debug("Pulling out metrics for topic name {} for command {}", topicString, command);
+        List<Metric> responseMetrics = extractMetrics(command, pcfMessage, topicString);
+        context.transformAndPrintMetrics(responseMetrics);
+      } else {
+        logger.debug("Topic name {} is excluded.", topicString);
+      }
     }
+  }
 
-    private void processPCFRequestAndPublishQMetrics(String topicGenericName, PCFMessage request, String command) throws IOException, MQDataException {
-        logger.debug("sending PCF agent request to topic metrics for generic topic {} for command {}", topicGenericName, command);
-        long startTime = System.currentTimeMillis();
-        PCFMessage[] response = context.send(request);
-        long endTime = System.currentTimeMillis() - startTime;
-        logger.debug("PCF agent topic metrics query response for generic topic {} for command {} received in {} milliseconds", topicGenericName, command, endTime);
-        if (response == null || response.length <= 0) {
-            logger.debug("Unexpected Error while PCFMessage.send() for command {}, response is either null or empty", command);
-            return;
-        }
-
-        for (PCFMessage pcfMessage : response) {
-            String topicString = pcfMessage.getStringParameterValue(CMQC.MQCA_TOPIC_STRING).trim();
-            Set<ExcludeFilters> excludeFilters = context.getTopicExcludeFilters();
-            if (!ExcludeFilters.isExcluded(topicString, excludeFilters)) { //check for exclude filters
-                logger.debug("Pulling out metrics for topic name {} for command {}", topicString, command);
-                List<Metric> responseMetrics = extractMetrics(command, pcfMessage, topicString);
-                context.transformAndPrintMetrics(responseMetrics);
-            } else {
-                logger.debug("Topic name {} is excluded.", topicString);
+  private List<Metric> extractMetrics(String command, PCFMessage pcfMessage, String topicString)
+      throws PCFException {
+    List<Metric> responseMetrics = Lists.newArrayList();
+    context.forEachMetric(
+        (metrickey, wmqOverride) -> {
+          try {
+            PCFParameter pcfParam = pcfMessage.getParameter(wmqOverride.getConstantValue());
+            if (pcfParam instanceof MQCFIN) {
+              int metricVal = pcfMessage.getIntParameterValue(wmqOverride.getConstantValue());
+              Metric metric =
+                  metricCreator.createMetric(
+                      metrickey, metricVal, wmqOverride, topicString, metrickey);
+              responseMetrics.add(metric);
             }
-        }
-    }
-
-    private List<Metric> extractMetrics(String command, PCFMessage pcfMessage, String topicString) throws PCFException {
-        List<Metric> responseMetrics = Lists.newArrayList();
-        context.forEachMetric((metrickey, wmqOverride) -> {
-            try {
-                PCFParameter pcfParam = pcfMessage.getParameter(wmqOverride.getConstantValue());
-                if (pcfParam instanceof MQCFIN) {
-                    int metricVal = pcfMessage.getIntParameterValue(wmqOverride.getConstantValue());
-                    Metric metric = metricCreator.createMetric(metrickey, metricVal, wmqOverride, topicString, metrickey);
-                    responseMetrics.add(metric);
-                }
-            } catch (PCFException pcfe) {
-                logger.error("PCFException caught while collecting metric for Topic: {} for metric: {} in command {}", topicString, wmqOverride.getIbmCommand(), command, pcfe);
-            }
+          } catch (PCFException pcfe) {
+            logger.error(
+                "PCFException caught while collecting metric for Topic: {} for metric: {} in command {}",
+                topicString,
+                wmqOverride.getIbmCommand(),
+                command,
+                pcfe);
+          }
         });
-        return responseMetrics;
-    }
+    return responseMetrics;
+  }
 }

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/IntAttributesBuilder.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/IntAttributesBuilder.java
@@ -1,40 +1,53 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.appdynamics.extensions.webspheremq.metricscollector;
 
 import com.appdynamics.extensions.webspheremq.config.WMQMetricOverride;
-
-import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
- * This class is responsible for building a list of integer-valued attributes
- * from a predefined collection of MWQMetricOverride metrics. It does this
- * by allocating a new int[] and appending the predefined values to
- * an array of input values.
+ * This class is responsible for building a list of integer-valued attributes from a predefined
+ * collection of MWQMetricOverride metrics. It does this by allocating a new int[] and appending the
+ * predefined values to an array of input values.
  */
 public final class IntAttributesBuilder {
-    private final Collection<WMQMetricOverride> metrics;
+  private final Collection<WMQMetricOverride> metrics;
 
-    public IntAttributesBuilder(@Nullable Map<String, WMQMetricOverride> metrics) {
-        this(metrics == null ? null : metrics.values());
+  public IntAttributesBuilder(@Nullable Map<String, WMQMetricOverride> metrics) {
+    this(metrics == null ? null : metrics.values());
+  }
+
+  public IntAttributesBuilder(@Nullable Collection<WMQMetricOverride> metrics) {
+    this.metrics = metrics == null ? Collections.emptySet() : metrics;
+  }
+
+  int[] buildIntAttributesArray(int... inputAttrs) {
+    int[] attrs = new int[inputAttrs.length + metrics.size()];
+    // copy input attrs
+    System.arraycopy(inputAttrs, 0, attrs, 0, inputAttrs.length);
+
+    // fill attrs from metrics.
+    int i = inputAttrs.length;
+    for (WMQMetricOverride metric : metrics) {
+      attrs[i++] = metric.getConstantValue();
     }
 
-    public IntAttributesBuilder(@Nullable Collection<WMQMetricOverride> metrics) {
-        this.metrics = metrics == null ? Collections.emptySet() : metrics;
-    }
-
-    int[] buildIntAttributesArray(int... inputAttrs) {
-        int[] attrs = new int[inputAttrs.length + metrics.size()];
-        // copy input attrs
-        System.arraycopy(inputAttrs, 0, attrs, 0, inputAttrs.length);
-
-        // fill attrs from metrics.
-        int i = inputAttrs.length;
-        for (WMQMetricOverride metric : metrics) {
-            attrs[i++] = metric.getConstantValue();
-        }
-
-        return attrs;
-    }
+    return attrs;
+  }
 }

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/JobSubmitterContext.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/JobSubmitterContext.java
@@ -1,61 +1,78 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.appdynamics.extensions.webspheremq.metricscollector;
 
 import com.appdynamics.extensions.conf.MonitorContextConfiguration;
 import com.appdynamics.extensions.webspheremq.config.WMQMetricOverride;
-
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 
 /**
- * JobSubmitterContext is a bundle class used by MetricsPublisher instances in order
- * to bundle together collaborators and to encapsulate some common repeated
- * functionality.
+ * JobSubmitterContext is a bundle class used by MetricsPublisher instances in order to bundle
+ * together collaborators and to encapsulate some common repeated functionality.
  */
-final public class JobSubmitterContext {
+public final class JobSubmitterContext {
 
-    private final MonitorContextConfiguration monitorContextConfig;
-    private final CountDownLatch countDownLatch;
-    private final MetricsCollectorContext collectorContext;
+  private final MonitorContextConfiguration monitorContextConfig;
+  private final CountDownLatch countDownLatch;
+  private final MetricsCollectorContext collectorContext;
 
-    public JobSubmitterContext(MonitorContextConfiguration monitorContextConfig, CountDownLatch countDownLatch, MetricsCollectorContext collectorContext) {
-        this.monitorContextConfig = monitorContextConfig;
-        this.countDownLatch = countDownLatch;
-        this.collectorContext = collectorContext;
+  public JobSubmitterContext(
+      MonitorContextConfiguration monitorContextConfig,
+      CountDownLatch countDownLatch,
+      MetricsCollectorContext collectorContext) {
+    this.monitorContextConfig = monitorContextConfig;
+    this.countDownLatch = countDownLatch;
+    this.collectorContext = collectorContext;
+  }
+
+  String getMetricPrefix() {
+    return monitorContextConfig.getMetricPrefix();
+  }
+
+  Future<?> submitPublishJob(String name, MetricsPublisher publisher) {
+    MetricsPublisherJob job = new MetricsPublisherJob(publisher, countDownLatch);
+    return monitorContextConfig.getContext().getExecutorService().submit(name, job);
+  }
+
+  int getConfigInt(String key, int defaultValue) {
+    Object result = monitorContextConfig.getConfigYml().get(key);
+    if (result == null) {
+      return defaultValue;
     }
+    return (Integer) result;
+  }
 
-    String getMetricPrefix() {
-        return monitorContextConfig.getMetricPrefix();
-    }
+  MetricCreator newMetricCreator(String firstPathComponent) {
+    return new MetricCreator(
+        getMetricPrefix(), collectorContext.getQueueManagerName(), firstPathComponent);
+  }
 
-    Future<?> submitPublishJob(String name, MetricsPublisher publisher) {
-        MetricsPublisherJob job = new MetricsPublisherJob(publisher, countDownLatch);
-        return monitorContextConfig.getContext()
-                .getExecutorService()
-                .submit(name, job);
-    }
+  MetricsCollectorContext newCollectorContext(Map<String, WMQMetricOverride> newMetrics) {
+    IntAttributesBuilder attributesBuilder = new IntAttributesBuilder(newMetrics);
+    return new MetricsCollectorContext(
+        newMetrics,
+        attributesBuilder,
+        collectorContext.getQueueManager(),
+        collectorContext.getAgent(),
+        collectorContext.getMetricWriteHelper());
+  }
 
-    int getConfigInt(String key, int defaultValue) {
-        Object result = monitorContextConfig.getConfigYml().get(key);
-        if(result == null){
-            return defaultValue;
-        }
-        return (Integer) result;
-    }
-
-    MetricCreator newMetricCreator(String firstPathComponent) {
-        return new MetricCreator(getMetricPrefix(), collectorContext.getQueueManagerName(), firstPathComponent);
-    }
-
-    MetricsCollectorContext newCollectorContext(Map<String, WMQMetricOverride> newMetrics) {
-        IntAttributesBuilder attributesBuilder = new IntAttributesBuilder(newMetrics);
-        return new MetricsCollectorContext(newMetrics, attributesBuilder,
-                collectorContext.getQueueManager(),
-                collectorContext.getAgent(),
-                collectorContext.getMetricWriteHelper());
-    }
-
-    Map<String, WMQMetricOverride> getMetricsForCommand(String command){
-        return collectorContext.getMetricsForCommand(command);
-    }
+  Map<String, WMQMetricOverride> getMetricsForCommand(String command) {
+    return collectorContext.getMetricsForCommand(command);
+  }
 }

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/ListenerMetricsCollector.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/ListenerMetricsCollector.java
@@ -13,109 +13,110 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.appdynamics.extensions.webspheremq.metricscollector;
 
-import com.appdynamics.extensions.MetricWriteHelper;
-import com.appdynamics.extensions.conf.MonitorContextConfiguration;
 import com.appdynamics.extensions.metrics.Metric;
 import com.appdynamics.extensions.webspheremq.config.ExcludeFilters;
-import com.appdynamics.extensions.webspheremq.config.QueueManager;
-import com.appdynamics.extensions.webspheremq.config.WMQMetricOverride;
 import com.google.common.collect.Lists;
 import com.ibm.mq.constants.CMQCFC;
 import com.ibm.mq.headers.pcf.PCFMessage;
-import com.ibm.mq.headers.pcf.PCFMessageAgent;
 import com.singularity.ee.agent.systemagent.api.exception.TaskExecutionException;
+import java.util.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.*;
-import java.util.concurrent.CountDownLatch;
-
 /**
- * ListenerMetricsCollector is a specialized implementation of the MetricsCollector that is responsible
- * for collecting and publishing metrics related to IBM MQ Listeners.
+ * ListenerMetricsCollector is a specialized implementation of the MetricsCollector that is
+ * responsible for collecting and publishing metrics related to IBM MQ Listeners.
  *
- * This class interacts with PCFMessageAgent to query metrics for specific listeners, applies "include:"
- * and "exclude:" listenerFilters defined in config yaml, and uses MetricWriteHelper to publish the collected metrics
- * in the required format.
+ * <p>This class interacts with PCFMessageAgent to query metrics for specific listeners, applies
+ * "include:" and "exclude:" listenerFilters defined in config yaml, and uses MetricWriteHelper to
+ * publish the collected metrics in the required format.
  *
- * Key functionalities include:
- *  • query using PCF Command: MQCMD_INQUIRE_LISTENER_STATUS to get the status of one or more listeners on a queue manager.
- *  • retrieve tcp/ip listeners runtime information such as:
- *    - listener is running or stopped
- *    - port number and transport type
- *    - last error codes
- *    - associated command server
- *  •
+ * <p>Key functionalities include: • query using PCF Command: MQCMD_INQUIRE_LISTENER_STATUS to get
+ * the status of one or more listeners on a queue manager. • retrieve tcp/ip listeners runtime
+ * information such as: - listener is running or stopped - port number and transport type - last
+ * error codes - associated command server •
  *
- * It utilizes WMQMetricOverride to map metrics from the configuration to their IBM MQ constants.
- *
- *
+ * <p>It utilizes WMQMetricOverride to map metrics from the configuration to their IBM MQ constants.
  */
-final public class ListenerMetricsCollector implements MetricsPublisher {
+public final class ListenerMetricsCollector implements MetricsPublisher {
 
-    private  final static Logger logger = LoggerFactory.getLogger(ListenerMetricsCollector.class);
-    public final static String ARTIFACT = "Listeners";
-    private final MetricCreator metricCreator;
-    private final MetricsCollectorContext context;
+  private static final Logger logger = LoggerFactory.getLogger(ListenerMetricsCollector.class);
+  public static final String ARTIFACT = "Listeners";
+  private final MetricCreator metricCreator;
+  private final MetricsCollectorContext context;
 
-    public ListenerMetricsCollector(MetricsCollectorContext context, MetricCreator metricCreator) {
-        this.metricCreator = metricCreator;
-        this.context = context;
+  public ListenerMetricsCollector(MetricsCollectorContext context, MetricCreator metricCreator) {
+    this.metricCreator = metricCreator;
+    this.context = context;
+  }
+
+  @Override
+  public void publishMetrics() throws TaskExecutionException {
+    long entryTime = System.currentTimeMillis();
+
+    if (context.hasNoMetricsToReport()) {
+      logger.debug(
+          "Listener metrics to report from the config is null or empty, nothing to publish");
+      return;
     }
 
-    @Override
-    public void publishMetrics() throws TaskExecutionException {
-        long entryTime = System.currentTimeMillis();
+    int[] attrs = context.buildIntAttributesArray(CMQCFC.MQCACH_LISTENER_NAME);
+    logger.debug(
+        "Attributes being sent along PCF agent request to query channel metrics: "
+            + Arrays.toString(attrs));
 
-        if (context.hasNoMetricsToReport()) {
-            logger.debug("Listener metrics to report from the config is null or empty, nothing to publish");
-            return;
+    Set<String> listenerGenericNames = context.getListenerIncludeFilterNames();
+    for (String listenerGenericName : listenerGenericNames) {
+      PCFMessage request = new PCFMessage(CMQCFC.MQCMD_INQUIRE_LISTENER_STATUS);
+      request.addParameter(CMQCFC.MQCACH_LISTENER_NAME, listenerGenericName);
+      request.addParameter(CMQCFC.MQIACF_LISTENER_STATUS_ATTRS, attrs);
+      try {
+        logger.debug(
+            "sending PCF agent request to query metrics for generic listener {}",
+            listenerGenericName);
+        long startTime = System.currentTimeMillis();
+        PCFMessage[] response = context.send(request);
+        long endTime = System.currentTimeMillis() - startTime;
+        logger.debug(
+            "PCF agent listener metrics query response for generic listener {} received in {} milliseconds",
+            listenerGenericName,
+            endTime);
+        if (response == null || response.length <= 0) {
+          logger.debug(
+              "Unexpected Error while PCFMessage.send(), response is either null or empty");
+          return;
         }
-
-        int[] attrs = context.buildIntAttributesArray(CMQCFC.MQCACH_LISTENER_NAME);
-        logger.debug("Attributes being sent along PCF agent request to query channel metrics: " + Arrays.toString(attrs));
-
-        Set<String> listenerGenericNames = context.getListenerIncludeFilterNames();
-        for(String listenerGenericName : listenerGenericNames){
-            PCFMessage request = new PCFMessage(CMQCFC.MQCMD_INQUIRE_LISTENER_STATUS);
-            request.addParameter(CMQCFC.MQCACH_LISTENER_NAME, listenerGenericName);
-            request.addParameter(CMQCFC.MQIACF_LISTENER_STATUS_ATTRS, attrs);
-            try {
-                logger.debug("sending PCF agent request to query metrics for generic listener {}", listenerGenericName);
-                long startTime = System.currentTimeMillis();
-                PCFMessage[] response = context.send(request);
-                long endTime = System.currentTimeMillis() - startTime;
-                logger.debug("PCF agent listener metrics query response for generic listener {} received in {} milliseconds", listenerGenericName, endTime);
-                if (response == null || response.length <= 0) {
-                    logger.debug("Unexpected Error while PCFMessage.send(), response is either null or empty");
-                    return;
-                }
-                for (PCFMessage pcfMessage : response) {
-                    String listenerName = pcfMessage.getStringParameterValue(CMQCFC.MQCACH_LISTENER_NAME).trim();
-                    Set<ExcludeFilters> excludeFilters = context.getListenerExcludeFilters();
-                    if (!ExcludeFilters.isExcluded(listenerName, excludeFilters)) { //check for exclude filters
-                        logger.debug("Pulling out metrics for listener name {}", listenerName);
-                        List<Metric> responseMetrics = Lists.newArrayList();
-                        context.forEachMetric((metricKey, wmqOverride) -> {
-                            int metricVal = pcfMessage.getIntParameterValue(wmqOverride.getConstantValue());
-                            Metric metric = metricCreator.createMetric(metricKey, metricVal, wmqOverride, listenerName, metricKey);
-                            responseMetrics.add(metric);
-                        });
-                        context.transformAndPrintMetrics(responseMetrics);
-                    } else {
-                        logger.debug("Listener name {} is excluded.", listenerName);
-                    }
-                }
-            }
-            catch (Exception e) {
-                logger.error("Unexpected Error occurred while collecting metrics for listener " + listenerGenericName, e);
-            }
+        for (PCFMessage pcfMessage : response) {
+          String listenerName =
+              pcfMessage.getStringParameterValue(CMQCFC.MQCACH_LISTENER_NAME).trim();
+          Set<ExcludeFilters> excludeFilters = context.getListenerExcludeFilters();
+          if (!ExcludeFilters.isExcluded(
+              listenerName, excludeFilters)) { // check for exclude filters
+            logger.debug("Pulling out metrics for listener name {}", listenerName);
+            List<Metric> responseMetrics = Lists.newArrayList();
+            context.forEachMetric(
+                (metricKey, wmqOverride) -> {
+                  int metricVal = pcfMessage.getIntParameterValue(wmqOverride.getConstantValue());
+                  Metric metric =
+                      metricCreator.createMetric(
+                          metricKey, metricVal, wmqOverride, listenerName, metricKey);
+                  responseMetrics.add(metric);
+                });
+            context.transformAndPrintMetrics(responseMetrics);
+          } else {
+            logger.debug("Listener name {} is excluded.", listenerName);
+          }
         }
-        long exitTime = System.currentTimeMillis() - entryTime;
-        logger.debug("Time taken to publish metrics for all listener is {} milliseconds", exitTime);
-
+      } catch (Exception e) {
+        logger.error(
+            "Unexpected Error occurred while collecting metrics for listener "
+                + listenerGenericName,
+            e);
+      }
     }
+    long exitTime = System.currentTimeMillis() - entryTime;
+    logger.debug("Time taken to publish metrics for all listener is {} milliseconds", exitTime);
+  }
 }

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/MetricCreator.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/MetricCreator.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.appdynamics.extensions.webspheremq.metricscollector;
 
 import com.appdynamics.extensions.metrics.Metric;
@@ -8,48 +23,48 @@ import javax.annotation.Nullable;
 
 public final class MetricCreator {
 
-    private final String metricPrefix;
-    private final String queueManagerName;
-    @Nullable
-    private final String firstPathComponent;
+  private final String metricPrefix;
+  private final String queueManagerName;
+  @Nullable private final String firstPathComponent;
 
-    public MetricCreator(String metricPrefix, QueueManager queueManager) {
-        this(metricPrefix, WMQUtil.getQueueManagerNameFromConfig(queueManager), null);
-    }
+  public MetricCreator(String metricPrefix, QueueManager queueManager) {
+    this(metricPrefix, WMQUtil.getQueueManagerNameFromConfig(queueManager), null);
+  }
 
-    public MetricCreator(String metricPrefix, QueueManager queueManager, @Nullable String firstPathComponent) {
-        this(metricPrefix, WMQUtil.getQueueManagerNameFromConfig(queueManager), firstPathComponent);
-    }
+  public MetricCreator(
+      String metricPrefix, QueueManager queueManager, @Nullable String firstPathComponent) {
+    this(metricPrefix, WMQUtil.getQueueManagerNameFromConfig(queueManager), firstPathComponent);
+  }
 
-    public MetricCreator(String metricPrefix, String queueManagerName, @Nullable String firstPathComponent) {
-        this.metricPrefix = metricPrefix;
-        this.queueManagerName = queueManagerName;
-        this.firstPathComponent = firstPathComponent;
-    }
+  public MetricCreator(
+      String metricPrefix, String queueManagerName, @Nullable String firstPathComponent) {
+    this.metricPrefix = metricPrefix;
+    this.queueManagerName = queueManagerName;
+    this.firstPathComponent = firstPathComponent;
+  }
 
-    Metric createMetric(String metricName, int metricValue, WMQMetricOverride wmqOverride, String... pathElements) {
-        String metricPath = getMetricsName(queueManagerName, pathElements);
-        if (wmqOverride != null && wmqOverride.getMetricProperties() != null) {
-            return new Metric(metricName, String.valueOf(metricValue), metricPath, wmqOverride.getMetricProperties());
-        }
-        return new Metric(metricName, String.valueOf(metricValue), metricPath);
+  Metric createMetric(
+      String metricName, int metricValue, WMQMetricOverride wmqOverride, String... pathElements) {
+    String metricPath = getMetricsName(queueManagerName, pathElements);
+    if (wmqOverride != null && wmqOverride.getMetricProperties() != null) {
+      return new Metric(
+          metricName, String.valueOf(metricValue), metricPath, wmqOverride.getMetricProperties());
     }
+    return new Metric(metricName, String.valueOf(metricValue), metricPath);
+  }
 
-    private String getMetricsName(String qmNameToBeDisplayed, String... pathElements) {
-        StringBuilder pathBuilder = new StringBuilder(metricPrefix);
-        pathBuilder.append("|")
-                .append(qmNameToBeDisplayed)
-                .append("|");
-        if(firstPathComponent != null){
-            pathBuilder.append(firstPathComponent)
-                    .append("|");
-        }
-        for (int i = 0; i < pathElements.length; i++) {
-            pathBuilder.append(pathElements[i]);
-            if (i != pathElements.length - 1) {
-                pathBuilder.append("|");
-            }
-        }
-        return pathBuilder.toString();
+  private String getMetricsName(String qmNameToBeDisplayed, String... pathElements) {
+    StringBuilder pathBuilder = new StringBuilder(metricPrefix);
+    pathBuilder.append("|").append(qmNameToBeDisplayed).append("|");
+    if (firstPathComponent != null) {
+      pathBuilder.append(firstPathComponent).append("|");
     }
+    for (int i = 0; i < pathElements.length; i++) {
+      pathBuilder.append(pathElements[i]);
+      if (i != pathElements.length - 1) {
+        pathBuilder.append("|");
+      }
+    }
+    return pathBuilder.toString();
+  }
 }

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/MetricsCollectorContext.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/MetricsCollectorContext.java
@@ -1,4 +1,21 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.appdynamics.extensions.webspheremq.metricscollector;
+
+import static java.util.Collections.emptyMap;
 
 import com.appdynamics.extensions.MetricWriteHelper;
 import com.appdynamics.extensions.metrics.Metric;
@@ -10,146 +27,150 @@ import com.ibm.mq.headers.MQDataException;
 import com.ibm.mq.headers.pcf.PCFException;
 import com.ibm.mq.headers.pcf.PCFMessage;
 import com.ibm.mq.headers.pcf.PCFMessageAgent;
+import java.io.IOException;
+import java.util.*;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nullable;
-import javax.annotation.concurrent.Immutable;
-import java.io.IOException;
-import java.util.*;
-import java.util.concurrent.Future;
-import java.util.stream.Collectors;
-
-import static java.util.Collections.emptyMap;
-
 /**
- * A temporary bundle to contain the collaborators of the original MetricsCollector
- * base class until we can finish unwinding things. When done and there are no
- * longer usages of MetricsCollector, we could consider renaming this.
+ * A temporary bundle to contain the collaborators of the original MetricsCollector base class until
+ * we can finish unwinding things. When done and there are no longer usages of MetricsCollector, we
+ * could consider renaming this.
  */
 @Immutable
 public final class MetricsCollectorContext {
 
-    private static final Logger logger = LoggerFactory.getLogger(MetricsCollectorContext.class);
+  private static final Logger logger = LoggerFactory.getLogger(MetricsCollectorContext.class);
 
-    private final Map<String, WMQMetricOverride> metricsToReport;
-    private final IntAttributesBuilder attributesBuilder;
-    private final QueueManager queueManager;
-    private final PCFMessageAgent agent;
-    private final MetricWriteHelper metricWriteHelper;
+  private final Map<String, WMQMetricOverride> metricsToReport;
+  private final IntAttributesBuilder attributesBuilder;
+  private final QueueManager queueManager;
+  private final PCFMessageAgent agent;
+  private final MetricWriteHelper metricWriteHelper;
 
-    public MetricsCollectorContext(@Nullable Map<String, WMQMetricOverride> metricsToReport,
-                                   QueueManager queueManager, PCFMessageAgent agent, MetricWriteHelper metricWriteHelper) {
-        this(metricsToReport, new IntAttributesBuilder(metricsToReport),
-                queueManager, agent, metricWriteHelper);
+  public MetricsCollectorContext(
+      @Nullable Map<String, WMQMetricOverride> metricsToReport,
+      QueueManager queueManager,
+      PCFMessageAgent agent,
+      MetricWriteHelper metricWriteHelper) {
+    this(
+        metricsToReport,
+        new IntAttributesBuilder(metricsToReport),
+        queueManager,
+        agent,
+        metricWriteHelper);
+  }
+
+  public MetricsCollectorContext(
+      @Nullable Map<String, WMQMetricOverride> metricsToReport,
+      IntAttributesBuilder attributesBuilder,
+      QueueManager queueManager,
+      PCFMessageAgent agent,
+      MetricWriteHelper metricWriteHelper) {
+    this.metricsToReport =
+        metricsToReport == null ? Collections.emptyMap() : new HashMap<>(metricsToReport);
+    this.attributesBuilder = attributesBuilder;
+    this.queueManager = queueManager;
+    this.agent = agent;
+    this.metricWriteHelper = metricWriteHelper;
+  }
+
+  boolean hasNoMetricsToReport() {
+    return metricsToReport.isEmpty();
+  }
+
+  int[] buildIntAttributesArray(int... inputAttrs) {
+    return attributesBuilder.buildIntAttributesArray(inputAttrs);
+  }
+
+  Set<String> getChannelIncludeFilterNames() {
+    return queueManager.getChannelFilters().getInclude();
+  }
+
+  Set<ExcludeFilters> getChannelExcludeFilters() {
+    return queueManager.getChannelFilters().getExclude();
+  }
+
+  Set<String> getListenerIncludeFilterNames() {
+    return queueManager.getListenerFilters().getInclude();
+  }
+
+  Set<ExcludeFilters> getListenerExcludeFilters() {
+    return queueManager.getListenerFilters().getExclude();
+  }
+
+  Set<String> getTopicIncludeFilterNames() {
+    return queueManager.getTopicFilters().getInclude();
+  }
+
+  Set<ExcludeFilters> getTopicExcludeFilters() {
+    return queueManager.getTopicFilters().getExclude();
+  }
+
+  Set<String> getQueueIncludeFilterNames() {
+    return queueManager.getQueueFilters().getInclude();
+  }
+
+  Set<ExcludeFilters> getQueueExcludeFilters() {
+    return queueManager.getQueueFilters().getExclude();
+  }
+
+  PCFMessage[] send(PCFMessage request) throws IOException, MQDataException {
+    return agent.send(request);
+  }
+
+  void forEachMetric(MetricConsumerAction action) throws PCFException {
+    if (metricsToReport == null) {
+      return;
     }
-
-    public MetricsCollectorContext(@Nullable Map<String, WMQMetricOverride> metricsToReport,
-                                   IntAttributesBuilder attributesBuilder, QueueManager queueManager,
-                                   PCFMessageAgent agent, MetricWriteHelper metricWriteHelper) {
-        this.metricsToReport = metricsToReport == null ? Collections.emptyMap() : new HashMap<>(metricsToReport);
-        this.attributesBuilder = attributesBuilder;
-        this.queueManager = queueManager;
-        this.agent = agent;
-        this.metricWriteHelper = metricWriteHelper;
+    for (Map.Entry<String, WMQMetricOverride> entry : metricsToReport.entrySet()) {
+      action.accept(entry.getKey(), entry.getValue());
     }
+  }
 
-    boolean hasNoMetricsToReport() {
-        return metricsToReport.isEmpty();
+  void transformAndPrintMetric(Metric responseMetrics) {
+    transformAndPrintMetrics(Collections.singletonList(responseMetrics));
+  }
+
+  void transformAndPrintMetrics(List<Metric> responseMetrics) {
+    metricWriteHelper.transformAndPrintMetrics(responseMetrics);
+  }
+
+  String getQueueManagerName() {
+    return WMQUtil.getQueueManagerNameFromConfig(queueManager);
+  }
+
+  QueueManager getQueueManager() {
+    return queueManager;
+  }
+
+  PCFMessageAgent getAgent() {
+    return agent;
+  }
+
+  MetricWriteHelper getMetricWriteHelper() {
+    return metricWriteHelper;
+  }
+
+  String getAgentQueueManagerName() {
+    return agent.getQManagerName();
+  }
+
+  Map<String, WMQMetricOverride> getMetricsForCommand(String command) {
+    if (metricsToReport == null || metricsToReport.isEmpty()) {
+      logger.debug("There are no metrics configured for {}", command);
+      return emptyMap();
     }
+    return metricsToReport.entrySet().stream()
+        .filter(entry -> entry.getValue().getIbmCommand().equalsIgnoreCase(command))
+        .collect(
+            Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (x, y) -> y, HashMap::new));
+  }
 
-    int[] buildIntAttributesArray(int... inputAttrs) {
-        return attributesBuilder.buildIntAttributesArray(inputAttrs);
-    }
-
-    Set<String> getChannelIncludeFilterNames() {
-        return queueManager.getChannelFilters().getInclude();
-    }
-
-    Set<ExcludeFilters> getChannelExcludeFilters() {
-        return queueManager.getChannelFilters().getExclude();
-    }
-
-    Set<String> getListenerIncludeFilterNames() {
-        return queueManager.getListenerFilters().getInclude();
-    }
-
-    Set<ExcludeFilters> getListenerExcludeFilters() {
-        return queueManager.getListenerFilters().getExclude();
-    }
-
-    Set<String> getTopicIncludeFilterNames() {
-        return queueManager.getTopicFilters().getInclude();
-    }
-
-    Set<ExcludeFilters> getTopicExcludeFilters() {
-        return queueManager.getTopicFilters().getExclude();
-    }
-
-    Set<String> getQueueIncludeFilterNames() {
-        return queueManager.getQueueFilters().getInclude();
-    }
-
-    Set<ExcludeFilters> getQueueExcludeFilters() {
-        return queueManager.getQueueFilters().getExclude();
-    }
-
-    PCFMessage[] send(PCFMessage request) throws IOException, MQDataException {
-        return agent.send(request);
-    }
-
-    void forEachMetric(MetricConsumerAction action) throws PCFException {
-        if (metricsToReport == null) {
-            return;
-        }
-        for (Map.Entry<String, WMQMetricOverride> entry : metricsToReport.entrySet()) {
-            action.accept(entry.getKey(), entry.getValue());
-        }
-    }
-
-    void transformAndPrintMetric(Metric responseMetrics) {
-        transformAndPrintMetrics(Collections.singletonList(responseMetrics));
-    }
-
-    void transformAndPrintMetrics(List<Metric> responseMetrics) {
-        metricWriteHelper.transformAndPrintMetrics(responseMetrics);
-    }
-
-    String getQueueManagerName() {
-        return WMQUtil.getQueueManagerNameFromConfig(queueManager);
-    }
-
-    QueueManager getQueueManager() {
-        return queueManager;
-    }
-
-    PCFMessageAgent getAgent() {
-        return agent;
-    }
-
-    MetricWriteHelper getMetricWriteHelper() {
-        return metricWriteHelper;
-    }
-
-    String getAgentQueueManagerName() {
-        return agent.getQManagerName();
-    }
-
-    Map<String, WMQMetricOverride> getMetricsForCommand(String command) {
-        if (metricsToReport == null || metricsToReport.isEmpty()) {
-            logger.debug("There are no metrics configured for {}", command);
-            return emptyMap();
-        }
-        return metricsToReport.entrySet().stream()
-                .filter(entry ->
-                        entry.getValue().getIbmCommand().equalsIgnoreCase(command))
-                .collect(Collectors.toMap(
-                        Map.Entry::getKey, Map.Entry::getValue,
-                        (x, y) -> y, HashMap::new));
-    }
-
-    interface MetricConsumerAction {
-        void accept(String key, WMQMetricOverride wmqMetricOverride) throws PCFException;
-
-    }
+  interface MetricConsumerAction {
+    void accept(String key, WMQMetricOverride wmqMetricOverride) throws PCFException;
+  }
 }

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/MetricsPublisher.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/MetricsPublisher.java
@@ -1,9 +1,23 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.appdynamics.extensions.webspheremq.metricscollector;
 
 import com.singularity.ee.agent.systemagent.api.exception.TaskExecutionException;
 
 public interface MetricsPublisher {
 
-    void publishMetrics() throws TaskExecutionException;
-
+  void publishMetrics() throws TaskExecutionException;
 }

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/MetricsPublisherJob.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/MetricsPublisherJob.java
@@ -1,33 +1,45 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.appdynamics.extensions.webspheremq.metricscollector;
 
 import com.singularity.ee.agent.systemagent.api.exception.TaskExecutionException;
+import java.util.concurrent.CountDownLatch;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.concurrent.CountDownLatch;
+/** A simple job that just runs a MetricsPublisher one time. */
+public final class MetricsPublisherJob implements Runnable {
 
-/**
- * A simple job that just runs a MetricsPublisher one time.
- */
-final public class MetricsPublisherJob implements Runnable {
+  public static final Logger logger = LoggerFactory.getLogger(MetricsPublisherJob.class);
+  private final MetricsPublisher delegate;
+  private final CountDownLatch latch;
 
-    public static final Logger logger = LoggerFactory.getLogger(MetricsPublisherJob.class);
-    private final MetricsPublisher delegate;
-    private final CountDownLatch latch;
+  public MetricsPublisherJob(MetricsPublisher delegate, CountDownLatch latch) {
+    this.delegate = delegate;
+    this.latch = latch;
+  }
 
-    public MetricsPublisherJob(MetricsPublisher delegate, CountDownLatch latch) {
-        this.delegate = delegate;
-        this.latch = latch;
+  @Override
+  public void run() {
+    try {
+      delegate.publishMetrics();
+    } catch (TaskExecutionException e) {
+      logger.error("Error executing " + delegate.getClass().getSimpleName(), e);
+    } finally {
+      latch.countDown();
     }
-
-    @Override
-    public void run() {
-        try {
-            delegate.publishMetrics();
-        } catch (TaskExecutionException e) {
-            logger.error("Error executing " + delegate.getClass().getSimpleName(), e);
-        } finally {
-            latch.countDown();
-        }
-    }
+  }
 }

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/QueueCollectionBuddy.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/QueueCollectionBuddy.java
@@ -1,4 +1,23 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.appdynamics.extensions.webspheremq.metricscollector;
+
+import static com.ibm.mq.constants.CMQC.*;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
 
 import com.appdynamics.extensions.metrics.Metric;
 import com.appdynamics.extensions.webspheremq.config.ExcludeFilters;
@@ -7,182 +26,215 @@ import com.google.common.collect.Lists;
 import com.ibm.mq.constants.CMQC;
 import com.ibm.mq.headers.MQDataException;
 import com.ibm.mq.headers.pcf.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-
-import static com.ibm.mq.constants.CMQC.*;
-import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
- * A collaborator buddy of the queue collectors that helps them to send a message,
- * process the response, and generate metrics.
+ * A collaborator buddy of the queue collectors that helps them to send a message, process the
+ * response, and generate metrics.
  */
 final class QueueCollectionBuddy {
-    private static final Logger logger = LoggerFactory.getLogger(QueueCollectionBuddy.class);
+  private static final Logger logger = LoggerFactory.getLogger(QueueCollectionBuddy.class);
 
-    private final MetricsCollectorContext context;
-    private final QueueCollectorSharedState sharedState;
-    private final MetricCreator metricCreator;
-    private final String command;
+  private final MetricsCollectorContext context;
+  private final QueueCollectorSharedState sharedState;
+  private final MetricCreator metricCreator;
+  private final String command;
 
-    QueueCollectionBuddy(MetricsCollectorContext context, QueueCollectorSharedState sharedState,
-                         MetricCreator metricCreator, String command) {
-        this.context = context;
-        this.sharedState = sharedState;
-        this.metricCreator = metricCreator;
-        this.command = command;
+  QueueCollectionBuddy(
+      MetricsCollectorContext context,
+      QueueCollectorSharedState sharedState,
+      MetricCreator metricCreator,
+      String command) {
+    this.context = context;
+    this.sharedState = sharedState;
+    this.metricCreator = metricCreator;
+    this.command = command;
+  }
+
+  /**
+   * Sends a PCFMessage request, reads the response, and generates metrics from the response. It
+   * handles all exceptions.
+   */
+  void processPCFRequestAndPublishQMetrics(PCFMessage request, String queueGenericName) {
+    try {
+      doProcessPCFRequestAndPublishQMetrics(request, queueGenericName);
+    } catch (PCFException pcfe) {
+      logger.error(
+          "PCFException caught while collecting metric for Queue: {} for command {}",
+          queueGenericName,
+          command,
+          pcfe);
+      if (pcfe.exceptionSource instanceof PCFMessage[]) {
+        PCFMessage[] msgs = (PCFMessage[]) pcfe.exceptionSource;
+        for (PCFMessage msg : msgs) {
+          logger.error(msg.toString());
+        }
+      }
+      if (pcfe.exceptionSource instanceof PCFMessage) {
+        PCFMessage msg = (PCFMessage) pcfe.exceptionSource;
+        logger.error(msg.toString());
+      }
+      // Don't throw exception as it will stop queue metric collection
+    } catch (Exception mqe) {
+      logger.error("MQException caught", mqe);
+      // Don't throw exception as it will stop queue metric collection
+    }
+  }
+
+  private void doProcessPCFRequestAndPublishQMetrics(PCFMessage request, String queueGenericName)
+      throws IOException, MQDataException {
+    logger.debug(
+        "sending PCF agent request to query metrics for generic queue {} for command {}",
+        queueGenericName,
+        command);
+    long startTime = System.currentTimeMillis();
+    PCFMessage[] response = context.send(request);
+    long endTime = System.currentTimeMillis() - startTime;
+    logger.debug(
+        "PCF agent queue metrics query response for generic queue {} for command {} received in {} milliseconds",
+        queueGenericName,
+        command,
+        endTime);
+    if (response == null || response.length == 0) {
+      logger.debug(
+          "Unexpected Error while PCFMessage.send() for command {}, response is either null or empty",
+          command);
+      return;
+    }
+    for (PCFMessage pcfMessage : response) {
+      handleMessage(pcfMessage);
+    }
+  }
+
+  private void handleMessage(PCFMessage message) throws PCFException {
+    String queueName = message.getStringParameterValue(CMQC.MQCA_Q_NAME).trim();
+    String queueType = getQueueTypeFromName(message, queueName);
+    if (queueType == null) {
+      logger.info("Unable to determine queue type for queue name = {}", queueName);
+      return;
     }
 
-    /**
-     * Sends a PCFMessage request, reads the response, and generates metrics from the response.
-     * It handles all exceptions.
-     */
-    void processPCFRequestAndPublishQMetrics(PCFMessage request, String queueGenericName) {
-        try {
-            doProcessPCFRequestAndPublishQMetrics(request, queueGenericName);
-        } catch (PCFException pcfe) {
-            logger.error("PCFException caught while collecting metric for Queue: {} for command {}", queueGenericName, command, pcfe);
-            if (pcfe.exceptionSource instanceof PCFMessage[]) {
-                PCFMessage[] msgs = (PCFMessage[]) pcfe.exceptionSource;
-                for (PCFMessage msg : msgs) {
-                    logger.error(msg.toString());
-                }
-            }
-            if (pcfe.exceptionSource instanceof PCFMessage) {
-                PCFMessage msg = (PCFMessage) pcfe.exceptionSource;
-                logger.error(msg.toString());
-            }
-            // Don't throw exception as it will stop queue metric collection
-        } catch (Exception mqe) {
-            logger.error("MQException caught", mqe);
-            // Don't throw exception as it will stop queue metric collection
-        }
+    Set<ExcludeFilters> excludeFilters = context.getQueueExcludeFilters();
+    if (!ExcludeFilters.isExcluded(queueName, excludeFilters)) { // check for exclude filters
+      logger.debug("Pulling out metrics for queue name {} for command {}", queueName, command);
+      List<Metric> responseMetrics = getMetrics(message, queueName, queueType);
+      context.transformAndPrintMetrics(responseMetrics);
+    } else {
+      logger.debug("Queue name {} is excluded.", queueName);
+    }
+  }
+
+  private String getQueueTypeFromName(PCFMessage message, String queueName) throws PCFException {
+    if (message.getParameterValue(CMQC.MQIA_Q_TYPE) == null) {
+      return sharedState.getType(queueName);
     }
 
-    private void doProcessPCFRequestAndPublishQMetrics(PCFMessage request, String queueGenericName) throws IOException, MQDataException {
-        logger.debug("sending PCF agent request to query metrics for generic queue {} for command {}",
-                queueGenericName, command);
-        long startTime = System.currentTimeMillis();
-        PCFMessage[] response = context.send(request);
-        long endTime = System.currentTimeMillis() - startTime;
-        logger.debug("PCF agent queue metrics query response for generic queue {} for command {} received in {} milliseconds", queueGenericName, command, endTime);
-        if (response == null || response.length == 0) {
-            logger.debug("Unexpected Error while PCFMessage.send() for command {}, response is either null or empty", command);
-            return;
-        }
-        for (PCFMessage pcfMessage : response) {
-            handleMessage(pcfMessage);
-        }
+    String queueType = getQueueType(message);
+    sharedState.putQueueType(queueName, queueType);
+    return queueType;
+  }
+
+  private static String getQueueType(PCFMessage message) throws PCFException {
+    String baseQueueType = getBaseQueueType(message);
+    return maybeAppendUsage(message, baseQueueType);
+  }
+
+  private static String maybeAppendUsage(PCFMessage message, String baseQueueType)
+      throws PCFException {
+    if (message.getParameter(CMQC.MQIA_USAGE) == null) {
+      return baseQueueType;
     }
-
-    private void handleMessage(PCFMessage message) throws PCFException {
-        String queueName = message.getStringParameterValue(CMQC.MQCA_Q_NAME).trim();
-        String queueType = getQueueTypeFromName(message, queueName);
-        if (queueType == null) {
-            logger.info("Unable to determine queue type for queue name = {}", queueName);
-            return;
-        }
-
-        Set<ExcludeFilters> excludeFilters = context.getQueueExcludeFilters();
-        if (!ExcludeFilters.isExcluded(queueName, excludeFilters)) { //check for exclude filters
-            logger.debug("Pulling out metrics for queue name {} for command {}", queueName, command);
-            List<Metric> responseMetrics = getMetrics(message, queueName, queueType);
-            context.transformAndPrintMetrics(responseMetrics);
-        } else {
-            logger.debug("Queue name {} is excluded.", queueName);
-        }
+    switch (message.getIntParameterValue(CMQC.MQIA_USAGE)) {
+      case CMQC.MQUS_NORMAL:
+        return baseQueueType + "-normal";
+      case CMQC.MQUS_TRANSMISSION:
+        return baseQueueType + "-transmission";
     }
+    return baseQueueType;
+  }
 
-    private String getQueueTypeFromName(PCFMessage message, String queueName) throws PCFException {
-        if (message.getParameterValue(CMQC.MQIA_Q_TYPE) == null) {
-            return sharedState.getType(queueName);
-        }
-
-        String queueType = getQueueType(message);
-        sharedState.putQueueType(queueName, queueType);
-        return queueType;
+  private static String getBaseQueueType(PCFMessage message) throws PCFException {
+    switch (message.getIntParameterValue(CMQC.MQIA_Q_TYPE)) {
+      case MQQT_LOCAL:
+        return "local";
+      case MQQT_ALIAS:
+        return "alias";
+      case MQQT_REMOTE:
+        return "remote";
+      case MQQT_CLUSTER:
+        return "cluster";
+      case MQQT_MODEL:
+        return "model";
     }
+    logger.warn("Unknown type of queue {}", message.getIntParameterValue(CMQC.MQIA_Q_TYPE));
+    return "unknown";
+  }
 
-    private static String getQueueType(PCFMessage message) throws PCFException {
-        String baseQueueType = getBaseQueueType(message);
-        return maybeAppendUsage(message, baseQueueType);
-    }
-
-    private static String maybeAppendUsage(PCFMessage message, String baseQueueType) throws PCFException {
-        if (message.getParameter(CMQC.MQIA_USAGE) == null) {
-            return baseQueueType;
-        }
-        switch (message.getIntParameterValue(CMQC.MQIA_USAGE)) {
-            case CMQC.MQUS_NORMAL:
-                return baseQueueType + "-normal";
-            case CMQC.MQUS_TRANSMISSION:
-                return baseQueueType + "-transmission";
-        }
-        return baseQueueType;
-    }
-
-    private static String getBaseQueueType(PCFMessage message) throws PCFException {
-        switch (message.getIntParameterValue(CMQC.MQIA_Q_TYPE)) {
-            case MQQT_LOCAL:
-                return "local";
-            case MQQT_ALIAS:
-                return "alias";
-            case MQQT_REMOTE:
-                return "remote";
-            case MQQT_CLUSTER:
-                return "cluster";
-            case MQQT_MODEL:
-                return "model";
-        }
-        logger.warn("Unknown type of queue {}", message.getIntParameterValue(CMQC.MQIA_Q_TYPE));
-        return "unknown";
-    }
-
-    private List<Metric> getMetrics(PCFMessage pcfMessage, String queueName, String queueType) throws PCFException {
-        List<Metric> responseMetrics = Lists.newArrayList();
-        context.forEachMetric((metricKey, wmqOverride) -> {
-            try {
-                List<Metric> tempMetrics = buildMetrics(pcfMessage, queueName, queueType, metricKey, wmqOverride);
-                responseMetrics.addAll(tempMetrics);
-            } catch (PCFException pcfe) {
-                logger.error("PCFException caught while collecting metric for Queue: {} for metric: {} in command {}", queueName, wmqOverride.getIbmCommand(), command, pcfe);
-            }
+  private List<Metric> getMetrics(PCFMessage pcfMessage, String queueName, String queueType)
+      throws PCFException {
+    List<Metric> responseMetrics = Lists.newArrayList();
+    context.forEachMetric(
+        (metricKey, wmqOverride) -> {
+          try {
+            List<Metric> tempMetrics =
+                buildMetrics(pcfMessage, queueName, queueType, metricKey, wmqOverride);
+            responseMetrics.addAll(tempMetrics);
+          } catch (PCFException pcfe) {
+            logger.error(
+                "PCFException caught while collecting metric for Queue: {} for metric: {} in command {}",
+                queueName,
+                wmqOverride.getIbmCommand(),
+                command,
+                pcfe);
+          }
         });
-        return responseMetrics;
-    }
+    return responseMetrics;
+  }
 
-    private List<Metric> buildMetrics(PCFMessage pcfMessage, String queueName, String queueType, String metricKey, WMQMetricOverride wmqOverride) throws PCFException {
-        PCFParameter pcfParam = pcfMessage.getParameter(wmqOverride.getConstantValue());
-        if (pcfParam == null) {
-            logger.warn("PCF parameter is null in response for Queue: {} for metric: {} in command {}", queueName, wmqOverride.getIbmCommand(), command);
-            return emptyList();
-        }
-        if (pcfParam instanceof MQCFIN) {
-            int metricVal = pcfMessage.getIntParameterValue(wmqOverride.getConstantValue());
-            Metric metric = metricCreator.createMetric(metricKey, metricVal, wmqOverride, queueName, queueType, metricKey);
-            return singletonList(metric);
-        }
-        List<Metric> tempMetrics = new ArrayList<>();
-        if (pcfParam instanceof MQCFIL) {
-            int[] metricVals = pcfMessage.getIntListParameterValue(wmqOverride.getConstantValue());
-            if (metricVals == null) {
-                return emptyList();
-            }
-
-            int count = 0;
-            for (int val : metricVals) {
-                count++;
-                String metricName = metricKey + "_" + count;
-                Metric metric = metricCreator.createMetric(metricName, val, wmqOverride, queueName, metricName);
-                tempMetrics.add(metric);
-            }
-        }
-        return tempMetrics;
+  private List<Metric> buildMetrics(
+      PCFMessage pcfMessage,
+      String queueName,
+      String queueType,
+      String metricKey,
+      WMQMetricOverride wmqOverride)
+      throws PCFException {
+    PCFParameter pcfParam = pcfMessage.getParameter(wmqOverride.getConstantValue());
+    if (pcfParam == null) {
+      logger.warn(
+          "PCF parameter is null in response for Queue: {} for metric: {} in command {}",
+          queueName,
+          wmqOverride.getIbmCommand(),
+          command);
+      return emptyList();
     }
+    if (pcfParam instanceof MQCFIN) {
+      int metricVal = pcfMessage.getIntParameterValue(wmqOverride.getConstantValue());
+      Metric metric =
+          metricCreator.createMetric(
+              metricKey, metricVal, wmqOverride, queueName, queueType, metricKey);
+      return singletonList(metric);
+    }
+    List<Metric> tempMetrics = new ArrayList<>();
+    if (pcfParam instanceof MQCFIL) {
+      int[] metricVals = pcfMessage.getIntListParameterValue(wmqOverride.getConstantValue());
+      if (metricVals == null) {
+        return emptyList();
+      }
+
+      int count = 0;
+      for (int val : metricVals) {
+        count++;
+        String metricName = metricKey + "_" + count;
+        Metric metric =
+            metricCreator.createMetric(metricName, val, wmqOverride, queueName, metricName);
+        tempMetrics.add(metric);
+      }
+    }
+    return tempMetrics;
+  }
 }

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/QueueCollectorSharedState.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/QueueCollectorSharedState.java
@@ -1,37 +1,47 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.appdynamics.extensions.webspheremq.metricscollector;
 
-import javax.annotation.Nullable;
 import java.util.concurrent.ConcurrentHashMap;
+import javax.annotation.Nullable;
 
-/**
- * A miserable hack to encapsulate the state that is shared between queue collectors
- */
+/** A miserable hack to encapsulate the state that is shared between queue collectors */
 public final class QueueCollectorSharedState {
 
-    private final ConcurrentHashMap<String, String> queueNameToType = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<String, String> queueNameToType = new ConcurrentHashMap<>();
 
-    private final static QueueCollectorSharedState INSTANCE = new QueueCollectorSharedState();
+  private static final QueueCollectorSharedState INSTANCE = new QueueCollectorSharedState();
 
-    public static QueueCollectorSharedState getInstance() {
-        return INSTANCE;
-    }
+  public static QueueCollectorSharedState getInstance() {
+    return INSTANCE;
+  }
 
-    private QueueCollectorSharedState(){}
+  private QueueCollectorSharedState() {}
 
-    public void putQueueType(String name, String value){
-        queueNameToType.put(name, value);
-    }
+  public void putQueueType(String name, String value) {
+    queueNameToType.put(name, value);
+  }
 
-    @Nullable
-    public String getType(String name){
-        return queueNameToType.get(name);
-    }
+  @Nullable
+  public String getType(String name) {
+    return queueNameToType.get(name);
+  }
 
-    // Only exists for testing and should not normally ever be called.
-    void resetForTest(){
-        queueNameToType.clear();
-    }
-
-
-
+  // Only exists for testing and should not normally ever be called.
+  void resetForTest() {
+    queueNameToType.clear();
+  }
 }

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/QueueManagerMetricsCollector.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/QueueManagerMetricsCollector.java
@@ -13,78 +13,75 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.appdynamics.extensions.webspheremq.metricscollector;
 
-import com.appdynamics.extensions.MetricWriteHelper;
-import com.appdynamics.extensions.conf.MonitorContextConfiguration;
 import com.appdynamics.extensions.metrics.Metric;
-import com.appdynamics.extensions.webspheremq.config.QueueManager;
-import com.appdynamics.extensions.webspheremq.config.WMQMetricOverride;
 import com.google.common.collect.Lists;
 import com.ibm.mq.constants.CMQCFC;
 import com.ibm.mq.headers.pcf.PCFMessage;
-import com.ibm.mq.headers.pcf.PCFMessageAgent;
 import com.singularity.ee.agent.systemagent.api.exception.TaskExecutionException;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.CountDownLatch;
+/** This class is responsible for queue manager metric collection. */
+public final class QueueManagerMetricsCollector implements MetricsPublisher {
 
-/**
- * This class is responsible for queue manager metric collection.
- */
-final public class QueueManagerMetricsCollector implements MetricsPublisher {
+  private static final Logger logger = LoggerFactory.getLogger(QueueManagerMetricsCollector.class);
+  public static final String ARTIFACT = "Queue Manager";
+  private final MetricsCollectorContext context;
+  private final MetricCreator metricCreator;
 
-	private static final Logger logger = LoggerFactory.getLogger(QueueManagerMetricsCollector.class);
-	public final static String ARTIFACT = "Queue Manager";
-	private final MetricsCollectorContext context;
-	private final MetricCreator metricCreator;
+  public QueueManagerMetricsCollector(
+      MetricsCollectorContext context, MetricCreator metricCreator) {
+    this.context = context;
+    this.metricCreator = metricCreator;
+  }
 
-	public QueueManagerMetricsCollector(MetricsCollectorContext context, MetricCreator metricCreator) {
-        this.context = context;
-        this.metricCreator = metricCreator;
+  @Override
+  public void publishMetrics() throws TaskExecutionException {
+    long entryTime = System.currentTimeMillis();
+    logger.debug(
+        "publishMetrics entry time for queuemanager {} is {} milliseconds",
+        context.getAgentQueueManagerName(),
+        entryTime);
+    // CMQCFC.MQCMD_INQUIRE_Q_MGR_STATUS is 161
+    PCFMessage request = new PCFMessage(CMQCFC.MQCMD_INQUIRE_Q_MGR_STATUS);
+    // CMQCFC.MQIACF_Q_MGR_STATUS_ATTRS is 1229
+    request.addParameter(CMQCFC.MQIACF_Q_MGR_STATUS_ATTRS, new int[] {CMQCFC.MQIACF_ALL});
+    try {
+      // Note that agent.send() method is synchronized
+      logger.debug(
+          "sending PCF agent request to query queuemanager {}", context.getAgentQueueManagerName());
+      long startTime = System.currentTimeMillis();
+      PCFMessage[] responses = context.send(request);
+      long endTime = System.currentTimeMillis() - startTime;
+      logger.debug(
+          "PCF agent queuemanager metrics query response for {} received in {} milliseconds",
+          context.getAgentQueueManagerName(),
+          endTime);
+      if (responses == null || responses.length <= 0) {
+        logger.debug("Unexpected Error while PCFMessage.send(), response is either null or empty");
+        return;
+      }
+      List<Metric> responseMetrics = Lists.newArrayList();
+      context.forEachMetric(
+          (metricKey, wmqOverride) -> {
+            int metricVal = responses[0].getIntParameterValue(wmqOverride.getConstantValue());
+            if (logger.isDebugEnabled()) {
+              logger.debug("Metric: {}={}", metricKey, metricVal);
+            }
+            Metric metric =
+                metricCreator.createMetric(metricKey, metricVal, wmqOverride, metricKey);
+            responseMetrics.add(metric);
+          });
+      context.transformAndPrintMetrics(responseMetrics);
+    } catch (Exception e) {
+      logger.error(e.getMessage());
+      throw new TaskExecutionException(e);
+    } finally {
+      long exitTime = System.currentTimeMillis() - entryTime;
+      logger.debug("Time taken to publish metrics for queuemanager is {} milliseconds", exitTime);
     }
-
-	@Override
-	public void publishMetrics() throws TaskExecutionException {
-		long entryTime = System.currentTimeMillis();
-		logger.debug("publishMetrics entry time for queuemanager {} is {} milliseconds",
-				context.getAgentQueueManagerName(), entryTime);
-		// CMQCFC.MQCMD_INQUIRE_Q_MGR_STATUS is 161
-		PCFMessage request = new PCFMessage(CMQCFC.MQCMD_INQUIRE_Q_MGR_STATUS);
-		// CMQCFC.MQIACF_Q_MGR_STATUS_ATTRS is 1229
-		request.addParameter(CMQCFC.MQIACF_Q_MGR_STATUS_ATTRS, new int[] { CMQCFC.MQIACF_ALL });
-		try {
-			// Note that agent.send() method is synchronized
-			logger.debug("sending PCF agent request to query queuemanager {}", context.getAgentQueueManagerName());
-			long startTime = System.currentTimeMillis();
-			PCFMessage[] responses = context.send(request);
-			long endTime = System.currentTimeMillis() - startTime;
-			logger.debug("PCF agent queuemanager metrics query response for {} received in {} milliseconds", context.getAgentQueueManagerName(), endTime);
-			if (responses == null || responses.length <= 0) {
-				logger.debug("Unexpected Error while PCFMessage.send(), response is either null or empty");
-				return;
-			}
-			List<Metric> responseMetrics = Lists.newArrayList();
-			context.forEachMetric((metricKey, wmqOverride) -> {
-				int metricVal = responses[0].getIntParameterValue(wmqOverride.getConstantValue());
-				if (logger.isDebugEnabled()) {
-                    logger.debug("Metric: {}={}", metricKey, metricVal);
-				}
-				Metric metric = metricCreator.createMetric(metricKey, metricVal, wmqOverride, metricKey);
-				responseMetrics.add(metric);
-			});
-			context.transformAndPrintMetrics(responseMetrics);
-		} catch (Exception e) {
-			logger.error(e.getMessage());
-			throw new TaskExecutionException(e);
-		} finally {
-			long exitTime = System.currentTimeMillis() - entryTime;
-			logger.debug("Time taken to publish metrics for queuemanager is {} milliseconds", exitTime);
-		}
-	}
+  }
 }

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/QueueMetricsCollector.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/QueueMetricsCollector.java
@@ -13,30 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.appdynamics.extensions.webspheremq.metricscollector;
-
-import com.appdynamics.extensions.MetricWriteHelper;
-import com.appdynamics.extensions.conf.MonitorContextConfiguration;
-import com.appdynamics.extensions.metrics.Metric;
-import com.appdynamics.extensions.webspheremq.config.ExcludeFilters;
-import com.appdynamics.extensions.webspheremq.config.QueueManager;
-import com.appdynamics.extensions.webspheremq.config.WMQMetricOverride;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.ibm.mq.constants.CMQC;
-import com.ibm.mq.headers.MQDataException;
-import com.ibm.mq.headers.pcf.*;
-import com.singularity.ee.agent.systemagent.api.exception.TaskExecutionException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.*;
 
 import static com.ibm.mq.constants.CMQC.MQQT_ALIAS;
 import static com.ibm.mq.constants.CMQC.MQQT_CLUSTER;
@@ -44,162 +21,215 @@ import static com.ibm.mq.constants.CMQC.MQQT_LOCAL;
 import static com.ibm.mq.constants.CMQC.MQQT_MODEL;
 import static com.ibm.mq.constants.CMQC.MQQT_REMOTE;
 
-final public class QueueMetricsCollector implements MetricsPublisher {
+import com.appdynamics.extensions.metrics.Metric;
+import com.appdynamics.extensions.webspheremq.config.ExcludeFilters;
+import com.appdynamics.extensions.webspheremq.config.WMQMetricOverride;
+import com.google.common.collect.Lists;
+import com.ibm.mq.constants.CMQC;
+import com.ibm.mq.headers.MQDataException;
+import com.ibm.mq.headers.pcf.*;
+import com.singularity.ee.agent.systemagent.api.exception.TaskExecutionException;
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-	private static final Logger logger = LoggerFactory.getLogger(QueueMetricsCollector.class);
-	public final static String ARTIFACT = "Queues";
+public final class QueueMetricsCollector implements MetricsPublisher {
 
-	// hack to share state of queue type between collectors.
-	// The queue information is only available as response of some commands.
-	private final QueueCollectorSharedState sharedState;
-	private final MetricCreator metricCreator;
-	private final Map<String, WMQMetricOverride> metrics;
-    private final JobSubmitterContext context;
+  private static final Logger logger = LoggerFactory.getLogger(QueueMetricsCollector.class);
+  public static final String ARTIFACT = "Queues";
 
-    public QueueMetricsCollector(Map<String, WMQMetricOverride> metricsToReport,
-                                 QueueCollectorSharedState sharedState,
-								 JobSubmitterContext context) {
-		this.sharedState = sharedState;
-		this.metrics = metricsToReport;
-        this.context = context;
-		this.metricCreator = context.newMetricCreator(ARTIFACT);
+  // hack to share state of queue type between collectors.
+  // The queue information is only available as response of some commands.
+  private final QueueCollectorSharedState sharedState;
+  private final MetricCreator metricCreator;
+  private final Map<String, WMQMetricOverride> metrics;
+  private final JobSubmitterContext context;
+
+  public QueueMetricsCollector(
+      Map<String, WMQMetricOverride> metricsToReport,
+      QueueCollectorSharedState sharedState,
+      JobSubmitterContext context) {
+    this.sharedState = sharedState;
+    this.metrics = metricsToReport;
+    this.context = context;
+    this.metricCreator = context.newMetricCreator(ARTIFACT);
+  }
+
+  @Override
+  public void publishMetrics() throws TaskExecutionException {
+    logger.info("Collecting queue metrics...");
+    List<Future> futures = Lists.newArrayList();
+    Map<String, WMQMetricOverride> metricsForInquireQCmd =
+        context.getMetricsForCommand(InquireQCmdCollector.COMMAND);
+    if (!metricsForInquireQCmd.isEmpty()) {
+      MetricsCollectorContext collectorContext = context.newCollectorContext(metricsForInquireQCmd);
+      QueueCollectionBuddy queueBuddy =
+          new QueueCollectionBuddy(
+              collectorContext, sharedState, metricCreator, InquireQCmdCollector.COMMAND);
+      MetricsPublisher publisher = new InquireQCmdCollector(collectorContext, queueBuddy);
+      futures.add(context.submitPublishJob("InquireQCmdCollector", publisher));
     }
+    Map<String, WMQMetricOverride> metricsForInquireQStatusCmd =
+        context.getMetricsForCommand(InquireQStatusCmdCollector.COMMAND);
+    if (!metricsForInquireQStatusCmd.isEmpty()) {
+      MetricsCollectorContext collectorContext =
+          context.newCollectorContext(metricsForInquireQStatusCmd);
+      QueueCollectionBuddy queueBuddy =
+          new QueueCollectionBuddy(
+              collectorContext, sharedState, metricCreator, InquireQStatusCmdCollector.COMMAND);
+      MetricsPublisher publisher = new InquireQStatusCmdCollector(collectorContext, queueBuddy);
+      futures.add(context.submitPublishJob("InquireQStatusCmdCollector", publisher));
+    }
+    Map<String, WMQMetricOverride> metricsForResetQStatsCmd =
+        context.getMetricsForCommand(ResetQStatsCmdCollector.COMMAND);
+    if (!metricsForResetQStatsCmd.isEmpty()) {
+      MetricsCollectorContext collectorContext =
+          context.newCollectorContext(metricsForResetQStatsCmd);
+      QueueCollectionBuddy queueBuddy =
+          new QueueCollectionBuddy(
+              collectorContext, sharedState, metricCreator, ResetQStatsCmdCollector.COMMAND);
+      MetricsPublisher collector = new ResetQStatsCmdCollector(collectorContext, queueBuddy);
+      futures.add(context.submitPublishJob("ResetQStatsCmdCollector", collector));
+    }
+    for (Future<?> future : futures) {
+      try {
+        int timeout = context.getConfigInt("queueMetricsCollectionTimeoutInSeconds", 20);
+        future.get(timeout, TimeUnit.SECONDS);
+      } catch (InterruptedException e) {
+        logger.error("The thread was interrupted ", e);
+      } catch (ExecutionException e) {
+        logger.error("Something unforeseen has happened ", e);
+      } catch (TimeoutException e) {
+        logger.error("Thread timed out ", e);
+      }
+    }
+  }
 
-	@Override
-	public void publishMetrics() throws TaskExecutionException {
-		logger.info("Collecting queue metrics...");
-		List<Future> futures = Lists.newArrayList();
-		Map<String, WMQMetricOverride>  metricsForInquireQCmd = context.getMetricsForCommand(InquireQCmdCollector.COMMAND);
-		if(!metricsForInquireQCmd.isEmpty()){
-			MetricsCollectorContext collectorContext = context.newCollectorContext(metricsForInquireQCmd);
-			QueueCollectionBuddy queueBuddy = new QueueCollectionBuddy(collectorContext, sharedState, metricCreator, InquireQCmdCollector.COMMAND);
-			MetricsPublisher publisher = new InquireQCmdCollector(collectorContext, queueBuddy);
-			futures.add(context.submitPublishJob("InquireQCmdCollector", publisher));
-		}
-		Map<String, WMQMetricOverride>  metricsForInquireQStatusCmd = context.getMetricsForCommand(InquireQStatusCmdCollector.COMMAND);
-		if(!metricsForInquireQStatusCmd.isEmpty()){
-			MetricsCollectorContext collectorContext = context.newCollectorContext(metricsForInquireQStatusCmd);
-			QueueCollectionBuddy queueBuddy = new QueueCollectionBuddy(collectorContext, sharedState, metricCreator, InquireQStatusCmdCollector.COMMAND);
-			MetricsPublisher publisher = new InquireQStatusCmdCollector(collectorContext, queueBuddy);
-			futures.add(context.submitPublishJob("InquireQStatusCmdCollector", publisher));
-		}
-		Map<String, WMQMetricOverride>  metricsForResetQStatsCmd = context.getMetricsForCommand(ResetQStatsCmdCollector.COMMAND);
-		if(!metricsForResetQStatsCmd.isEmpty()){
-			MetricsCollectorContext collectorContext = context.newCollectorContext(metricsForResetQStatsCmd);
-			QueueCollectionBuddy queueBuddy = new QueueCollectionBuddy(collectorContext, sharedState, metricCreator, ResetQStatsCmdCollector.COMMAND);
-			MetricsPublisher collector = new ResetQStatsCmdCollector(collectorContext, queueBuddy);
-			futures.add(context.submitPublishJob("ResetQStatsCmdCollector", collector));
-		}
-		for(Future<?> future: futures){
-			try {
-				int timeout = context.getConfigInt("queueMetricsCollectionTimeoutInSeconds", 20);
-				future.get(timeout, TimeUnit.SECONDS);
-			} catch (InterruptedException e) {
-				logger.error("The thread was interrupted ",e);
-			} catch (ExecutionException e) {
-				logger.error("Something unforeseen has happened ",e);
-			} catch (TimeoutException e) {
-				logger.error("Thread timed out ",e);
-			}
-		}
-	}
+  protected void processPCFRequestAndPublishQMetrics(
+      MetricsCollectorContext context, String queueGenericName, PCFMessage request, String command)
+      throws IOException, MQDataException {
+    logger.debug(
+        "sending PCF agent request to query metrics for generic queue {} for command {}",
+        queueGenericName,
+        command);
+    long startTime = System.currentTimeMillis();
+    PCFMessage[] response = context.send(request);
+    long endTime = System.currentTimeMillis() - startTime;
+    logger.debug(
+        "PCF agent queue metrics query response for generic queue {} for command {} received in {} milliseconds",
+        queueGenericName,
+        command,
+        endTime);
+    if (response == null || response.length <= 0) {
+      logger.debug(
+          "Unexpected Error while PCFMessage.send() for command {}, response is either null or empty",
+          command);
+      return;
+    }
+    for (int i = 0; i < response.length; i++) {
+      String queueName = response[i].getStringParameterValue(CMQC.MQCA_Q_NAME).trim();
+      String queueType;
+      if (response[i].getParameterValue(CMQC.MQIA_Q_TYPE) == null) {
+        queueType = sharedState.getType(queueName);
+        if (queueType == null) {
+          continue;
+        }
+      } else {
+        switch (response[i].getIntParameterValue(CMQC.MQIA_Q_TYPE)) {
+          case MQQT_LOCAL:
+            queueType = "local";
+            break;
+          case MQQT_ALIAS:
+            queueType = "alias";
+            break;
+          case MQQT_REMOTE:
+            queueType = "remote";
+            break;
+          case MQQT_CLUSTER:
+            queueType = "cluster";
+            break;
+          case MQQT_MODEL:
+            queueType = "model";
+            break;
+          default:
+            logger.warn(
+                "Unknown type of queue {}", response[i].getIntParameterValue(CMQC.MQIA_Q_TYPE));
+            queueType = "unknown";
+            break;
+        }
+        if (response[i].getParameter(CMQC.MQIA_USAGE) != null) {
+          switch (response[i].getIntParameterValue(CMQC.MQIA_USAGE)) {
+            case CMQC.MQUS_NORMAL:
+              queueType += "-normal";
+              break;
+            case CMQC.MQUS_TRANSMISSION:
+              queueType += "-transmission";
+              break;
+          }
+        }
+        sharedState.putQueueType(queueName, queueType);
+      }
 
-	protected void processPCFRequestAndPublishQMetrics(MetricsCollectorContext context, String queueGenericName, PCFMessage request, String command) throws IOException, MQDataException {
-		logger.debug("sending PCF agent request to query metrics for generic queue {} for command {}",queueGenericName,command);
-		long startTime = System.currentTimeMillis();
-		PCFMessage[] response = context.send(request);
-		long endTime = System.currentTimeMillis() - startTime;
-		logger.debug("PCF agent queue metrics query response for generic queue {} for command {} received in {} milliseconds", queueGenericName, command,endTime);
-		if (response == null || response.length <= 0) {
-			logger.debug("Unexpected Error while PCFMessage.send() for command {}, response is either null or empty",command);
-			return;
-		}
-		for (int i = 0; i < response.length; i++) {
-			String queueName = response[i].getStringParameterValue(CMQC.MQCA_Q_NAME).trim();
-			String queueType;
-			if (response[i].getParameterValue(CMQC.MQIA_Q_TYPE) == null) {
-				queueType = sharedState.getType(queueName);
-				if (queueType == null) {
-					continue;
-				}
-			} else {
-				switch(response[i].getIntParameterValue(CMQC.MQIA_Q_TYPE)) {
-					case MQQT_LOCAL:
-						queueType = "local";
-						break;
-					case MQQT_ALIAS:
-						queueType = "alias";
-						break;
-					case MQQT_REMOTE:
-						queueType = "remote";
-						break;
-					case MQQT_CLUSTER:
-						queueType = "cluster";
-						break;
-					case MQQT_MODEL:
-						queueType = "model";
-						break;
-					default:
-						logger.warn("Unknown type of queue {}", response[i].getIntParameterValue(CMQC.MQIA_Q_TYPE));
-						queueType = "unknown";
-						break;
-				}
-				if (response[i].getParameter(CMQC.MQIA_USAGE) != null) {
-					switch(response[i].getIntParameterValue(CMQC.MQIA_USAGE)) {
-						case CMQC.MQUS_NORMAL:
-							queueType += "-normal";
-							break;
-						case CMQC.MQUS_TRANSMISSION:
-							queueType += "-transmission";
-							break;
-					}
-				}
-				sharedState.putQueueType(queueName, queueType);
-			}
-
-			Set<ExcludeFilters> excludeFilters = context.getQueueExcludeFilters();
-			if(!ExcludeFilters.isExcluded(queueName,excludeFilters)) { //check for exclude filters
-				logger.debug("Pulling out metrics for queue name {} for command {}",queueName,command);
-				Iterator<String> itr = metrics.keySet().iterator();
-				List<Metric> responseMetrics = Lists.newArrayList();
-				while (itr.hasNext()) {
-					String metrickey = itr.next();
-					WMQMetricOverride wmqOverride = metrics.get(metrickey);
-					try{
-						PCFParameter pcfParam = response[i].getParameter(wmqOverride.getConstantValue());
-						if (pcfParam != null) {
-							if(pcfParam instanceof MQCFIN){
-								int metricVal = response[i].getIntParameterValue(wmqOverride.getConstantValue());
-								Metric metric = metricCreator.createMetric(metrickey, metricVal, wmqOverride, queueName, queueType, metrickey);
-								responseMetrics.add(metric);
-							}
-							else if(pcfParam instanceof MQCFIL){
-								int[] metricVals = response[i].getIntListParameterValue(wmqOverride.getConstantValue());
-								if(metricVals != null){
-									int count=0;
-									for(int val : metricVals){
-										count++;
-										Metric metric = metricCreator.createMetric( metrickey + "_" + count,
-												val, wmqOverride, queueName,
-												metrickey + "_" + count);
-										responseMetrics.add(metric);
-									}
-								}
-							}
-						} else {
-							logger.warn("PCF parameter is null in response for Queue: {} for metric: {} in command {}", queueName, wmqOverride.getIbmCommand(),command);
-						}
-					}
-					catch (PCFException pcfe) {
-						logger.error("PCFException caught while collecting metric for Queue: {} for metric: {} in command {}",queueName, wmqOverride.getIbmCommand(),command, pcfe);
-					}
-
-				}
-				context.transformAndPrintMetrics(responseMetrics);
-			}
-			else{
-				logger.debug("Queue name {} is excluded.",queueName);
-			}
-		}
-	}
+      Set<ExcludeFilters> excludeFilters = context.getQueueExcludeFilters();
+      if (!ExcludeFilters.isExcluded(queueName, excludeFilters)) { // check for exclude filters
+        logger.debug("Pulling out metrics for queue name {} for command {}", queueName, command);
+        Iterator<String> itr = metrics.keySet().iterator();
+        List<Metric> responseMetrics = Lists.newArrayList();
+        while (itr.hasNext()) {
+          String metrickey = itr.next();
+          WMQMetricOverride wmqOverride = metrics.get(metrickey);
+          try {
+            PCFParameter pcfParam = response[i].getParameter(wmqOverride.getConstantValue());
+            if (pcfParam != null) {
+              if (pcfParam instanceof MQCFIN) {
+                int metricVal = response[i].getIntParameterValue(wmqOverride.getConstantValue());
+                Metric metric =
+                    metricCreator.createMetric(
+                        metrickey, metricVal, wmqOverride, queueName, queueType, metrickey);
+                responseMetrics.add(metric);
+              } else if (pcfParam instanceof MQCFIL) {
+                int[] metricVals =
+                    response[i].getIntListParameterValue(wmqOverride.getConstantValue());
+                if (metricVals != null) {
+                  int count = 0;
+                  for (int val : metricVals) {
+                    count++;
+                    Metric metric =
+                        metricCreator.createMetric(
+                            metrickey + "_" + count,
+                            val,
+                            wmqOverride,
+                            queueName,
+                            metrickey + "_" + count);
+                    responseMetrics.add(metric);
+                  }
+                }
+              }
+            } else {
+              logger.warn(
+                  "PCF parameter is null in response for Queue: {} for metric: {} in command {}",
+                  queueName,
+                  wmqOverride.getIbmCommand(),
+                  command);
+            }
+          } catch (PCFException pcfe) {
+            logger.error(
+                "PCFException caught while collecting metric for Queue: {} for metric: {} in command {}",
+                queueName,
+                wmqOverride.getIbmCommand(),
+                command,
+                pcfe);
+          }
+        }
+        context.transformAndPrintMetrics(responseMetrics);
+      } else {
+        logger.debug("Queue name {} is excluded.", queueName);
+      }
+    }
+  }
 }

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/ReadConfigurationEventQueueCollector.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/ReadConfigurationEventQueueCollector.java
@@ -13,14 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.appdynamics.extensions.webspheremq.metricscollector;
 
 import com.appdynamics.extensions.MetricWriteHelper;
 import com.appdynamics.extensions.conf.MonitorContextConfiguration;
 import com.appdynamics.extensions.logging.ExtensionsLoggerFactory;
 import com.appdynamics.extensions.metrics.Metric;
-import com.appdynamics.extensions.webspheremq.common.WMQUtil;
 import com.appdynamics.extensions.webspheremq.config.QueueManager;
 import com.appdynamics.extensions.webspheremq.config.WMQMetricOverride;
 import com.google.common.collect.Lists;
@@ -32,144 +30,165 @@ import com.ibm.mq.MQQueueManager;
 import com.ibm.mq.constants.CMQC;
 import com.ibm.mq.constants.CMQCFC;
 import com.ibm.mq.constants.MQConstants;
-import com.ibm.mq.headers.pcf.MQCFH;
 import com.ibm.mq.headers.pcf.PCFMessage;
 import com.ibm.mq.headers.pcf.PCFMessageAgent;
 import com.singularity.ee.agent.systemagent.api.exception.TaskExecutionException;
-import org.slf4j.Logger;
-
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CountDownLatch;
+import org.slf4j.Logger;
 
-final public class ReadConfigurationEventQueueCollector implements MetricsPublisher {
+public final class ReadConfigurationEventQueueCollector implements MetricsPublisher {
 
-	private static final Logger logger = ExtensionsLoggerFactory.getLogger(ReadConfigurationEventQueueCollector.class);
-	private final MetricWriteHelper metricWriteHelper;
-	private final QueueManager queueManager;
-	private final PCFMessageAgent agent;
-	private final MonitorContextConfiguration monitorContextConfig;
-	private final MQQueueManager mqQueueManager;
-	private final Map<String, WMQMetricOverride> metricsToReport;
-	private final long bootTime;
-    private final MetricCreator metricCreator;
+  private static final Logger logger =
+      ExtensionsLoggerFactory.getLogger(ReadConfigurationEventQueueCollector.class);
+  private final MetricWriteHelper metricWriteHelper;
+  private final QueueManager queueManager;
+  private final PCFMessageAgent agent;
+  private final MonitorContextConfiguration monitorContextConfig;
+  private final MQQueueManager mqQueueManager;
+  private final Map<String, WMQMetricOverride> metricsToReport;
+  private final long bootTime;
+  private final MetricCreator metricCreator;
 
-    public ReadConfigurationEventQueueCollector(Map<String, WMQMetricOverride> metricsToReport, MonitorContextConfiguration monitorContextConfig, PCFMessageAgent agent, MQQueueManager mqQueueManager, QueueManager queueManager, MetricWriteHelper metricWriteHelper, MetricCreator metricCreator) {
-		this.metricsToReport = metricsToReport;
-		this.monitorContextConfig = monitorContextConfig;
-		this.agent = agent;
-		this.mqQueueManager = mqQueueManager;
-		this.queueManager = queueManager;
-		this.metricWriteHelper = metricWriteHelper;
-		this.bootTime = System.currentTimeMillis();
-        this.metricCreator = metricCreator;
-	}
+  public ReadConfigurationEventQueueCollector(
+      Map<String, WMQMetricOverride> metricsToReport,
+      MonitorContextConfiguration monitorContextConfig,
+      PCFMessageAgent agent,
+      MQQueueManager mqQueueManager,
+      QueueManager queueManager,
+      MetricWriteHelper metricWriteHelper,
+      MetricCreator metricCreator) {
+    this.metricsToReport = metricsToReport;
+    this.monitorContextConfig = monitorContextConfig;
+    this.agent = agent;
+    this.mqQueueManager = mqQueueManager;
+    this.queueManager = queueManager;
+    this.metricWriteHelper = metricWriteHelper;
+    this.bootTime = System.currentTimeMillis();
+    this.metricCreator = metricCreator;
+  }
 
-	private PCFMessage findLastUpdate(long entryTime, String configurationQueueName) throws Exception {
-		// find the last update:
-		PCFMessage candidate = null;
+  private PCFMessage findLastUpdate(long entryTime, String configurationQueueName)
+      throws Exception {
+    // find the last update:
+    PCFMessage candidate = null;
 
-		boolean consumeEvents = this.queueManager.getConsumeConfigurationEventInterval() > 0 && (entryTime-this.bootTime) % this.queueManager.getConsumeConfigurationEventInterval() == 0;
+    boolean consumeEvents =
+        this.queueManager.getConsumeConfigurationEventInterval() > 0
+            && (entryTime - this.bootTime)
+                    % this.queueManager.getConsumeConfigurationEventInterval()
+                == 0;
 
-		MQQueue queue = null;
-		try {
-			int queueAccessOptions = MQConstants.MQOO_FAIL_IF_QUIESCING | MQConstants.MQOO_INPUT_SHARED;
-			if (!consumeEvents) {
-				// we are not consuming the events.
-				queueAccessOptions |= MQConstants.MQOO_BROWSE;
-			}
-			queue = mqQueueManager.accessQueue(configurationQueueName, queueAccessOptions);
-			int maxSequenceNumber = 0;
-            // keep going until receiving the exception MQConstants.MQRC_NO_MSG_AVAILABLE
-			while (true) {
-				try {
-					MQGetMessageOptions getOptions = new MQGetMessageOptions();
-					getOptions.options = MQConstants.MQGMO_NO_WAIT | MQConstants.MQGMO_FAIL_IF_QUIESCING;
-					if (!consumeEvents) {
-						getOptions.options |= MQConstants.MQGMO_BROWSE_NEXT;
-					}
-					MQMessage message = new MQMessage();
+    MQQueue queue = null;
+    try {
+      int queueAccessOptions = MQConstants.MQOO_FAIL_IF_QUIESCING | MQConstants.MQOO_INPUT_SHARED;
+      if (!consumeEvents) {
+        // we are not consuming the events.
+        queueAccessOptions |= MQConstants.MQOO_BROWSE;
+      }
+      queue = mqQueueManager.accessQueue(configurationQueueName, queueAccessOptions);
+      int maxSequenceNumber = 0;
+      // keep going until receiving the exception MQConstants.MQRC_NO_MSG_AVAILABLE
+      while (true) {
+        try {
+          MQGetMessageOptions getOptions = new MQGetMessageOptions();
+          getOptions.options = MQConstants.MQGMO_NO_WAIT | MQConstants.MQGMO_FAIL_IF_QUIESCING;
+          if (!consumeEvents) {
+            getOptions.options |= MQConstants.MQGMO_BROWSE_NEXT;
+          }
+          MQMessage message = new MQMessage();
 
-					queue.get(message, getOptions);
-					PCFMessage received = new PCFMessage(message);
-					if (received.getMsgSeqNumber() > maxSequenceNumber) {
-						maxSequenceNumber = received.getMsgSeqNumber();
-						candidate = received;
-					}
+          queue.get(message, getOptions);
+          PCFMessage received = new PCFMessage(message);
+          if (received.getMsgSeqNumber() > maxSequenceNumber) {
+            maxSequenceNumber = received.getMsgSeqNumber();
+            candidate = received;
+          }
 
-				} catch (MQException e) {
-					if (e.reasonCode != MQConstants.MQRC_NO_MSG_AVAILABLE) {
-						logger.error(e.getMessage(), e);
-					}
-					break;
-				} catch (IOException e) {
-					logger.error(e.getMessage(), e);
-					break;
-				}
-			}
-		} finally {
-			if (queue != null) {
-				queue.close();
-			}
-		}
-		return candidate;
-	}
+        } catch (MQException e) {
+          if (e.reasonCode != MQConstants.MQRC_NO_MSG_AVAILABLE) {
+            logger.error(e.getMessage(), e);
+          }
+          break;
+        } catch (IOException e) {
+          logger.error(e.getMessage(), e);
+          break;
+        }
+      }
+    } finally {
+      if (queue != null) {
+        queue.close();
+      }
+    }
+    return candidate;
+  }
 
-    @Override
-	public void publishMetrics() throws TaskExecutionException {
-		long entryTime = System.currentTimeMillis();
-		String configurationQueueName = this.queueManager.getConfigurationQueueName();
-		logger.info("sending PCF agent request to read configuration events from queue {}", configurationQueueName);
-		try {
+  @Override
+  public void publishMetrics() throws TaskExecutionException {
+    long entryTime = System.currentTimeMillis();
+    String configurationQueueName = this.queueManager.getConfigurationQueueName();
+    logger.info(
+        "sending PCF agent request to read configuration events from queue {}",
+        configurationQueueName);
+    try {
 
-			PCFMessage candidate = findLastUpdate(entryTime, configurationQueueName);
+      PCFMessage candidate = findLastUpdate(entryTime, configurationQueueName);
 
-			if (candidate == null) {
-				if (queueManager.isRefreshQueueManagerConfigurationEnabled()) {
-					// no event found.
-					// we issue a refresh request, which will generate a configuration event on the configuration event queue.
-					// note this may incur a performance cost to the queue manager.
-					PCFMessage request = new PCFMessage(CMQCFC.MQCMD_REFRESH_Q_MGR);
-					request.addParameter(CMQCFC.MQIACF_REFRESH_TYPE, CMQCFC.MQRT_CONFIGURATION);
-					request.addParameter(CMQCFC.MQIACF_OBJECT_TYPE, CMQC.MQOT_Q_MGR);
-					agent.send(request);
-					// try again:
-					candidate = findLastUpdate(entryTime, configurationQueueName);
-				}
-			}
+      if (candidate == null) {
+        if (queueManager.isRefreshQueueManagerConfigurationEnabled()) {
+          // no event found.
+          // we issue a refresh request, which will generate a configuration event on the
+          // configuration event queue.
+          // note this may incur a performance cost to the queue manager.
+          PCFMessage request = new PCFMessage(CMQCFC.MQCMD_REFRESH_Q_MGR);
+          request.addParameter(CMQCFC.MQIACF_REFRESH_TYPE, CMQCFC.MQRT_CONFIGURATION);
+          request.addParameter(CMQCFC.MQIACF_OBJECT_TYPE, CMQC.MQOT_Q_MGR);
+          agent.send(request);
+          // try again:
+          candidate = findLastUpdate(entryTime, configurationQueueName);
+        }
+      }
 
-			if (candidate != null) {
-				List<Metric> metrics = Lists.newArrayList();
-				Iterator<String> overrideItr = metricsToReport.keySet().iterator();
-				while (overrideItr.hasNext()) {
-					String metrickey = overrideItr.next();
-					WMQMetricOverride wmqOverride = metricsToReport.get(metrickey);
-					if (candidate.getParameter(wmqOverride.getConstantValue()) != null) {
-						int metricValue = candidate.getIntParameterValue(wmqOverride.getConstantValue());
-						Metric m = metricCreator.createMetric(metrickey, metricValue, wmqOverride, metrickey);
-						metrics.add(m);
-					}
-				}
-				this.metricWriteHelper.transformAndPrintMetrics(metrics);
-			}
+      if (candidate != null) {
+        List<Metric> metrics = Lists.newArrayList();
+        Iterator<String> overrideItr = metricsToReport.keySet().iterator();
+        while (overrideItr.hasNext()) {
+          String metrickey = overrideItr.next();
+          WMQMetricOverride wmqOverride = metricsToReport.get(metrickey);
+          if (candidate.getParameter(wmqOverride.getConstantValue()) != null) {
+            int metricValue = candidate.getIntParameterValue(wmqOverride.getConstantValue());
+            Metric m = metricCreator.createMetric(metrickey, metricValue, wmqOverride, metrickey);
+            metrics.add(m);
+          }
+        }
+        this.metricWriteHelper.transformAndPrintMetrics(metrics);
+      }
 
-		} catch (Exception e) {
-			logger.error("Unexpected Error occurred while collecting configuration events for queue " + configurationQueueName, e);
-		}
-		long exitTime = System.currentTimeMillis() - entryTime;
-		logger.debug("Time taken to publish metrics for configuration events is {} milliseconds", exitTime);
-	}
+    } catch (Exception e) {
+      logger.error(
+          "Unexpected Error occurred while collecting configuration events for queue "
+              + configurationQueueName,
+          e);
+    }
+    long exitTime = System.currentTimeMillis() - entryTime;
+    logger.debug(
+        "Time taken to publish metrics for configuration events is {} milliseconds", exitTime);
+  }
 
-	private String getMetricsName(String qmNameToBeDisplayed, String... pathelements) {
-		StringBuilder pathBuilder = new StringBuilder(monitorContextConfig.getMetricPrefix()).append("|").append(qmNameToBeDisplayed).append("|");
-		for (int i = 0; i < pathelements.length; i++) {
-			pathBuilder.append(pathelements[i]);
-			if (i != pathelements.length - 1) {
-				pathBuilder.append("|");
-			}
-		}
-		return pathBuilder.toString();
-	}
+  private String getMetricsName(String qmNameToBeDisplayed, String... pathelements) {
+    StringBuilder pathBuilder =
+        new StringBuilder(monitorContextConfig.getMetricPrefix())
+            .append("|")
+            .append(qmNameToBeDisplayed)
+            .append("|");
+    for (int i = 0; i < pathelements.length; i++) {
+      pathBuilder.append(pathelements[i]);
+      if (i != pathelements.length - 1) {
+        pathBuilder.append("|");
+      }
+    }
+    return pathBuilder.toString();
+  }
 }

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/ResetQStatsCmdCollector.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/ResetQStatsCmdCollector.java
@@ -13,58 +13,63 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.appdynamics.extensions.webspheremq.metricscollector;
-
 
 import com.ibm.mq.constants.CMQC;
 import com.ibm.mq.constants.CMQCFC;
-import com.ibm.mq.headers.pcf.PCFException;
 import com.ibm.mq.headers.pcf.PCFMessage;
 import com.singularity.ee.agent.systemagent.api.exception.TaskExecutionException;
+import java.util.Arrays;
+import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Arrays;
-import java.util.Set;
-
 final class ResetQStatsCmdCollector implements MetricsPublisher {
 
-    private static final Logger logger = LoggerFactory.getLogger(ResetQStatsCmdCollector.class);
+  private static final Logger logger = LoggerFactory.getLogger(ResetQStatsCmdCollector.class);
 
-    static final String COMMAND = "MQCMD_RESET_Q_STATS";
-    private final MetricsCollectorContext context;
-    private final QueueCollectionBuddy queueBuddy;
+  static final String COMMAND = "MQCMD_RESET_Q_STATS";
+  private final MetricsCollectorContext context;
+  private final QueueCollectionBuddy queueBuddy;
 
-    ResetQStatsCmdCollector(MetricsCollectorContext context, QueueCollectionBuddy queueBuddy) {
-        this.context = context;
-        this.queueBuddy = queueBuddy;
+  ResetQStatsCmdCollector(MetricsCollectorContext context, QueueCollectionBuddy queueBuddy) {
+    this.context = context;
+    this.queueBuddy = queueBuddy;
+  }
+
+  @Override
+  public void publishMetrics() throws TaskExecutionException {
+    logger.info("Collecting metrics for command {}", COMMAND);
+    /*
+     * attrs = { CMQC.MQCA_Q_NAME, MQIA_HIGH_Q_DEPTH,MQIA_MSG_DEQ_COUNT, MQIA_MSG_ENQ_COUNT };
+     */
+    long entryTime = System.currentTimeMillis();
+
+    if (context.hasNoMetricsToReport()) {
+      logger.debug(
+          "Queue metrics to report from the config is null or empty, nothing to publish for command {}",
+          COMMAND);
+      return;
     }
 
-    @Override
-    public void publishMetrics() throws TaskExecutionException {
-        logger.info("Collecting metrics for command {}",COMMAND);
-		/*
-		 * attrs = { CMQC.MQCA_Q_NAME, MQIA_HIGH_Q_DEPTH,MQIA_MSG_DEQ_COUNT, MQIA_MSG_ENQ_COUNT };
-		 */
-        long entryTime = System.currentTimeMillis();
+    int[] attrs = context.buildIntAttributesArray(CMQC.MQCA_Q_NAME);
+    logger.debug(
+        "Attributes being sent along PCF agent request to query queue metrics: {} for command {}",
+        Arrays.toString(attrs),
+        COMMAND);
 
-        if (context.hasNoMetricsToReport()) {
-            logger.debug("Queue metrics to report from the config is null or empty, nothing to publish for command {}",COMMAND);
-            return;
-        }
-
-        int[] attrs = context.buildIntAttributesArray(CMQC.MQCA_Q_NAME);
-        logger.debug("Attributes being sent along PCF agent request to query queue metrics: {} for command {}", Arrays.toString(attrs),COMMAND);
-
-        Set<String> queueGenericNames = context.getQueueIncludeFilterNames();
-        for(String queueGenericName : queueGenericNames){
-            // list of all metrics extracted through MQCMD_RESET_Q_STATS is mentioned here https://www.ibm.com/support/knowledgecenter/SSFKSJ_8.0.0/com.ibm.mq.ref.adm.doc/q088310_.htm
-            PCFMessage request = new PCFMessage(CMQCFC.MQCMD_RESET_Q_STATS);
-            request.addParameter(CMQC.MQCA_Q_NAME, queueGenericName);
-            queueBuddy.processPCFRequestAndPublishQMetrics(request, queueGenericName);
-        }
-        long exitTime = System.currentTimeMillis() - entryTime;
-        logger.debug("Time taken to publish metrics for all queues is {} milliseconds for command {}", exitTime,COMMAND);
+    Set<String> queueGenericNames = context.getQueueIncludeFilterNames();
+    for (String queueGenericName : queueGenericNames) {
+      // list of all metrics extracted through MQCMD_RESET_Q_STATS is mentioned here
+      // https://www.ibm.com/support/knowledgecenter/SSFKSJ_8.0.0/com.ibm.mq.ref.adm.doc/q088310_.htm
+      PCFMessage request = new PCFMessage(CMQCFC.MQCMD_RESET_Q_STATS);
+      request.addParameter(CMQC.MQCA_Q_NAME, queueGenericName);
+      queueBuddy.processPCFRequestAndPublishQMetrics(request, queueGenericName);
     }
+    long exitTime = System.currentTimeMillis() - entryTime;
+    logger.debug(
+        "Time taken to publish metrics for all queues is {} milliseconds for command {}",
+        exitTime,
+        COMMAND);
+  }
 }

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/TopicMetricsCollector.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/TopicMetricsCollector.java
@@ -13,58 +13,56 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.appdynamics.extensions.webspheremq.metricscollector;
 
 import com.appdynamics.extensions.webspheremq.config.WMQMetricOverride;
 import com.google.common.collect.Lists;
 import com.singularity.ee.agent.systemagent.api.exception.TaskExecutionException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import static java.util.Collections.emptyMap;
+public final class TopicMetricsCollector implements MetricsPublisher {
+  private static final Logger logger = LoggerFactory.getLogger(TopicMetricsCollector.class);
+  private final JobSubmitterContext context;
 
-final public class TopicMetricsCollector implements MetricsPublisher {
-    private static final Logger logger = LoggerFactory.getLogger(TopicMetricsCollector.class);
-        private final JobSubmitterContext context;
+  public TopicMetricsCollector(JobSubmitterContext context) {
+    this.context = context;
+  }
 
-    public TopicMetricsCollector(JobSubmitterContext context) {
-        this.context = context;
+  @Override
+  public void publishMetrics() throws TaskExecutionException {
+    logger.info("Collecting Topic metrics...");
+    List<Future<?>> futures = Lists.newArrayList();
+
+    //  to query the current status of topics, which is essential for monitoring and managing the
+    // publish/subscribe environment in IBM MQ.
+    Map<String, WMQMetricOverride> metricsForInquireTStatusCmd =
+        context.getMetricsForCommand(InquireTStatusCmdCollector.COMMAND);
+    if (!metricsForInquireTStatusCmd.isEmpty()) {
+      MetricCreator metricCreator = context.newMetricCreator(InquireTStatusCmdCollector.ARTIFACT);
+      MetricsCollectorContext collectorContext =
+          context.newCollectorContext(metricsForInquireTStatusCmd);
+      InquireTStatusCmdCollector metricsPublisher =
+          new InquireTStatusCmdCollector(collectorContext, metricCreator);
+      futures.add(context.submitPublishJob("Topic Status Cmd Collector", metricsPublisher));
     }
-
-    @Override
-    public void publishMetrics() throws TaskExecutionException {
-        logger.info("Collecting Topic metrics...");
-        List<Future<?>> futures = Lists.newArrayList();
-
-        //  to query the current status of topics, which is essential for monitoring and managing the publish/subscribe environment in IBM MQ.
-        Map<String, WMQMetricOverride> metricsForInquireTStatusCmd = context.getMetricsForCommand(InquireTStatusCmdCollector.COMMAND);
-        if (!metricsForInquireTStatusCmd.isEmpty()) {
-            MetricCreator metricCreator = context.newMetricCreator(InquireTStatusCmdCollector.ARTIFACT);
-            MetricsCollectorContext collectorContext = context.newCollectorContext(metricsForInquireTStatusCmd);
-            InquireTStatusCmdCollector metricsPublisher = new InquireTStatusCmdCollector(collectorContext, metricCreator);
-            futures.add(context.submitPublishJob("Topic Status Cmd Collector", metricsPublisher));
-        }
-        for (Future<?> future : futures) {
-            try {
-                int timeout = context.getConfigInt("topicMetricsCollectionTimeoutInSeconds", 20);
-                future.get(timeout, TimeUnit.SECONDS);
-            } catch (InterruptedException e) {
-                logger.error("The thread was interrupted ", e);
-            } catch (ExecutionException e) {
-                logger.error("Something unforeseen has happened ", e);
-            } catch (TimeoutException e) {
-                logger.error("Thread timed out ", e);
-            }
-        }
+    for (Future<?> future : futures) {
+      try {
+        int timeout = context.getConfigInt("topicMetricsCollectionTimeoutInSeconds", 20);
+        future.get(timeout, TimeUnit.SECONDS);
+      } catch (InterruptedException e) {
+        logger.error("The thread was interrupted ", e);
+      } catch (ExecutionException e) {
+        logger.error("Something unforeseen has happened ", e);
+      } catch (TimeoutException e) {
+        logger.error("Thread timed out ", e);
+      }
     }
+  }
 }

--- a/src/test/java/com/appdynamics/extensions/opentelemetry/ConfigTest.java
+++ b/src/test/java/com/appdynamics/extensions/opentelemetry/ConfigTest.java
@@ -15,50 +15,57 @@
  */
 package com.appdynamics.extensions.opentelemetry;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 class ConfigTest {
 
-    private Properties systemProperties;
+  private Properties systemProperties;
 
-    @BeforeEach
-    public void cacheSystemProperties() {
-        systemProperties = new Properties();
-        for (Map.Entry<Object, Object> entry : System.getProperties().entrySet()) {
-            systemProperties.put(entry.getKey().toString(), entry.getValue().toString());
-        }
+  @BeforeEach
+  public void cacheSystemProperties() {
+    systemProperties = new Properties();
+    for (Map.Entry<Object, Object> entry : System.getProperties().entrySet()) {
+      systemProperties.put(entry.getKey().toString(), entry.getValue().toString());
     }
+  }
 
-    @Test
-   void testSSLConnection() {
-        Config.setUpSSLConnection(new HashMap<String, Object>() {{
-            put("sslConnection", new HashMap<String, Object>() {{
-                put("keyStorePath", "foo");
-                put("trustStorePath", "bar");
-                put("keyStorePassword", "password");
-                put("trustStorePassword", "password1");
-            }});
-        }});
+  @Test
+  void testSSLConnection() {
+    Config.setUpSSLConnection(
+        new HashMap<String, Object>() {
+          {
+            put(
+                "sslConnection",
+                new HashMap<String, Object>() {
+                  {
+                    put("keyStorePath", "foo");
+                    put("trustStorePath", "bar");
+                    put("keyStorePassword", "password");
+                    put("trustStorePassword", "password1");
+                  }
+                });
+          }
+        });
 
-        assertThat(System.getProperties().get("javax.net.ssl.keyStore")).isEqualTo("foo");
-        assertThat(System.getProperties().get("javax.net.ssl.trustStorePath")).isEqualTo("bar");
-        assertThat(System.getProperties().get("javax.net.ssl.keyStorePassword")).isEqualTo("password");
-        assertThat(System.getProperties().get("javax.net.ssl.trustStorePassword")).isEqualTo("password1");
+    assertThat(System.getProperties().get("javax.net.ssl.keyStore")).isEqualTo("foo");
+    assertThat(System.getProperties().get("javax.net.ssl.trustStorePath")).isEqualTo("bar");
+    assertThat(System.getProperties().get("javax.net.ssl.keyStorePassword")).isEqualTo("password");
+    assertThat(System.getProperties().get("javax.net.ssl.trustStorePassword"))
+        .isEqualTo("password1");
+  }
+
+  @AfterEach
+  public void resetSystemProperties() {
+    System.getProperties().clear();
+    for (Map.Entry<Object, Object> entry : systemProperties.entrySet()) {
+      System.setProperty(entry.getKey().toString(), entry.getValue().toString());
     }
-
-    @AfterEach
-    public void resetSystemProperties() {
-        System.getProperties().clear();
-        for (Map.Entry<Object, Object> entry : systemProperties.entrySet()) {
-            System.setProperty(entry.getKey().toString(), entry.getValue().toString());
-        }
-    }
+  }
 }

--- a/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/ChannelMetricsCollectorTest.java
+++ b/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/ChannelMetricsCollectorTest.java
@@ -13,14 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.appdynamics.extensions.webspheremq.metricscollector;
+
+import static com.appdynamics.extensions.webspheremq.metricscollector.MetricAssert.assertThatMetric;
+import static com.appdynamics.extensions.webspheremq.metricscollector.MetricPropertiesAssert.standardPropsForAlias;
+import static com.ibm.mq.constants.CMQC.MQRC_SELECTOR_ERROR;
+import static com.ibm.mq.constants.CMQCFC.MQRCCF_CHL_STATUS_NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.Mockito.*;
 
 import com.appdynamics.extensions.AMonitorJob;
 import com.appdynamics.extensions.MetricWriteHelper;
 import com.appdynamics.extensions.conf.MonitorContextConfiguration;
 import com.appdynamics.extensions.metrics.Metric;
-import com.appdynamics.extensions.metrics.MetricProperties;
 import com.appdynamics.extensions.util.PathResolver;
 import com.appdynamics.extensions.webspheremq.common.Constants;
 import com.appdynamics.extensions.webspheremq.common.WMQUtil;
@@ -33,6 +39,10 @@ import com.ibm.mq.headers.pcf.PCFException;
 import com.ibm.mq.headers.pcf.PCFMessage;
 import com.ibm.mq.headers.pcf.PCFMessageAgent;
 import com.singularity.ee.agent.systemagent.api.AManagedMonitor;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -43,257 +53,280 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.math.BigDecimal;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Stream;
-
-import static com.appdynamics.extensions.webspheremq.metricscollector.MetricAssert.assertThatMetric;
-import static com.appdynamics.extensions.webspheremq.metricscollector.MetricPropertiesAssert.metricPropertiesMatching;
-import static com.appdynamics.extensions.webspheremq.metricscollector.MetricPropertiesAssert.standardPropsForAlias;
-import static com.ibm.mq.constants.CMQC.MQRC_SELECTOR_ERROR;
-import static com.ibm.mq.constants.CMQCFC.MQRCCF_CHL_STATUS_NOT_FOUND;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.params.provider.Arguments.arguments;
-import static org.mockito.Mockito.*;
-
 @ExtendWith(MockitoExtension.class)
 class ChannelMetricsCollectorTest {
-    ChannelMetricsCollector classUnderTest;
+  ChannelMetricsCollector classUnderTest;
 
-    @Mock
-    AMonitorJob aMonitorJob;
+  @Mock AMonitorJob aMonitorJob;
 
-    @Mock
-    PCFMessageAgent pcfMessageAgent;
+  @Mock PCFMessageAgent pcfMessageAgent;
 
-    @Mock
-    MetricWriteHelper metricWriteHelper;
+  @Mock MetricWriteHelper metricWriteHelper;
 
-    MonitorContextConfiguration monitorContextConfig;
+  MonitorContextConfiguration monitorContextConfig;
 
-    QueueManager queueManager;
-    ArgumentCaptor<List<Metric>> pathCaptor;
-    MetricCreator metricCreator;
-    MetricsCollectorContext context;
+  QueueManager queueManager;
+  ArgumentCaptor<List<Metric>> pathCaptor;
+  MetricCreator metricCreator;
+  MetricsCollectorContext context;
 
-    @BeforeEach
-    void setup() {
-        monitorContextConfig = new MonitorContextConfiguration("WMQMonitor", "Custom Metrics|WMQMonitor|", PathResolver.resolveDirectory(AManagedMonitor.class), aMonitorJob);
-        monitorContextConfig.setConfigYml("src/test/resources/conf/config.yml");
-        Map<String, ?> configMap = monitorContextConfig.getConfigYml();
-        ObjectMapper mapper = new ObjectMapper();
-        queueManager = mapper.convertValue(((List) configMap.get("queueManagers")).get(0), QueueManager.class);
-        Map<String, Map<String, WMQMetricOverride>> metricsMap = WMQUtil.getMetricsToReportFromConfigYml((List<Map>) configMap.get("mqMetrics"));
-        Map<String, WMQMetricOverride> channelMetrics = metricsMap.get(Constants.METRIC_TYPE_CHANNEL);
-        Map<String, Map<String, WMQMetricOverride>> metricsByCommand = new HashMap<>();
-        assertThat(channelMetrics).isNotEmpty();
-        for (Map.Entry<String, WMQMetricOverride> e : channelMetrics.entrySet()) {
-            String cmd = e.getValue().getIbmCommand() == null ? "MQCMD_INQUIRE_CHANNEL_STATUS" : e.getValue().getIbmCommand();
-            metricsByCommand.putIfAbsent(cmd, new HashMap<>());
-            metricsByCommand.get(cmd).put(e.getKey(), e.getValue());
-        }
-        Map<String, WMQMetricOverride> channelMetricsToReport = metricsByCommand.get("MQCMD_INQUIRE_CHANNEL_STATUS");
-        pathCaptor = ArgumentCaptor.forClass(List.class);
-        metricCreator = new MetricCreator(monitorContextConfig.getMetricPrefix(), queueManager, ChannelMetricsCollector.ARTIFACT);
-        IntAttributesBuilder attributesBuilder = new IntAttributesBuilder(channelMetricsToReport);
-        context = new MetricsCollectorContext(channelMetricsToReport, attributesBuilder, queueManager, pcfMessageAgent, metricWriteHelper);
+  @BeforeEach
+  void setup() {
+    monitorContextConfig =
+        new MonitorContextConfiguration(
+            "WMQMonitor",
+            "Custom Metrics|WMQMonitor|",
+            PathResolver.resolveDirectory(AManagedMonitor.class),
+            aMonitorJob);
+    monitorContextConfig.setConfigYml("src/test/resources/conf/config.yml");
+    Map<String, ?> configMap = monitorContextConfig.getConfigYml();
+    ObjectMapper mapper = new ObjectMapper();
+    queueManager =
+        mapper.convertValue(((List) configMap.get("queueManagers")).get(0), QueueManager.class);
+    Map<String, Map<String, WMQMetricOverride>> metricsMap =
+        WMQUtil.getMetricsToReportFromConfigYml((List<Map>) configMap.get("mqMetrics"));
+    Map<String, WMQMetricOverride> channelMetrics = metricsMap.get(Constants.METRIC_TYPE_CHANNEL);
+    Map<String, Map<String, WMQMetricOverride>> metricsByCommand = new HashMap<>();
+    assertThat(channelMetrics).isNotEmpty();
+    for (Map.Entry<String, WMQMetricOverride> e : channelMetrics.entrySet()) {
+      String cmd =
+          e.getValue().getIbmCommand() == null
+              ? "MQCMD_INQUIRE_CHANNEL_STATUS"
+              : e.getValue().getIbmCommand();
+      metricsByCommand.putIfAbsent(cmd, new HashMap<>());
+      metricsByCommand.get(cmd).put(e.getKey(), e.getValue());
     }
+    Map<String, WMQMetricOverride> channelMetricsToReport =
+        metricsByCommand.get("MQCMD_INQUIRE_CHANNEL_STATUS");
+    pathCaptor = ArgumentCaptor.forClass(List.class);
+    metricCreator =
+        new MetricCreator(
+            monitorContextConfig.getMetricPrefix(), queueManager, ChannelMetricsCollector.ARTIFACT);
+    IntAttributesBuilder attributesBuilder = new IntAttributesBuilder(channelMetricsToReport);
+    context =
+        new MetricsCollectorContext(
+            channelMetricsToReport,
+            attributesBuilder,
+            queueManager,
+            pcfMessageAgent,
+            metricWriteHelper);
+  }
 
-    @Test
-    void testPublishMetrics() throws Exception {
-        List<String> metricPathsList = Lists.newArrayList();
-        metricPathsList.add("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QM1|Channels|DEV.ADMIN.SVRCONN|Status");
-        metricPathsList.add("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QM1|Channels|DEV.APP.SVRCONN|Status");
-        metricPathsList.add("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QM1|Channels|ActiveChannelsCount");
+  @Test
+  void testPublishMetrics() throws Exception {
+    List<String> metricPathsList = Lists.newArrayList();
+    metricPathsList.add(
+        "Server|Component:Tier1|Custom Metrics|WebsphereMQ|QM1|Channels|DEV.ADMIN.SVRCONN|Status");
+    metricPathsList.add(
+        "Server|Component:Tier1|Custom Metrics|WebsphereMQ|QM1|Channels|DEV.APP.SVRCONN|Status");
+    metricPathsList.add(
+        "Server|Component:Tier1|Custom Metrics|WebsphereMQ|QM1|Channels|ActiveChannelsCount");
 
-        when(pcfMessageAgent.send(any(PCFMessage.class))).thenReturn(createPCFResponseForInquireChannelStatusCmd());
-        classUnderTest = new ChannelMetricsCollector(context, metricCreator);
+    when(pcfMessageAgent.send(any(PCFMessage.class)))
+        .thenReturn(createPCFResponseForInquireChannelStatusCmd());
+    classUnderTest = new ChannelMetricsCollector(context, metricCreator);
 
-        classUnderTest.publishMetrics();
+    classUnderTest.publishMetrics();
 
-        verify(metricWriteHelper, times(3)).transformAndPrintMetrics(pathCaptor.capture());
+    verify(metricWriteHelper, times(3)).transformAndPrintMetrics(pathCaptor.capture());
 
-        List<List<Metric>> allValues = pathCaptor.getAllValues();
-        assertThat(allValues).hasSize(3);
-        assertThat(allValues.get(0)).hasSize(6);
-        assertThat(allValues.get(1)).hasSize(6);
-        assertThat(allValues.get(2)).hasSize(1);
+    List<List<Metric>> allValues = pathCaptor.getAllValues();
+    assertThat(allValues).hasSize(3);
+    assertThat(allValues.get(0)).hasSize(6);
+    assertThat(allValues.get(1)).hasSize(6);
+    assertThat(allValues.get(2)).hasSize(1);
 
-        assertRowWithList(allValues.get(0), "ADMIN");
-        assertRowWithList(allValues.get(1), "APP");
+    assertRowWithList(allValues.get(0), "ADMIN");
+    assertRowWithList(allValues.get(1), "APP");
 
-        assertThatMetric(allValues.get(2).get(0))
-                .hasName("ActiveChannelsCount")
-                .hasPath("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Channels|ActiveChannelsCount")
-                .hasValue("2")
-                .withPropertiesMatching(standardPropsForAlias("ActiveChannelsCount"));
-    }
+    assertThatMetric(allValues.get(2).get(0))
+        .hasName("ActiveChannelsCount")
+        .hasPath(
+            "Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Channels|ActiveChannelsCount")
+        .hasValue("2")
+        .withPropertiesMatching(standardPropsForAlias("ActiveChannelsCount"));
+  }
 
-    void assertRowWithList(List<Metric> metrics, String component) {
-        assertThatMetric(metrics.get(0))
-                .hasName("Status")
-                .hasPath("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Channels|DEV." + component + ".SVRCONN|Status")
-                .hasValue("3")
-                .withPropertiesMatching(standardPropsForAlias("Status"));
+  void assertRowWithList(List<Metric> metrics, String component) {
+    assertThatMetric(metrics.get(0))
+        .hasName("Status")
+        .hasPath(
+            "Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Channels|DEV."
+                + component
+                + ".SVRCONN|Status")
+        .hasValue("3")
+        .withPropertiesMatching(standardPropsForAlias("Status"));
 
-        assertThatMetric(metrics.get(1))
-                .hasName("Messages")
-                .hasPath("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Channels|DEV." + component + ".SVRCONN|Messages")
-                .hasValue("17")
-                .withPropertiesMatching(standardPropsForAlias("Messages"));
+    assertThatMetric(metrics.get(1))
+        .hasName("Messages")
+        .hasPath(
+            "Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Channels|DEV."
+                + component
+                + ".SVRCONN|Messages")
+        .hasValue("17")
+        .withPropertiesMatching(standardPropsForAlias("Messages"));
 
-        assertThatMetric(metrics.get(2))
-                .hasName("BuffersSent")
-                .hasPath("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Channels|DEV." + component + ".SVRCONN|BuffersSent")
-                .hasValue("19")
-                .withPropertiesMatching(standardPropsForAlias("Buffers Sent"));
+    assertThatMetric(metrics.get(2))
+        .hasName("BuffersSent")
+        .hasPath(
+            "Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Channels|DEV."
+                + component
+                + ".SVRCONN|BuffersSent")
+        .hasValue("19")
+        .withPropertiesMatching(standardPropsForAlias("Buffers Sent"));
 
-        assertThatMetric(metrics.get(3))
-                .hasName("ByteSent")
-                .hasPath("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Channels|DEV." + component + ".SVRCONN|ByteSent")
-                .hasValue("6984")
-                .withPropertiesMatching(standardPropsForAlias("Byte Sent"));
+    assertThatMetric(metrics.get(3))
+        .hasName("ByteSent")
+        .hasPath(
+            "Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Channels|DEV."
+                + component
+                + ".SVRCONN|ByteSent")
+        .hasValue("6984")
+        .withPropertiesMatching(standardPropsForAlias("Byte Sent"));
 
-        assertThatMetric(metrics.get(4))
-                .hasName("BuffersReceived")
-                .hasPath("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Channels|DEV." + component + ".SVRCONN|BuffersReceived")
-                .hasValue("20")
-                .withPropertiesMatching(standardPropsForAlias("Buffers Received"));
+    assertThatMetric(metrics.get(4))
+        .hasName("BuffersReceived")
+        .hasPath(
+            "Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Channels|DEV."
+                + component
+                + ".SVRCONN|BuffersReceived")
+        .hasValue("20")
+        .withPropertiesMatching(standardPropsForAlias("Buffers Received"));
 
-        assertThatMetric(metrics.get(5))
-                .hasName("ByteReceived")
-                .hasPath("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Channels|DEV." + component + ".SVRCONN|ByteReceived")
-                .hasValue("5772")
-                .withPropertiesMatching(standardPropsForAlias("Byte Received"));
-    }
+    assertThatMetric(metrics.get(5))
+        .hasName("ByteReceived")
+        .hasPath(
+            "Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Channels|DEV."
+                + component
+                + ".SVRCONN|ByteReceived")
+        .hasValue("5772")
+        .withPropertiesMatching(standardPropsForAlias("Byte Received"));
+  }
 
-    /*
-        Request
-        PCFMessage:
-        MQCFH [type: 1, strucLength: 36, version: 1, command: 42 (MQCMD_INQUIRE_CHANNEL_STATUS), msgSeqNumber: 1, control: 1, compCode: 0, reason: 0, parameterCount: 3]
-        MQCFST [type: 4, strucLength: 24, parameter: 3501 (MQCACH_FIRST/MQCACH_CHANNEL_NAME), codedCharSetId: 0, stringLength: 1, string: *]
-        MQCFIN [type: 3, strucLength: 16, parameter: 1523 (MQIACH_CHANNEL_INSTANCE_TYPE), value: 1011]
-        MQCFIL [type: 5, strucLength: 48, parameter: 1524 (MQIACH_CHANNEL_INSTANCE_ATTRS), count: 8, values: {3501, 3506, 1527, 1534, 1538, 1535, 1539, 1536}]
+  /*
+     Request
+     PCFMessage:
+     MQCFH [type: 1, strucLength: 36, version: 1, command: 42 (MQCMD_INQUIRE_CHANNEL_STATUS), msgSeqNumber: 1, control: 1, compCode: 0, reason: 0, parameterCount: 3]
+     MQCFST [type: 4, strucLength: 24, parameter: 3501 (MQCACH_FIRST/MQCACH_CHANNEL_NAME), codedCharSetId: 0, stringLength: 1, string: *]
+     MQCFIN [type: 3, strucLength: 16, parameter: 1523 (MQIACH_CHANNEL_INSTANCE_TYPE), value: 1011]
+     MQCFIL [type: 5, strucLength: 48, parameter: 1524 (MQIACH_CHANNEL_INSTANCE_ATTRS), count: 8, values: {3501, 3506, 1527, 1534, 1538, 1535, 1539, 1536}]
 
-        Response
-        PCFMessage:
-        MQCFH [type: 2, strucLength: 36, version: 1, command: 42 (MQCMD_INQUIRE_CHANNEL_STATUS), msgSeqNumber: 1, control: 1, compCode: 0, reason: 0, parameterCount: 11]
-        MQCFST [type: 4, strucLength: 40, parameter: 3501 (MQCACH_FIRST/MQCACH_CHANNEL_NAME), codedCharSetId: 819, stringLength: 20, string: DEV.ADMIN.SVRCONN   ]
-        MQCFIN [type: 3, strucLength: 16, parameter: 1511 (MQIACH_CHANNEL_TYPE), value: 7]
-        MQCFIN [type: 3, strucLength: 16, parameter: 1539 (MQIACH_BUFFERS_RCVD/MQIACH_BUFFERS_RECEIVED), value: 20]
-        MQCFIN [type: 3, strucLength: 16, parameter: 1538 (MQIACH_BUFFERS_SENT), value: 19]
-        MQCFIN [type: 3, strucLength: 16, parameter: 1536 (MQIACH_BYTES_RCVD/MQIACH_BYTES_RECEIVED), value: 5772]
-        MQCFIN [type: 3, strucLength: 16, parameter: 1535 (MQIACH_BYTES_SENT), value: 6984]
-        MQCFST [type: 4, strucLength: 284, parameter: 3506 (MQCACH_CONNECTION_NAME), codedCharSetId: 819, stringLength: 264, string: 172.17.0.1]
-        MQCFIN [type: 3, strucLength: 16, parameter: 1523 (MQIACH_CHANNEL_INSTANCE_TYPE), value: 1011]
-        MQCFIN [type: 3, strucLength: 16, parameter: 1534 (MQIACH_MSGS), value: 17]
-        MQCFIN [type: 3, strucLength: 16, parameter: 1527 (MQIACH_CHANNEL_STATUS), value: 3]
-        MQCFIN [type: 3, strucLength: 16, parameter: 1609 (MQIACH_CHANNEL_SUBSTATE), value: 300]
-     */
+     Response
+     PCFMessage:
+     MQCFH [type: 2, strucLength: 36, version: 1, command: 42 (MQCMD_INQUIRE_CHANNEL_STATUS), msgSeqNumber: 1, control: 1, compCode: 0, reason: 0, parameterCount: 11]
+     MQCFST [type: 4, strucLength: 40, parameter: 3501 (MQCACH_FIRST/MQCACH_CHANNEL_NAME), codedCharSetId: 819, stringLength: 20, string: DEV.ADMIN.SVRCONN   ]
+     MQCFIN [type: 3, strucLength: 16, parameter: 1511 (MQIACH_CHANNEL_TYPE), value: 7]
+     MQCFIN [type: 3, strucLength: 16, parameter: 1539 (MQIACH_BUFFERS_RCVD/MQIACH_BUFFERS_RECEIVED), value: 20]
+     MQCFIN [type: 3, strucLength: 16, parameter: 1538 (MQIACH_BUFFERS_SENT), value: 19]
+     MQCFIN [type: 3, strucLength: 16, parameter: 1536 (MQIACH_BYTES_RCVD/MQIACH_BYTES_RECEIVED), value: 5772]
+     MQCFIN [type: 3, strucLength: 16, parameter: 1535 (MQIACH_BYTES_SENT), value: 6984]
+     MQCFST [type: 4, strucLength: 284, parameter: 3506 (MQCACH_CONNECTION_NAME), codedCharSetId: 819, stringLength: 264, string: 172.17.0.1]
+     MQCFIN [type: 3, strucLength: 16, parameter: 1523 (MQIACH_CHANNEL_INSTANCE_TYPE), value: 1011]
+     MQCFIN [type: 3, strucLength: 16, parameter: 1534 (MQIACH_MSGS), value: 17]
+     MQCFIN [type: 3, strucLength: 16, parameter: 1527 (MQIACH_CHANNEL_STATUS), value: 3]
+     MQCFIN [type: 3, strucLength: 16, parameter: 1609 (MQIACH_CHANNEL_SUBSTATE), value: 300]
+  */
 
-    private PCFMessage[] createPCFResponseForInquireChannelStatusCmd() {
-        PCFMessage response1 = new PCFMessage(2, CMQCFC.MQCMD_INQUIRE_CHANNEL_STATUS, 1, true);
-        response1.addParameter(CMQCFC.MQCACH_CHANNEL_NAME, "DEV.ADMIN.SVRCONN");
-        response1.addParameter(CMQCFC.MQIACH_CHANNEL_TYPE, 7);
-        response1.addParameter(CMQCFC.MQIACH_BUFFERS_RECEIVED, 20);
-        response1.addParameter(CMQCFC.MQIACH_BUFFERS_SENT, 19);
-        response1.addParameter(CMQCFC.MQIACH_BYTES_RECEIVED, 5772);
-        response1.addParameter(CMQCFC.MQIACH_BYTES_SENT, 6984);
-        response1.addParameter(CMQCFC.MQCACH_CONNECTION_NAME, "172.17.0.1 ");
-        response1.addParameter(CMQCFC.MQIACH_CHANNEL_INSTANCE_TYPE, 1011);
-        response1.addParameter(CMQCFC.MQIACH_MSGS, 17);
-        response1.addParameter(CMQCFC.MQIACH_CHANNEL_STATUS, 3);
-        response1.addParameter(CMQCFC.MQIACH_CHANNEL_SUBSTATE, 300);
+  private PCFMessage[] createPCFResponseForInquireChannelStatusCmd() {
+    PCFMessage response1 = new PCFMessage(2, CMQCFC.MQCMD_INQUIRE_CHANNEL_STATUS, 1, true);
+    response1.addParameter(CMQCFC.MQCACH_CHANNEL_NAME, "DEV.ADMIN.SVRCONN");
+    response1.addParameter(CMQCFC.MQIACH_CHANNEL_TYPE, 7);
+    response1.addParameter(CMQCFC.MQIACH_BUFFERS_RECEIVED, 20);
+    response1.addParameter(CMQCFC.MQIACH_BUFFERS_SENT, 19);
+    response1.addParameter(CMQCFC.MQIACH_BYTES_RECEIVED, 5772);
+    response1.addParameter(CMQCFC.MQIACH_BYTES_SENT, 6984);
+    response1.addParameter(CMQCFC.MQCACH_CONNECTION_NAME, "172.17.0.1 ");
+    response1.addParameter(CMQCFC.MQIACH_CHANNEL_INSTANCE_TYPE, 1011);
+    response1.addParameter(CMQCFC.MQIACH_MSGS, 17);
+    response1.addParameter(CMQCFC.MQIACH_CHANNEL_STATUS, 3);
+    response1.addParameter(CMQCFC.MQIACH_CHANNEL_SUBSTATE, 300);
 
-        PCFMessage response2 = new PCFMessage(2, CMQCFC.MQCMD_INQUIRE_CHANNEL_STATUS, 2, true);
-        response2.addParameter(CMQCFC.MQCACH_CHANNEL_NAME, "DEV.APP.SVRCONN");
-        response2.addParameter(CMQCFC.MQIACH_CHANNEL_TYPE, 7);
-        response2.addParameter(CMQCFC.MQIACH_BUFFERS_RECEIVED, 20);
-        response2.addParameter(CMQCFC.MQIACH_BUFFERS_SENT, 19);
-        response2.addParameter(CMQCFC.MQIACH_BYTES_RECEIVED, 5772);
-        response2.addParameter(CMQCFC.MQIACH_BYTES_SENT, 6984);
-        response2.addParameter(CMQCFC.MQCACH_CONNECTION_NAME, "172.17.0.2 ");
-        response2.addParameter(CMQCFC.MQIACH_CHANNEL_INSTANCE_TYPE, 1011);
-        response2.addParameter(CMQCFC.MQIACH_MSGS, 17);
-        response2.addParameter(CMQCFC.MQIACH_CHANNEL_STATUS, 3);
-        response2.addParameter(CMQCFC.MQIACH_CHANNEL_SUBSTATE, 300);
+    PCFMessage response2 = new PCFMessage(2, CMQCFC.MQCMD_INQUIRE_CHANNEL_STATUS, 2, true);
+    response2.addParameter(CMQCFC.MQCACH_CHANNEL_NAME, "DEV.APP.SVRCONN");
+    response2.addParameter(CMQCFC.MQIACH_CHANNEL_TYPE, 7);
+    response2.addParameter(CMQCFC.MQIACH_BUFFERS_RECEIVED, 20);
+    response2.addParameter(CMQCFC.MQIACH_BUFFERS_SENT, 19);
+    response2.addParameter(CMQCFC.MQIACH_BYTES_RECEIVED, 5772);
+    response2.addParameter(CMQCFC.MQIACH_BYTES_SENT, 6984);
+    response2.addParameter(CMQCFC.MQCACH_CONNECTION_NAME, "172.17.0.2 ");
+    response2.addParameter(CMQCFC.MQIACH_CHANNEL_INSTANCE_TYPE, 1011);
+    response2.addParameter(CMQCFC.MQIACH_MSGS, 17);
+    response2.addParameter(CMQCFC.MQIACH_CHANNEL_STATUS, 3);
+    response2.addParameter(CMQCFC.MQIACH_CHANNEL_SUBSTATE, 300);
 
-        PCFMessage response3 = new PCFMessage(2, CMQCFC.MQCMD_INQUIRE_CHANNEL_STATUS, 2, true);
-        response3.addParameter(CMQCFC.MQCACH_CHANNEL_NAME, "TEST.APP.SVRCONN");
-        response3.addParameter(CMQCFC.MQIACH_CHANNEL_TYPE, 7);
-        response3.addParameter(CMQCFC.MQIACH_BUFFERS_RECEIVED, 20);
-        response3.addParameter(CMQCFC.MQIACH_BUFFERS_SENT, 19);
-        response3.addParameter(CMQCFC.MQIACH_BYTES_RECEIVED, 5772);
-        response3.addParameter(CMQCFC.MQIACH_BYTES_SENT, 6984);
-        response3.addParameter(CMQCFC.MQCACH_CONNECTION_NAME, "172.17.0.2 ");
-        response3.addParameter(CMQCFC.MQIACH_CHANNEL_INSTANCE_TYPE, 1011);
-        response3.addParameter(CMQCFC.MQIACH_MSGS, 17);
-        response3.addParameter(CMQCFC.MQIACH_CHANNEL_STATUS, 3);
-        response3.addParameter(CMQCFC.MQIACH_CHANNEL_SUBSTATE, 300);
+    PCFMessage response3 = new PCFMessage(2, CMQCFC.MQCMD_INQUIRE_CHANNEL_STATUS, 2, true);
+    response3.addParameter(CMQCFC.MQCACH_CHANNEL_NAME, "TEST.APP.SVRCONN");
+    response3.addParameter(CMQCFC.MQIACH_CHANNEL_TYPE, 7);
+    response3.addParameter(CMQCFC.MQIACH_BUFFERS_RECEIVED, 20);
+    response3.addParameter(CMQCFC.MQIACH_BUFFERS_SENT, 19);
+    response3.addParameter(CMQCFC.MQIACH_BYTES_RECEIVED, 5772);
+    response3.addParameter(CMQCFC.MQIACH_BYTES_SENT, 6984);
+    response3.addParameter(CMQCFC.MQCACH_CONNECTION_NAME, "172.17.0.2 ");
+    response3.addParameter(CMQCFC.MQIACH_CHANNEL_INSTANCE_TYPE, 1011);
+    response3.addParameter(CMQCFC.MQIACH_MSGS, 17);
+    response3.addParameter(CMQCFC.MQIACH_CHANNEL_STATUS, 3);
+    response3.addParameter(CMQCFC.MQIACH_CHANNEL_SUBSTATE, 300);
 
-        return new PCFMessage[]{response1, response2, response3};
-    }
+    return new PCFMessage[] {response1, response2, response3};
+  }
 
-    @Test
-    void testPublishMetrics_nullResponse() throws Exception {
-        when(pcfMessageAgent.send(any(PCFMessage.class))).thenReturn(null);
-        classUnderTest = new ChannelMetricsCollector(context, metricCreator);
+  @Test
+  void testPublishMetrics_nullResponse() throws Exception {
+    when(pcfMessageAgent.send(any(PCFMessage.class))).thenReturn(null);
+    classUnderTest = new ChannelMetricsCollector(context, metricCreator);
 
-        classUnderTest.publishMetrics();
+    classUnderTest.publishMetrics();
 
-        verifyNoInteractions(metricWriteHelper);
-    }
+    verifyNoInteractions(metricWriteHelper);
+  }
 
-    @Test
-    void testPublishMetrics_emptyResponse() throws Exception {
-        when(pcfMessageAgent.send(any(PCFMessage.class))).thenReturn(new PCFMessage[]{});
-        classUnderTest = new ChannelMetricsCollector(context, metricCreator);
+  @Test
+  void testPublishMetrics_emptyResponse() throws Exception {
+    when(pcfMessageAgent.send(any(PCFMessage.class))).thenReturn(new PCFMessage[] {});
+    classUnderTest = new ChannelMetricsCollector(context, metricCreator);
 
-        classUnderTest.publishMetrics();
+    classUnderTest.publishMetrics();
 
-        verifyNoInteractions(metricWriteHelper);
-    }
+    verifyNoInteractions(metricWriteHelper);
+  }
 
-    @ParameterizedTest
-    @MethodSource("exceptionsToThrow")
-    void testPublishMetrics_pfException(Exception exceptionToThrow) throws Exception {
-        when(pcfMessageAgent.send(any(PCFMessage.class))).thenThrow(exceptionToThrow);
-        classUnderTest = new ChannelMetricsCollector(context, metricCreator);
+  @ParameterizedTest
+  @MethodSource("exceptionsToThrow")
+  void testPublishMetrics_pfException(Exception exceptionToThrow) throws Exception {
+    when(pcfMessageAgent.send(any(PCFMessage.class))).thenThrow(exceptionToThrow);
+    classUnderTest = new ChannelMetricsCollector(context, metricCreator);
 
-        classUnderTest.publishMetrics();
+    classUnderTest.publishMetrics();
 
-        verify(metricWriteHelper, times(1)).transformAndPrintMetrics(pathCaptor.capture());
+    verify(metricWriteHelper, times(1)).transformAndPrintMetrics(pathCaptor.capture());
 
-        // Even when exception is thrown, the active channels are still reported
-        List<List<Metric>> allValues = pathCaptor.getAllValues();
-        assertThat(allValues).hasSize(1);
-        assertThat(allValues.get(0)).hasSize(1);
-        assertThatMetric(allValues.get(0).get(0))
-                .hasName("ActiveChannelsCount")
-                .hasPath("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Channels|ActiveChannelsCount")
-                .hasValue("0")
-                .withPropertiesMatching(standardPropsForAlias("ActiveChannelsCount"));
-    }
+    // Even when exception is thrown, the active channels are still reported
+    List<List<Metric>> allValues = pathCaptor.getAllValues();
+    assertThat(allValues).hasSize(1);
+    assertThat(allValues.get(0)).hasSize(1);
+    assertThatMetric(allValues.get(0).get(0))
+        .hasName("ActiveChannelsCount")
+        .hasPath(
+            "Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Channels|ActiveChannelsCount")
+        .hasValue("0")
+        .withPropertiesMatching(standardPropsForAlias("ActiveChannelsCount"));
+  }
 
-    @Test
-    void noMetricsToReport() throws Exception {
-        classUnderTest = new ChannelMetricsCollector(context, metricCreator);
-        classUnderTest.publishMetrics();
-        verifyNoInteractions(metricWriteHelper);
-        classUnderTest = new ChannelMetricsCollector(context, metricCreator);
-        classUnderTest.publishMetrics();
-        verifyNoInteractions(metricWriteHelper);
-    }
+  @Test
+  void noMetricsToReport() throws Exception {
+    classUnderTest = new ChannelMetricsCollector(context, metricCreator);
+    classUnderTest.publishMetrics();
+    verifyNoInteractions(metricWriteHelper);
+    classUnderTest = new ChannelMetricsCollector(context, metricCreator);
+    classUnderTest.publishMetrics();
+    verifyNoInteractions(metricWriteHelper);
+  }
 
-    static Stream<Arguments> exceptionsToThrow() {
-        return Stream.of(
-                arguments(new RuntimeException("KBAOOM")),
-                arguments(new PCFException(91, MQRCCF_CHL_STATUS_NOT_FOUND, "flimflam")),
-                arguments(new PCFException(4, MQRC_SELECTOR_ERROR, "shazbot")),
-                arguments(new PCFException(4, 42, "boz"))
-        );
-    }
+  static Stream<Arguments> exceptionsToThrow() {
+    return Stream.of(
+        arguments(new RuntimeException("KBAOOM")),
+        arguments(new PCFException(91, MQRCCF_CHL_STATUS_NOT_FOUND, "flimflam")),
+        arguments(new PCFException(4, MQRC_SELECTOR_ERROR, "shazbot")),
+        arguments(new PCFException(4, 42, "boz")));
+  }
 }

--- a/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/InquireChannelCmdCollectorTest.java
+++ b/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/InquireChannelCmdCollectorTest.java
@@ -13,8 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.appdynamics.extensions.webspheremq.metricscollector;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.appdynamics.extensions.AMonitorJob;
 import com.appdynamics.extensions.MetricWriteHelper;
@@ -27,108 +32,129 @@ import com.appdynamics.extensions.webspheremq.config.QueueManager;
 import com.appdynamics.extensions.webspheremq.config.WMQMetricOverride;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
-import com.ibm.mq.constants.CMQC;
 import com.ibm.mq.constants.CMQCFC;
 import com.ibm.mq.headers.pcf.PCFMessage;
 import com.ibm.mq.headers.pcf.PCFMessageAgent;
 import com.singularity.ee.agent.systemagent.api.AManagedMonitor;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.CountDownLatch;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class InquireChannelCmdCollectorTest {
 
-    InquireChannelCmdCollector classUnderTest;
+  InquireChannelCmdCollector classUnderTest;
 
-    @Mock
-    AMonitorJob aMonitorJob;
+  @Mock AMonitorJob aMonitorJob;
 
-    @Mock
-    PCFMessageAgent pcfMessageAgent;
+  @Mock PCFMessageAgent pcfMessageAgent;
 
-    @Mock
-    MetricWriteHelper metricWriteHelper;
+  @Mock MetricWriteHelper metricWriteHelper;
 
-    MonitorContextConfiguration monitorContextConfig;
+  MonitorContextConfiguration monitorContextConfig;
 
-    ArgumentCaptor<List> pathCaptor;
-    MetricCreator metricCreator;
-    MetricsCollectorContext context;
+  ArgumentCaptor<List> pathCaptor;
+  MetricCreator metricCreator;
+  MetricsCollectorContext context;
 
-    @BeforeEach
-    public void setup() {
-        monitorContextConfig = new MonitorContextConfiguration("WMQMonitor", "Custom Metrics|WMQMonitor|", PathResolver.resolveDirectory(AManagedMonitor.class),aMonitorJob);
-        monitorContextConfig.setConfigYml("src/test/resources/conf/config.yml");
-        Map<String, ?> configMap = monitorContextConfig.getConfigYml();
-        ObjectMapper mapper = new ObjectMapper();
-        QueueManager queueManager = mapper.convertValue(((List)configMap.get("queueManagers")).get(0), QueueManager.class);
-        Map<String, Map<String, WMQMetricOverride>> metricsMap = WMQUtil.getMetricsToReportFromConfigYml((List<Map>) configMap.get("mqMetrics"));
-        Map<String, WMQMetricOverride> channelMetrics = metricsMap.get(Constants.METRIC_TYPE_CHANNEL);
-        Map<String, Map<String, WMQMetricOverride>> metricsByCommand = new HashMap<>();
-        for (String key : channelMetrics.keySet()) {
-            WMQMetricOverride wmqOverride = channelMetrics.get(key);
-            String cmd = wmqOverride.getIbmCommand() == null ? "MQCMD_INQUIRE_CHANNEL_STATUS" : wmqOverride.getIbmCommand();
-            metricsByCommand.putIfAbsent(cmd, new HashMap<>());
-            metricsByCommand.get(cmd).put(key, wmqOverride);
+  @BeforeEach
+  public void setup() {
+    monitorContextConfig =
+        new MonitorContextConfiguration(
+            "WMQMonitor",
+            "Custom Metrics|WMQMonitor|",
+            PathResolver.resolveDirectory(AManagedMonitor.class),
+            aMonitorJob);
+    monitorContextConfig.setConfigYml("src/test/resources/conf/config.yml");
+    Map<String, ?> configMap = monitorContextConfig.getConfigYml();
+    ObjectMapper mapper = new ObjectMapper();
+    QueueManager queueManager =
+        mapper.convertValue(((List) configMap.get("queueManagers")).get(0), QueueManager.class);
+    Map<String, Map<String, WMQMetricOverride>> metricsMap =
+        WMQUtil.getMetricsToReportFromConfigYml((List<Map>) configMap.get("mqMetrics"));
+    Map<String, WMQMetricOverride> channelMetrics = metricsMap.get(Constants.METRIC_TYPE_CHANNEL);
+    Map<String, Map<String, WMQMetricOverride>> metricsByCommand = new HashMap<>();
+    for (String key : channelMetrics.keySet()) {
+      WMQMetricOverride wmqOverride = channelMetrics.get(key);
+      String cmd =
+          wmqOverride.getIbmCommand() == null
+              ? "MQCMD_INQUIRE_CHANNEL_STATUS"
+              : wmqOverride.getIbmCommand();
+      metricsByCommand.putIfAbsent(cmd, new HashMap<>());
+      metricsByCommand.get(cmd).put(key, wmqOverride);
+    }
+    Map<String, WMQMetricOverride> channelMetricsToReport =
+        metricsByCommand.get("MQCMD_INQUIRE_CHANNEL");
+    pathCaptor = ArgumentCaptor.forClass(List.class);
+    metricCreator =
+        new MetricCreator(
+            monitorContextConfig.getMetricPrefix(),
+            queueManager,
+            InquireChannelCmdCollector.ARTIFACT);
+    IntAttributesBuilder attributesBuilder = new IntAttributesBuilder(channelMetricsToReport);
+    context =
+        new MetricsCollectorContext(
+            channelMetricsToReport,
+            attributesBuilder,
+            queueManager,
+            pcfMessageAgent,
+            metricWriteHelper);
+  }
+
+  @Test
+  public void testProcessPCFRequestAndPublishQMetricsForInquireQStatusCmd() throws Exception {
+    when(pcfMessageAgent.send(any(PCFMessage.class)))
+        .thenReturn(createPCFResponseForInquireChannelCmd());
+    classUnderTest = new InquireChannelCmdCollector(context, metricCreator);
+    classUnderTest.publishMetrics();
+    verify(metricWriteHelper, times(1)).transformAndPrintMetrics(pathCaptor.capture());
+    List<String> metricPathsList = Lists.newArrayList();
+    metricPathsList.add(
+        "Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Channels|my.channel|MsgRetryCount");
+    metricPathsList.add(
+        "Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Channels|my.channel|MsgsReceived");
+    metricPathsList.add(
+        "Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Channels|my.channel|MsgsSent");
+
+    for (List<Metric> metricList : pathCaptor.getAllValues()) {
+      for (Metric metric : metricList) {
+        if (metricPathsList.contains(metric.getMetricPath())) {
+          if (metric
+              .getMetricPath()
+              .equals(
+                  "Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Channels|my.channel|MsgRetryCount")) {
+            assertThat(metric.getMetricValue()).isEqualTo("22");
+          }
+          if (metric
+              .getMetricPath()
+              .equals(
+                  "Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Channels|my.channel|MsgsReceived")) {
+            assertThat(metric.getMetricValue()).isEqualTo("42");
+          }
+          if (metric
+              .getMetricPath()
+              .equals(
+                  "Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Channels|my.channel|MsgsSent")) {
+            assertThat(metric.getMetricValue()).isEqualTo("64");
+          }
         }
-        Map<String, WMQMetricOverride> channelMetricsToReport = metricsByCommand.get("MQCMD_INQUIRE_CHANNEL");
-        pathCaptor = ArgumentCaptor.forClass(List.class);
-        metricCreator = new MetricCreator(monitorContextConfig.getMetricPrefix(), queueManager, InquireChannelCmdCollector.ARTIFACT);
-        IntAttributesBuilder attributesBuilder = new IntAttributesBuilder(channelMetricsToReport);
-        context = new MetricsCollectorContext(channelMetricsToReport, attributesBuilder, queueManager, pcfMessageAgent, metricWriteHelper);
+      }
     }
+  }
 
-    @Test
-    public void testProcessPCFRequestAndPublishQMetricsForInquireQStatusCmd() throws Exception {
-        when(pcfMessageAgent.send(any(PCFMessage.class))).thenReturn(createPCFResponseForInquireChannelCmd());
-        classUnderTest = new InquireChannelCmdCollector(context, metricCreator);
-        classUnderTest.publishMetrics();
-        verify(metricWriteHelper, times(1)).transformAndPrintMetrics(pathCaptor.capture());
-        List<String> metricPathsList = Lists.newArrayList();
-        metricPathsList.add("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Channels|my.channel|MsgRetryCount");
-        metricPathsList.add("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Channels|my.channel|MsgsReceived");
-        metricPathsList.add("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Channels|my.channel|MsgsSent");
+  private PCFMessage[] createPCFResponseForInquireChannelCmd() {
+    PCFMessage response1 = new PCFMessage(2, CMQCFC.MQCMD_INQUIRE_CHANNEL, 1, true);
+    response1.addParameter(CMQCFC.MQCACH_CHANNEL_NAME, "my.channel");
+    response1.addParameter(CMQCFC.MQIACH_MR_COUNT, 22);
+    response1.addParameter(CMQCFC.MQIACH_MSGS_RECEIVED, 42);
+    response1.addParameter(CMQCFC.MQIACH_MSGS_SENT, 64);
 
-        for (List<Metric> metricList : pathCaptor.getAllValues()) {
-            for (Metric metric : metricList) {
-                if (metricPathsList.contains(metric.getMetricPath())) {
-                    if (metric.getMetricPath().equals("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Channels|my.channel|MsgRetryCount")) {
-                        assertThat(metric.getMetricValue()).isEqualTo("22");
-                    }
-                    if (metric.getMetricPath().equals("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Channels|my.channel|MsgsReceived")) {
-                        assertThat(metric.getMetricValue()).isEqualTo("42");
-                    }
-                    if (metric.getMetricPath().equals("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Channels|my.channel|MsgsSent")) {
-                        assertThat(metric.getMetricValue()).isEqualTo("64");
-                    }
-                }
-            }
-        }
-    }
-
-    private PCFMessage[] createPCFResponseForInquireChannelCmd() {
-        PCFMessage response1 = new PCFMessage(2, CMQCFC.MQCMD_INQUIRE_CHANNEL, 1, true);
-        response1.addParameter(CMQCFC.MQCACH_CHANNEL_NAME, "my.channel");
-        response1.addParameter(CMQCFC.MQIACH_MR_COUNT, 22);
-        response1.addParameter(CMQCFC.MQIACH_MSGS_RECEIVED, 42);
-        response1.addParameter(CMQCFC.MQIACH_MSGS_SENT, 64);
-
-        return new PCFMessage[]{response1};
-    }
+    return new PCFMessage[] {response1};
+  }
 }

--- a/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/ListenerMetricsCollectorTest.java
+++ b/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/ListenerMetricsCollectorTest.java
@@ -13,8 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.appdynamics.extensions.webspheremq.metricscollector;
+
+import static com.appdynamics.extensions.webspheremq.metricscollector.MetricAssert.assertThatMetric;
+import static com.appdynamics.extensions.webspheremq.metricscollector.MetricPropertiesAssert.standardPropsForAlias;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
 
 import com.appdynamics.extensions.AMonitorJob;
 import com.appdynamics.extensions.MetricWriteHelper;
@@ -30,6 +34,8 @@ import com.ibm.mq.constants.CMQCFC;
 import com.ibm.mq.headers.pcf.PCFMessage;
 import com.ibm.mq.headers.pcf.PCFMessageAgent;
 import com.singularity.ee.agent.systemagent.api.AManagedMonitor;
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -37,100 +43,108 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.List;
-import java.util.Map;
-
-import static com.appdynamics.extensions.webspheremq.metricscollector.MetricAssert.assertThatMetric;
-import static com.appdynamics.extensions.webspheremq.metricscollector.MetricPropertiesAssert.standardPropsForAlias;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
-
 @ExtendWith(MockitoExtension.class)
 class ListenerMetricsCollectorTest {
-    private ListenerMetricsCollector classUnderTest;
-    @Mock
-    private AMonitorJob aMonitorJob;
+  private ListenerMetricsCollector classUnderTest;
+  @Mock private AMonitorJob aMonitorJob;
 
-    @Mock
-    private PCFMessageAgent pcfMessageAgent;
+  @Mock private PCFMessageAgent pcfMessageAgent;
 
-    @Mock
-    private MetricWriteHelper metricWriteHelper;
+  @Mock private MetricWriteHelper metricWriteHelper;
 
-    private MonitorContextConfiguration monitorContextConfig;
-    private Map<String, WMQMetricOverride> listenerMetricsToReport;
-    private QueueManager queueManager;
-    private ArgumentCaptor<List<Metric>> pathCaptor;
-    private MetricCreator metricCreator;
+  private MonitorContextConfiguration monitorContextConfig;
+  private Map<String, WMQMetricOverride> listenerMetricsToReport;
+  private QueueManager queueManager;
+  private ArgumentCaptor<List<Metric>> pathCaptor;
+  private MetricCreator metricCreator;
 
-    @BeforeEach
-    public void setup() {
-        monitorContextConfig = new MonitorContextConfiguration("WMQMonitor", "Custom Metrics|WMQMonitor|", PathResolver.resolveDirectory(AManagedMonitor.class), aMonitorJob);
-        monitorContextConfig.setConfigYml("src/test/resources/conf/config.yml");
-        Map<String, ?> configMap = monitorContextConfig.getConfigYml();
-        ObjectMapper mapper = new ObjectMapper();
-        queueManager = mapper.convertValue(((List) configMap.get("queueManagers")).get(0), QueueManager.class);
-        Map<String, Map<String, WMQMetricOverride>> metricsMap = WMQUtil.getMetricsToReportFromConfigYml((List<Map>) configMap.get("mqMetrics"));
-        listenerMetricsToReport = metricsMap.get(Constants.METRIC_TYPE_LISTENER);
-        pathCaptor = ArgumentCaptor.forClass(List.class);
-        metricCreator = new MetricCreator(monitorContextConfig.getMetricPrefix(), queueManager, ListenerMetricsCollector.ARTIFACT);
-    }
+  @BeforeEach
+  public void setup() {
+    monitorContextConfig =
+        new MonitorContextConfiguration(
+            "WMQMonitor",
+            "Custom Metrics|WMQMonitor|",
+            PathResolver.resolveDirectory(AManagedMonitor.class),
+            aMonitorJob);
+    monitorContextConfig.setConfigYml("src/test/resources/conf/config.yml");
+    Map<String, ?> configMap = monitorContextConfig.getConfigYml();
+    ObjectMapper mapper = new ObjectMapper();
+    queueManager =
+        mapper.convertValue(((List) configMap.get("queueManagers")).get(0), QueueManager.class);
+    Map<String, Map<String, WMQMetricOverride>> metricsMap =
+        WMQUtil.getMetricsToReportFromConfigYml((List<Map>) configMap.get("mqMetrics"));
+    listenerMetricsToReport = metricsMap.get(Constants.METRIC_TYPE_LISTENER);
+    pathCaptor = ArgumentCaptor.forClass(List.class);
+    metricCreator =
+        new MetricCreator(
+            monitorContextConfig.getMetricPrefix(),
+            queueManager,
+            ListenerMetricsCollector.ARTIFACT);
+  }
 
-    @Test
-    public void testPublishMetrics() throws Exception {
-        when(pcfMessageAgent.send(any(PCFMessage.class))).thenReturn(createPCFResponseForInquireListenerStatusCmd());
-        IntAttributesBuilder attributesBuilder = new IntAttributesBuilder(listenerMetricsToReport);
-        MetricsCollectorContext context = new MetricsCollectorContext(listenerMetricsToReport, attributesBuilder, queueManager, pcfMessageAgent, metricWriteHelper);
-        classUnderTest = new ListenerMetricsCollector(context, metricCreator);
-        classUnderTest.publishMetrics();
-        verify(metricWriteHelper, times(2)).transformAndPrintMetrics(pathCaptor.capture());
+  @Test
+  public void testPublishMetrics() throws Exception {
+    when(pcfMessageAgent.send(any(PCFMessage.class)))
+        .thenReturn(createPCFResponseForInquireListenerStatusCmd());
+    IntAttributesBuilder attributesBuilder = new IntAttributesBuilder(listenerMetricsToReport);
+    MetricsCollectorContext context =
+        new MetricsCollectorContext(
+            listenerMetricsToReport,
+            attributesBuilder,
+            queueManager,
+            pcfMessageAgent,
+            metricWriteHelper);
+    classUnderTest = new ListenerMetricsCollector(context, metricCreator);
+    classUnderTest.publishMetrics();
+    verify(metricWriteHelper, times(2)).transformAndPrintMetrics(pathCaptor.capture());
 
-        List<List<Metric>> allValues = pathCaptor.getAllValues();
-        assertThat(allValues).hasSize(2);
-        assertThat(allValues.get(0)).hasSize(1);
-        assertThat(allValues.get(1)).hasSize(1);
+    List<List<Metric>> allValues = pathCaptor.getAllValues();
+    assertThat(allValues).hasSize(2);
+    assertThat(allValues.get(0)).hasSize(1);
+    assertThat(allValues.get(1)).hasSize(1);
 
-        assertThatMetric(allValues.get(0).get(0))
-                .hasName("Status")
-                .hasPath("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Listeners|DEV.DEFAULT.LISTENER.TCP|Status")
-                .hasValue("2")
-                .withPropertiesMatching(standardPropsForAlias("Status"));
+    assertThatMetric(allValues.get(0).get(0))
+        .hasName("Status")
+        .hasPath(
+            "Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Listeners|DEV.DEFAULT.LISTENER.TCP|Status")
+        .hasValue("2")
+        .withPropertiesMatching(standardPropsForAlias("Status"));
 
-        assertThatMetric(allValues.get(1).get(0))
-                .hasName("Status")
-                .hasPath("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Listeners|DEV.LISTENER.TCP|Status")
-                .hasValue("3")
-                .withPropertiesMatching(standardPropsForAlias("Status"));
-    }
+    assertThatMetric(allValues.get(1).get(0))
+        .hasName("Status")
+        .hasPath(
+            "Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Listeners|DEV.LISTENER.TCP|Status")
+        .hasValue("3")
+        .withPropertiesMatching(standardPropsForAlias("Status"));
+  }
 
-    /*
-        Request
-        PCFMessage:
-        MQCFH [type: 1, strucLength: 36, version: 1, command: 98 (MQCMD_INQUIRE_LISTENER_STATUS), msgSeqNumber: 1, control: 1, compCode: 0, reason: 0, parameterCount: 2]
-        MQCFST [type: 4, strucLength: 24, parameter: 3554 (MQCACH_LISTENER_NAME), codedCharSetId: 0, stringLength: 1, string: *]
-        MQCFIL [type: 5, strucLength: 24, parameter: 1223 (MQIACF_LISTENER_STATUS_ATTRS), count: 2, values: {3554, 1599}]
+  /*
+     Request
+     PCFMessage:
+     MQCFH [type: 1, strucLength: 36, version: 1, command: 98 (MQCMD_INQUIRE_LISTENER_STATUS), msgSeqNumber: 1, control: 1, compCode: 0, reason: 0, parameterCount: 2]
+     MQCFST [type: 4, strucLength: 24, parameter: 3554 (MQCACH_LISTENER_NAME), codedCharSetId: 0, stringLength: 1, string: *]
+     MQCFIL [type: 5, strucLength: 24, parameter: 1223 (MQIACF_LISTENER_STATUS_ATTRS), count: 2, values: {3554, 1599}]
 
-        Response
-        PCFMessage:
-        MQCFH [type: 2, strucLength: 36, version: 1, command: 98 (MQCMD_INQUIRE_LISTENER_STATUS), msgSeqNumber: 1, control: 1, compCode: 0, reason: 0, parameterCount: 2]
-        MQCFST [type: 4, strucLength: 48, parameter: 3554 (MQCACH_LISTENER_NAME), codedCharSetId: 819, stringLength: 27, string: SYSTEM.DEFAULT.LISTENER.TCP]
-        MQCFIN [type: 3, strucLength: 16, parameter: 1599 (MQIACH_LISTENER_STATUS), value: 2]
-     */
+     Response
+     PCFMessage:
+     MQCFH [type: 2, strucLength: 36, version: 1, command: 98 (MQCMD_INQUIRE_LISTENER_STATUS), msgSeqNumber: 1, control: 1, compCode: 0, reason: 0, parameterCount: 2]
+     MQCFST [type: 4, strucLength: 48, parameter: 3554 (MQCACH_LISTENER_NAME), codedCharSetId: 819, stringLength: 27, string: SYSTEM.DEFAULT.LISTENER.TCP]
+     MQCFIN [type: 3, strucLength: 16, parameter: 1599 (MQIACH_LISTENER_STATUS), value: 2]
+  */
 
-    private PCFMessage[] createPCFResponseForInquireListenerStatusCmd() {
-        PCFMessage response1 = new PCFMessage(2, CMQCFC.MQCMD_INQUIRE_LISTENER_STATUS, 1, true);
-        response1.addParameter(CMQCFC.MQCACH_LISTENER_NAME, "DEV.DEFAULT.LISTENER.TCP");
-        response1.addParameter(CMQCFC.MQIACH_LISTENER_STATUS, 2);
+  private PCFMessage[] createPCFResponseForInquireListenerStatusCmd() {
+    PCFMessage response1 = new PCFMessage(2, CMQCFC.MQCMD_INQUIRE_LISTENER_STATUS, 1, true);
+    response1.addParameter(CMQCFC.MQCACH_LISTENER_NAME, "DEV.DEFAULT.LISTENER.TCP");
+    response1.addParameter(CMQCFC.MQIACH_LISTENER_STATUS, 2);
 
-        PCFMessage response2 = new PCFMessage(2, CMQCFC.MQCMD_INQUIRE_LISTENER_STATUS, 2, true);
-        response2.addParameter(CMQCFC.MQCACH_LISTENER_NAME, "DEV.LISTENER.TCP");
-        response2.addParameter(CMQCFC.MQIACH_LISTENER_STATUS, 3);
+    PCFMessage response2 = new PCFMessage(2, CMQCFC.MQCMD_INQUIRE_LISTENER_STATUS, 2, true);
+    response2.addParameter(CMQCFC.MQCACH_LISTENER_NAME, "DEV.LISTENER.TCP");
+    response2.addParameter(CMQCFC.MQIACH_LISTENER_STATUS, 3);
 
-        PCFMessage response3 = new PCFMessage(2, CMQCFC.MQCMD_INQUIRE_LISTENER_STATUS, 3, true);
-        response3.addParameter(CMQCFC.MQCACH_LISTENER_NAME, "SYSTEM.LISTENER.TCP");
-        response3.addParameter(CMQCFC.MQIACH_LISTENER_STATUS, 1);
+    PCFMessage response3 = new PCFMessage(2, CMQCFC.MQCMD_INQUIRE_LISTENER_STATUS, 3, true);
+    response3.addParameter(CMQCFC.MQCACH_LISTENER_NAME, "SYSTEM.LISTENER.TCP");
+    response3.addParameter(CMQCFC.MQIACH_LISTENER_STATUS, 1);
 
-        return new PCFMessage[]{response1, response2, response3};
-    }
-
+    return new PCFMessage[] {response1, response2, response3};
+  }
 }

--- a/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/MetricAssert.java
+++ b/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/MetricAssert.java
@@ -1,47 +1,60 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.appdynamics.extensions.webspheremq.metricscollector;
-
-import com.appdynamics.extensions.metrics.Metric;
-import com.appdynamics.extensions.metrics.MetricProperties;
-import org.assertj.core.api.Assertions;
-
-import java.util.function.Function;
 
 import static com.appdynamics.extensions.webspheremq.metricscollector.MetricPropertiesAssert.metricPropertiesMatching;
 
+import com.appdynamics.extensions.metrics.Metric;
+import com.appdynamics.extensions.metrics.MetricProperties;
+import java.util.function.Function;
+import org.assertj.core.api.Assertions;
+
 public class MetricAssert {
 
-    private final Metric metric;
+  private final Metric metric;
 
-    public MetricAssert(Metric metric) {
-        this.metric = metric;
-    }
+  public MetricAssert(Metric metric) {
+    this.metric = metric;
+  }
 
-    static MetricAssert assertThatMetric(Metric metric){
-        return new MetricAssert(metric);
-    }
+  static MetricAssert assertThatMetric(Metric metric) {
+    return new MetricAssert(metric);
+  }
 
-    MetricAssert hasName(String name){
-        Assertions.assertThat(metric.getMetricName()).isEqualTo(name);
-        return this;
-    }
+  MetricAssert hasName(String name) {
+    Assertions.assertThat(metric.getMetricName()).isEqualTo(name);
+    return this;
+  }
 
-    MetricAssert hasValue(String value){
-        Assertions.assertThat(metric.getMetricValue()).isEqualTo(value);
-        return this;
-    }
+  MetricAssert hasValue(String value) {
+    Assertions.assertThat(metric.getMetricValue()).isEqualTo(value);
+    return this;
+  }
 
-    MetricPropertiesAssert withPropertiesMatching(){
-        return metricPropertiesMatching(metric.getMetricProperties());
-    }
+  MetricPropertiesAssert withPropertiesMatching() {
+    return metricPropertiesMatching(metric.getMetricProperties());
+  }
 
-    MetricPropertiesAssert withPropertiesMatching(Function<MetricProperties,MetricPropertiesAssert> fn){
-        return fn.apply(metric.getMetricProperties());
-    }
+  MetricPropertiesAssert withPropertiesMatching(
+      Function<MetricProperties, MetricPropertiesAssert> fn) {
+    return fn.apply(metric.getMetricProperties());
+  }
 
-    MetricAssert hasPath(String path){
-        Assertions.assertThat(metric.getMetricPath()).isEqualTo(path);
-        return this;
-    }
-
-
+  MetricAssert hasPath(String path) {
+    Assertions.assertThat(metric.getMetricPath()).isEqualTo(path);
+    return this;
+  }
 }

--- a/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/MetricPropertiesAssert.java
+++ b/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/MetricPropertiesAssert.java
@@ -1,55 +1,77 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.appdynamics.extensions.webspheremq.metricscollector;
-
-import com.appdynamics.extensions.metrics.MetricProperties;
-
-import java.math.BigDecimal;
-import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.appdynamics.extensions.metrics.MetricProperties;
+import java.math.BigDecimal;
+import java.util.function.Function;
+
 public class MetricPropertiesAssert {
 
-    private final MetricProperties metricProperties;
+  private final MetricProperties metricProperties;
 
-    public MetricPropertiesAssert(MetricProperties metricProperties) {
-        this.metricProperties = metricProperties;
-    }
+  public MetricPropertiesAssert(MetricProperties metricProperties) {
+    this.metricProperties = metricProperties;
+  }
 
-    static MetricPropertiesAssert metricPropertiesMatching(MetricProperties props){
-        return new MetricPropertiesAssert(props);
-    }
+  static MetricPropertiesAssert metricPropertiesMatching(MetricProperties props) {
+    return new MetricPropertiesAssert(props);
+  }
 
-    MetricPropertiesAssert alias(String alias){
-        assertThat(metricProperties.getAlias()).isEqualTo(alias);
-        return this;
-    }
-    MetricPropertiesAssert multiplier(BigDecimal multiplier){
-        assertThat(metricProperties.getMultiplier()).isEqualTo(multiplier);
-        return this;
-    }
-    MetricPropertiesAssert aggregationType(String aggregationType){
-        assertThat(metricProperties.getAggregationType()).isEqualTo(aggregationType);
-        return this;
-    }
-    MetricPropertiesAssert timeRollup(String rollup){
-        assertThat(metricProperties.getTimeRollUpType()).isEqualTo(rollup);
-        return this;
-    }
-    MetricPropertiesAssert clusterRollUp(String clusterRollUp){
-        assertThat(metricProperties.getClusterRollUpType()).isEqualTo(clusterRollUp);
-        return this;
-    }
-    MetricPropertiesAssert delta(boolean delta){
-        assertThat(metricProperties.getDelta()).isEqualTo(delta);
-        return this;
-    }
+  MetricPropertiesAssert alias(String alias) {
+    assertThat(metricProperties.getAlias()).isEqualTo(alias);
+    return this;
+  }
 
-    public static Function<MetricProperties, MetricPropertiesAssert> standardPropsForAlias(String alias) {
-        return mp -> metricPropertiesMatching(mp)
-                .alias(alias)
-                .multiplier(BigDecimal.ONE)
-                .aggregationType("AVERAGE").timeRollup("AVERAGE").clusterRollUp("INDIVIDUAL")
-                .delta(false);
-    }
+  MetricPropertiesAssert multiplier(BigDecimal multiplier) {
+    assertThat(metricProperties.getMultiplier()).isEqualTo(multiplier);
+    return this;
+  }
 
+  MetricPropertiesAssert aggregationType(String aggregationType) {
+    assertThat(metricProperties.getAggregationType()).isEqualTo(aggregationType);
+    return this;
+  }
+
+  MetricPropertiesAssert timeRollup(String rollup) {
+    assertThat(metricProperties.getTimeRollUpType()).isEqualTo(rollup);
+    return this;
+  }
+
+  MetricPropertiesAssert clusterRollUp(String clusterRollUp) {
+    assertThat(metricProperties.getClusterRollUpType()).isEqualTo(clusterRollUp);
+    return this;
+  }
+
+  MetricPropertiesAssert delta(boolean delta) {
+    assertThat(metricProperties.getDelta()).isEqualTo(delta);
+    return this;
+  }
+
+  public static Function<MetricProperties, MetricPropertiesAssert> standardPropsForAlias(
+      String alias) {
+    return mp ->
+        metricPropertiesMatching(mp)
+            .alias(alias)
+            .multiplier(BigDecimal.ONE)
+            .aggregationType("AVERAGE")
+            .timeRollup("AVERAGE")
+            .clusterRollUp("INDIVIDUAL")
+            .delta(false);
+  }
 }

--- a/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/MetricsPublisherJobTest.java
+++ b/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/MetricsPublisherJobTest.java
@@ -1,51 +1,70 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.appdynamics.extensions.webspheremq.metricscollector;
-
-import com.singularity.ee.agent.systemagent.api.exception.TaskExecutionException;
-import org.junit.jupiter.api.Test;
-
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.singularity.ee.agent.systemagent.api.exception.TaskExecutionException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.Test;
+
 class MetricsPublisherJobTest {
-    @Test
-    void testSuccess() {
-        CountDownLatch latch = new CountDownLatch(1);
-        AtomicBoolean publishCalled = new AtomicBoolean(false);
-        MetricsPublisherJob job = new MetricsPublisherJob(() -> publishCalled.set(true), latch);
-        job.run();
-        assertThat(publishCalled).isTrue();
-        assertThat(latch.getCount()).isEqualTo(0);
-    }
+  @Test
+  void testSuccess() {
+    CountDownLatch latch = new CountDownLatch(1);
+    AtomicBoolean publishCalled = new AtomicBoolean(false);
+    MetricsPublisherJob job = new MetricsPublisherJob(() -> publishCalled.set(true), latch);
+    job.run();
+    assertThat(publishCalled).isTrue();
+    assertThat(latch.getCount()).isEqualTo(0);
+  }
 
-    @Test
-    void otherExceptionsLeak() {
-        CountDownLatch latch = new CountDownLatch(1);
-        AtomicBoolean publishCalled = new AtomicBoolean(false);
-        MetricsPublisherJob job = new MetricsPublisherJob(() -> {
-            publishCalled.set(true);
-            throw new IllegalStateException("Boom");
-        }, latch);
+  @Test
+  void otherExceptionsLeak() {
+    CountDownLatch latch = new CountDownLatch(1);
+    AtomicBoolean publishCalled = new AtomicBoolean(false);
+    MetricsPublisherJob job =
+        new MetricsPublisherJob(
+            () -> {
+              publishCalled.set(true);
+              throw new IllegalStateException("Boom");
+            },
+            latch);
 
-        assertThrows(IllegalStateException.class, () -> job.run());
+    assertThrows(IllegalStateException.class, () -> job.run());
 
-        assertThat(publishCalled).isTrue();
-        assertThat(latch.getCount()).isEqualTo(0);
-    }
+    assertThat(publishCalled).isTrue();
+    assertThat(latch.getCount()).isEqualTo(0);
+  }
 
-    @Test
-    void testTaskExecutionException() {
-        CountDownLatch latch = new CountDownLatch(1);
-        AtomicBoolean publishCalled = new AtomicBoolean(false);
-        MetricsPublisherJob job = new MetricsPublisherJob(() -> {
-            publishCalled.set(true);
-            throw new TaskExecutionException("Boom");
-        }, latch);
-        job.run();
-        assertThat(publishCalled).isTrue();
-        assertThat(latch.getCount()).isEqualTo(0);
-    }
-
+  @Test
+  void testTaskExecutionException() {
+    CountDownLatch latch = new CountDownLatch(1);
+    AtomicBoolean publishCalled = new AtomicBoolean(false);
+    MetricsPublisherJob job =
+        new MetricsPublisherJob(
+            () -> {
+              publishCalled.set(true);
+              throw new TaskExecutionException("Boom");
+            },
+            latch);
+    job.run();
+    assertThat(publishCalled).isTrue();
+    assertThat(latch.getCount()).isEqualTo(0);
+  }
 }

--- a/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/QueueCollectionBuddyTest.java
+++ b/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/QueueCollectionBuddyTest.java
@@ -13,8 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.appdynamics.extensions.webspheremq.metricscollector;
+
+import static com.appdynamics.extensions.webspheremq.metricscollector.MetricAssert.assertThatMetric;
+import static com.appdynamics.extensions.webspheremq.metricscollector.MetricPropertiesAssert.standardPropsForAlias;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
 
 import com.appdynamics.extensions.AMonitorJob;
 import com.appdynamics.extensions.MetricWriteHelper;
@@ -31,6 +35,9 @@ import com.ibm.mq.constants.CMQCFC;
 import com.ibm.mq.headers.pcf.PCFMessage;
 import com.ibm.mq.headers.pcf.PCFMessageAgent;
 import com.singularity.ee.agent.systemagent.api.AManagedMonitor;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -38,362 +45,398 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.CountDownLatch;
-
-import static com.appdynamics.extensions.webspheremq.metricscollector.MetricAssert.assertThatMetric;
-import static com.appdynamics.extensions.webspheremq.metricscollector.MetricPropertiesAssert.standardPropsForAlias;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
-
 @ExtendWith(MockitoExtension.class)
 public class QueueCollectionBuddyTest {
-    private QueueCollectionBuddy classUnderTest;
+  private QueueCollectionBuddy classUnderTest;
 
-    @Mock
-    private AMonitorJob aMonitorJob;
+  @Mock private AMonitorJob aMonitorJob;
 
-    @Mock
-    private PCFMessageAgent pcfMessageAgent;
+  @Mock private PCFMessageAgent pcfMessageAgent;
 
-    @Mock
-    private MetricWriteHelper metricWriteHelper;
+  @Mock private MetricWriteHelper metricWriteHelper;
 
-    @Mock
-    private CountDownLatch phaser;
+  @Mock private CountDownLatch phaser;
 
-    private MonitorContextConfiguration monitorContextConfig;
-    private Map<String, WMQMetricOverride> queueMetricsToReport;
-    private QueueManager queueManager;
-    ArgumentCaptor<List<Metric>> pathCaptor;
-    MetricCreator metricCreator;
-    MetricsCollectorContext collectorContext;
+  private MonitorContextConfiguration monitorContextConfig;
+  private Map<String, WMQMetricOverride> queueMetricsToReport;
+  private QueueManager queueManager;
+  ArgumentCaptor<List<Metric>> pathCaptor;
+  MetricCreator metricCreator;
+  MetricsCollectorContext collectorContext;
 
-    @BeforeEach
-    void setup() {
-        monitorContextConfig = new MonitorContextConfiguration("WMQMonitor", "Custom Metrics|WMQMonitor|", PathResolver.resolveDirectory(AManagedMonitor.class), aMonitorJob);
-        monitorContextConfig.setConfigYml("src/test/resources/conf/config.yml");
-        Map<String, ?> configMap = monitorContextConfig.getConfigYml();
-        ObjectMapper mapper = new ObjectMapper();
-        queueManager = mapper.convertValue(((List)configMap.get("queueManagers")).get(0), QueueManager.class);
-        Map<String, Map<String, WMQMetricOverride>> metricsMap = WMQUtil.getMetricsToReportFromConfigYml((List<Map>) configMap.get("mqMetrics"));
-        queueMetricsToReport = metricsMap.get(Constants.METRIC_TYPE_QUEUE);
-        QueueCollectorSharedState.getInstance().resetForTest();
-        pathCaptor = ArgumentCaptor.forClass(List.class);
-        metricCreator = new MetricCreator(monitorContextConfig.getMetricPrefix(), queueManager, QueueMetricsCollector.ARTIFACT);
-        collectorContext = new MetricsCollectorContext(queueMetricsToReport, queueManager, pcfMessageAgent, metricWriteHelper);
-    }
+  @BeforeEach
+  void setup() {
+    monitorContextConfig =
+        new MonitorContextConfiguration(
+            "WMQMonitor",
+            "Custom Metrics|WMQMonitor|",
+            PathResolver.resolveDirectory(AManagedMonitor.class),
+            aMonitorJob);
+    monitorContextConfig.setConfigYml("src/test/resources/conf/config.yml");
+    Map<String, ?> configMap = monitorContextConfig.getConfigYml();
+    ObjectMapper mapper = new ObjectMapper();
+    queueManager =
+        mapper.convertValue(((List) configMap.get("queueManagers")).get(0), QueueManager.class);
+    Map<String, Map<String, WMQMetricOverride>> metricsMap =
+        WMQUtil.getMetricsToReportFromConfigYml((List<Map>) configMap.get("mqMetrics"));
+    queueMetricsToReport = metricsMap.get(Constants.METRIC_TYPE_QUEUE);
+    QueueCollectorSharedState.getInstance().resetForTest();
+    pathCaptor = ArgumentCaptor.forClass(List.class);
+    metricCreator =
+        new MetricCreator(
+            monitorContextConfig.getMetricPrefix(), queueManager, QueueMetricsCollector.ARTIFACT);
+    collectorContext =
+        new MetricsCollectorContext(
+            queueMetricsToReport, queueManager, pcfMessageAgent, metricWriteHelper);
+  }
 
-    @Test
-    void testProcessPCFRequestAndPublishQMetricsForInquireQStatusCmd() throws Exception {
-        QueueCollectorSharedState sharedState = QueueCollectorSharedState.getInstance();
-        sharedState.putQueueType("AMQ.5AF1608820C7D76E","local-transmission");
-        sharedState.putQueueType("DEV.DEAD.LETTER.QUEUE","local-transmission");
-        sharedState.putQueueType("DEV.QUEUE.1","local-transmission");
-        PCFMessage request = createPCFRequestForInquireQStatusCmd();
-        when(pcfMessageAgent.send(request)).thenReturn(createPCFResponseForInquireQStatusCmd());
+  @Test
+  void testProcessPCFRequestAndPublishQMetricsForInquireQStatusCmd() throws Exception {
+    QueueCollectorSharedState sharedState = QueueCollectorSharedState.getInstance();
+    sharedState.putQueueType("AMQ.5AF1608820C7D76E", "local-transmission");
+    sharedState.putQueueType("DEV.DEAD.LETTER.QUEUE", "local-transmission");
+    sharedState.putQueueType("DEV.QUEUE.1", "local-transmission");
+    PCFMessage request = createPCFRequestForInquireQStatusCmd();
+    when(pcfMessageAgent.send(request)).thenReturn(createPCFResponseForInquireQStatusCmd());
 
-        classUnderTest = new QueueCollectionBuddy(collectorContext, sharedState, metricCreator, "MQCMD_INQUIRE_Q_STATUS");
-        classUnderTest.processPCFRequestAndPublishQMetrics(request, "*");
+    classUnderTest =
+        new QueueCollectionBuddy(
+            collectorContext, sharedState, metricCreator, "MQCMD_INQUIRE_Q_STATUS");
+    classUnderTest.processPCFRequestAndPublishQMetrics(request, "*");
 
-        verify(metricWriteHelper, times(2)).transformAndPrintMetrics(pathCaptor.capture());
+    verify(metricWriteHelper, times(2)).transformAndPrintMetrics(pathCaptor.capture());
 
-        List<List<Metric>> allValues = pathCaptor.getAllValues();
-        assertThat(allValues).hasSize(2);
-        assertThat(allValues.get(0)).hasSize(5);
-        assertThat(allValues.get(1)).hasSize(5);
+    List<List<Metric>> allValues = pathCaptor.getAllValues();
+    assertThat(allValues).hasSize(2);
+    assertThat(allValues.get(0)).hasSize(5);
+    assertThat(allValues.get(1)).hasSize(5);
 
-        verifyStatusRow(allValues.get(0), "DEV.DEAD.LETTER.QUEUE", List.of(0, -1, -1, -1, 0));
-        verifyStatusRow(allValues.get(1), "DEV.QUEUE.1", List.of(1, -1, -1, -1, 10));
-    }
+    verifyStatusRow(allValues.get(0), "DEV.DEAD.LETTER.QUEUE", List.of(0, -1, -1, -1, 0));
+    verifyStatusRow(allValues.get(1), "DEV.QUEUE.1", List.of(1, -1, -1, -1, 10));
+  }
 
-    private static void verifyStatusRow(List<Metric> metrics, String component,
-                                        List<Integer> values) {
-        assertThatMetric(metrics.get(0))
-                .hasName("CurrentQueueDepth")
-                .hasPath("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Queues|" + component + "|local-transmission|CurrentQueueDepth")
-                .hasValue(String.valueOf(values.get(0)))
-                .withPropertiesMatching(standardPropsForAlias("Current Queue Depth"));
+  private static void verifyStatusRow(
+      List<Metric> metrics, String component, List<Integer> values) {
+    assertThatMetric(metrics.get(0))
+        .hasName("CurrentQueueDepth")
+        .hasPath(
+            "Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Queues|"
+                + component
+                + "|local-transmission|CurrentQueueDepth")
+        .hasValue(String.valueOf(values.get(0)))
+        .withPropertiesMatching(standardPropsForAlias("Current Queue Depth"));
 
-        assertThatMetric(metrics.get(1))
-                .hasName("OnQTime_1")
-                .hasPath("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Queues|" + component + "|OnQTime_1")
-                .hasValue(String.valueOf(values.get(1)))
-                .withPropertiesMatching(standardPropsForAlias("OnQTime"));
+    assertThatMetric(metrics.get(1))
+        .hasName("OnQTime_1")
+        .hasPath(
+            "Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Queues|"
+                + component
+                + "|OnQTime_1")
+        .hasValue(String.valueOf(values.get(1)))
+        .withPropertiesMatching(standardPropsForAlias("OnQTime"));
 
-        assertThatMetric(metrics.get(2))
-                .hasName("OnQTime_2")
-                .hasPath("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Queues|" + component + "|OnQTime_2")
-                .hasValue(String.valueOf(values.get(2)))
-                .withPropertiesMatching(standardPropsForAlias("OnQTime"));
+    assertThatMetric(metrics.get(2))
+        .hasName("OnQTime_2")
+        .hasPath(
+            "Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Queues|"
+                + component
+                + "|OnQTime_2")
+        .hasValue(String.valueOf(values.get(2)))
+        .withPropertiesMatching(standardPropsForAlias("OnQTime"));
 
-        assertThatMetric(metrics.get(3))
-                .hasName("OldestMsgAge")
-                .hasPath("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Queues|" + component + "|local-transmission|OldestMsgAge")
-                .hasValue(String.valueOf(values.get(3)))
-                .withPropertiesMatching(standardPropsForAlias("OldestMsgAge"));
+    assertThatMetric(metrics.get(3))
+        .hasName("OldestMsgAge")
+        .hasPath(
+            "Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Queues|"
+                + component
+                + "|local-transmission|OldestMsgAge")
+        .hasValue(String.valueOf(values.get(3)))
+        .withPropertiesMatching(standardPropsForAlias("OldestMsgAge"));
 
-        assertThatMetric(metrics.get(4))
-                .hasName("UncommittedMsgs")
-                .hasPath("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Queues|" + component + "|local-transmission|UncommittedMsgs")
-                .hasValue(String.valueOf(values.get(4)))
-                .withPropertiesMatching(standardPropsForAlias("UncommittedMsgs"));
-    }
+    assertThatMetric(metrics.get(4))
+        .hasName("UncommittedMsgs")
+        .hasPath(
+            "Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Queues|"
+                + component
+                + "|local-transmission|UncommittedMsgs")
+        .hasValue(String.valueOf(values.get(4)))
+        .withPropertiesMatching(standardPropsForAlias("UncommittedMsgs"));
+  }
 
-    @Test
-    void testProcessPCFRequestAndPublishQMetricsForInquireQCmd() throws Exception {
-        PCFMessage request = createPCFRequestForInquireQCmd();
-        when(pcfMessageAgent.send(request)).thenReturn(createPCFResponseForInquireQCmd());
-        classUnderTest = new QueueCollectionBuddy(collectorContext, QueueCollectorSharedState.getInstance(), metricCreator, "MQCMD_INQUIRE_Q");
-        classUnderTest.processPCFRequestAndPublishQMetrics(request, "*");
+  @Test
+  void testProcessPCFRequestAndPublishQMetricsForInquireQCmd() throws Exception {
+    PCFMessage request = createPCFRequestForInquireQCmd();
+    when(pcfMessageAgent.send(request)).thenReturn(createPCFResponseForInquireQCmd());
+    classUnderTest =
+        new QueueCollectionBuddy(
+            collectorContext,
+            QueueCollectorSharedState.getInstance(),
+            metricCreator,
+            "MQCMD_INQUIRE_Q");
+    classUnderTest.processPCFRequestAndPublishQMetrics(request, "*");
 
-        verify(metricWriteHelper, times(2)).transformAndPrintMetrics(pathCaptor.capture());
+    verify(metricWriteHelper, times(2)).transformAndPrintMetrics(pathCaptor.capture());
 
-        List<List<Metric>> allValues = pathCaptor.getAllValues();
-        assertThat(allValues).hasSize(2);
-        assertThat(allValues.get(0)).hasSize(4);
-        assertThat(allValues.get(1)).hasSize(4);
+    List<List<Metric>> allValues = pathCaptor.getAllValues();
+    assertThat(allValues).hasSize(2);
+    assertThat(allValues.get(0)).hasSize(4);
+    assertThat(allValues.get(1)).hasSize(4);
 
-        verifyQRow(allValues.get(0), "DEV.DEAD.LETTER.QUEUE", List.of(5000, 2, 2, 2));
-        verifyQRow(allValues.get(1), "DEV.QUEUE.1", List.of(5000, 3, 3, 3));
-    }
+    verifyQRow(allValues.get(0), "DEV.DEAD.LETTER.QUEUE", List.of(5000, 2, 2, 2));
+    verifyQRow(allValues.get(1), "DEV.QUEUE.1", List.of(5000, 3, 3, 3));
+  }
 
-    private static void verifyQRow(List<Metric> metrics, String component,
-                                        List<Integer> values) {
-        assertThatMetric(metrics.get(0))
-                .hasName("MaxQueueDepth")
-                .hasPath("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Queues|" + component + "|local-transmission|MaxQueueDepth")
-                .hasValue(String.valueOf(values.get(0)))
-                .withPropertiesMatching(standardPropsForAlias("Max Queue Depth"));
+  private static void verifyQRow(List<Metric> metrics, String component, List<Integer> values) {
+    assertThatMetric(metrics.get(0))
+        .hasName("MaxQueueDepth")
+        .hasPath(
+            "Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Queues|"
+                + component
+                + "|local-transmission|MaxQueueDepth")
+        .hasValue(String.valueOf(values.get(0)))
+        .withPropertiesMatching(standardPropsForAlias("Max Queue Depth"));
 
-        assertThatMetric(metrics.get(1))
-                .hasName("CurrentQueueDepth")
-                .hasPath("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Queues|" + component + "|local-transmission|CurrentQueueDepth")
-                .hasValue(String.valueOf(values.get(1)))
-                .withPropertiesMatching(standardPropsForAlias("Current Queue Depth"));
+    assertThatMetric(metrics.get(1))
+        .hasName("CurrentQueueDepth")
+        .hasPath(
+            "Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Queues|"
+                + component
+                + "|local-transmission|CurrentQueueDepth")
+        .hasValue(String.valueOf(values.get(1)))
+        .withPropertiesMatching(standardPropsForAlias("Current Queue Depth"));
 
-        assertThatMetric(metrics.get(2))
-                .hasName("OpenInputCount")
-                .hasPath("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Queues|" + component + "|local-transmission|OpenInputCount")
-                .hasValue(String.valueOf(values.get(2)))
-                .withPropertiesMatching(standardPropsForAlias("Open Input Count"));
+    assertThatMetric(metrics.get(2))
+        .hasName("OpenInputCount")
+        .hasPath(
+            "Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Queues|"
+                + component
+                + "|local-transmission|OpenInputCount")
+        .hasValue(String.valueOf(values.get(2)))
+        .withPropertiesMatching(standardPropsForAlias("Open Input Count"));
 
-        assertThatMetric(metrics.get(3))
-                .hasName("OpenOutputCount")
-                .hasPath("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Queues|" + component + "|local-transmission|OpenOutputCount")
-                .hasValue(String.valueOf(values.get(3)))
-                .withPropertiesMatching(standardPropsForAlias("Open Output Count"));
-    }
+    assertThatMetric(metrics.get(3))
+        .hasName("OpenOutputCount")
+        .hasPath(
+            "Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Queues|"
+                + component
+                + "|local-transmission|OpenOutputCount")
+        .hasValue(String.valueOf(values.get(3)))
+        .withPropertiesMatching(standardPropsForAlias("Open Output Count"));
+  }
 
-    @Test
-    void testProcessPCFRequestAndPublishQMetricsForResetQStatsCmd() throws Exception {
-        QueueCollectorSharedState sharedState = QueueCollectorSharedState.getInstance();
-        sharedState.putQueueType("AMQ.5AF1608820C7D76E","local-transmission");
-        sharedState.putQueueType("DEV.DEAD.LETTER.QUEUE","local-transmission");
-        sharedState.putQueueType("DEV.QUEUE.1","local-transmission");
-        PCFMessage request = createPCFRequestForResetQStatsCmd();
-        when(pcfMessageAgent.send(request)).thenReturn(createPCFResponseForResetQStatsCmd());
-        classUnderTest = new QueueCollectionBuddy(collectorContext, sharedState, metricCreator, "MQCMD_RESET_Q_STATUS");
-        classUnderTest.processPCFRequestAndPublishQMetrics(request, "*");
+  @Test
+  void testProcessPCFRequestAndPublishQMetricsForResetQStatsCmd() throws Exception {
+    QueueCollectorSharedState sharedState = QueueCollectorSharedState.getInstance();
+    sharedState.putQueueType("AMQ.5AF1608820C7D76E", "local-transmission");
+    sharedState.putQueueType("DEV.DEAD.LETTER.QUEUE", "local-transmission");
+    sharedState.putQueueType("DEV.QUEUE.1", "local-transmission");
+    PCFMessage request = createPCFRequestForResetQStatsCmd();
+    when(pcfMessageAgent.send(request)).thenReturn(createPCFResponseForResetQStatsCmd());
+    classUnderTest =
+        new QueueCollectionBuddy(
+            collectorContext, sharedState, metricCreator, "MQCMD_RESET_Q_STATUS");
+    classUnderTest.processPCFRequestAndPublishQMetrics(request, "*");
 
-        verify(metricWriteHelper, times(1)).transformAndPrintMetrics(pathCaptor.capture());
+    verify(metricWriteHelper, times(1)).transformAndPrintMetrics(pathCaptor.capture());
 
-        List<List<Metric>> allValues = pathCaptor.getAllValues();
-        assertThat(allValues).hasSize(1);
-        assertThat(allValues.get(0)).hasSize(3);
+    List<List<Metric>> allValues = pathCaptor.getAllValues();
+    assertThat(allValues).hasSize(1);
+    assertThat(allValues.get(0)).hasSize(3);
 
-        assertThatMetric(allValues.get(0).get(0))
-                .hasName("HighQDepth")
-                .hasPath("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Queues|DEV.DEAD.LETTER.QUEUE|local-transmission|HighQDepth")
-                .hasValue("10")
-                .withPropertiesMatching(standardPropsForAlias("HighQDepth"));
+    assertThatMetric(allValues.get(0).get(0))
+        .hasName("HighQDepth")
+        .hasPath(
+            "Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Queues|DEV.DEAD.LETTER.QUEUE|local-transmission|HighQDepth")
+        .hasValue("10")
+        .withPropertiesMatching(standardPropsForAlias("HighQDepth"));
 
-        assertThatMetric(allValues.get(0).get(1))
-                .hasName("MsgDeqCount")
-                .hasPath("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Queues|DEV.DEAD.LETTER.QUEUE|local-transmission|MsgDeqCount")
-                .hasValue("0")
-                .withPropertiesMatching(standardPropsForAlias("MsgDeqCount"));
+    assertThatMetric(allValues.get(0).get(1))
+        .hasName("MsgDeqCount")
+        .hasPath(
+            "Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Queues|DEV.DEAD.LETTER.QUEUE|local-transmission|MsgDeqCount")
+        .hasValue("0")
+        .withPropertiesMatching(standardPropsForAlias("MsgDeqCount"));
 
-        assertThatMetric(allValues.get(0).get(2))
-                .hasName("MsgEnqCount")
-                .hasPath("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Queues|DEV.DEAD.LETTER.QUEUE|local-transmission|MsgEnqCount")
-                .hasValue("3")
-                .withPropertiesMatching(standardPropsForAlias("MsgEnqCount"));
-    }
+    assertThatMetric(allValues.get(0).get(2))
+        .hasName("MsgEnqCount")
+        .hasPath(
+            "Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Queues|DEV.DEAD.LETTER.QUEUE|local-transmission|MsgEnqCount")
+        .hasValue("3")
+        .withPropertiesMatching(standardPropsForAlias("MsgEnqCount"));
+  }
 
-    /*
-        PCFMessage:
-        MQCFH [type: 1, strucLength: 36, version: 1, command: 41 (MQCMD_INQUIRE_Q_STATUS), msgSeqNumber: 1, control: 1, compCode: 0, reason: 0, parameterCount: 2]
-        MQCFST [type: 4, strucLength: 24, parameter: 2016 (MQCA_Q_NAME), codedCharSetId: 0, stringLength: 1, string: *]
-        MQCFIL [type: 5, strucLength: 32, parameter: 1026 (MQIACF_Q_STATUS_ATTRS), count: 4, values: {2016, 1226, 1227, 1027}]
-    */
-    private PCFMessage createPCFRequestForInquireQStatusCmd() {
-        PCFMessage request = new PCFMessage(CMQCFC.MQCMD_INQUIRE_Q_STATUS);
-        request.addParameter(CMQC.MQCA_Q_NAME, "*");
-        request.addParameter(CMQCFC.MQIACF_Q_STATUS_ATTRS, new int[]{2016, 1226, 1227, 1027});
-        return request;
-    }
+  /*
+      PCFMessage:
+      MQCFH [type: 1, strucLength: 36, version: 1, command: 41 (MQCMD_INQUIRE_Q_STATUS), msgSeqNumber: 1, control: 1, compCode: 0, reason: 0, parameterCount: 2]
+      MQCFST [type: 4, strucLength: 24, parameter: 2016 (MQCA_Q_NAME), codedCharSetId: 0, stringLength: 1, string: *]
+      MQCFIL [type: 5, strucLength: 32, parameter: 1026 (MQIACF_Q_STATUS_ATTRS), count: 4, values: {2016, 1226, 1227, 1027}]
+  */
+  private PCFMessage createPCFRequestForInquireQStatusCmd() {
+    PCFMessage request = new PCFMessage(CMQCFC.MQCMD_INQUIRE_Q_STATUS);
+    request.addParameter(CMQC.MQCA_Q_NAME, "*");
+    request.addParameter(CMQCFC.MQIACF_Q_STATUS_ATTRS, new int[] {2016, 1226, 1227, 1027});
+    return request;
+  }
 
-    /*
-        0 = {PCFMessage@6026} "PCFMessage:
-        MQCFH [type: 2, strucLength: 36, version: 2, command: 41 (MQCMD_INQUIRE_Q_STATUS), msgSeqNumber: 1, control: 0, compCode: 0, reason: 0, parameterCount: 6]
-        MQCFST [type: 4, strucLength: 68, parameter: 2016 (MQCA_Q_NAME), codedCharSetId: 819, stringLength: 48, string: AMQ.5AF1608820C7D76E                            ]
-        MQCFIN [type: 3, strucLength: 16, parameter: 1103 (MQIACF_Q_STATUS_TYPE), value: 1105]
-        MQCFIN [type: 3, strucLength: 16, parameter: 3 (MQIA_CURRENT_Q_DEPTH), value: 12]
-        MQCFIN [type: 3, strucLength: 16, parameter: 1227 (MQIACF_OLDEST_MSG_AGE), value: -1]
-        MQCFIL [type: 5, strucLength: 24, parameter: 1226 (MQIACF_Q_TIME_INDICATOR), count: 2, values: {-1, -1}]
-        MQCFIN [type: 3, strucLength: 16, parameter: 1027 (MQIACF_UNCOMMITTED_MSGS), value: 0]"
+  /*
+      0 = {PCFMessage@6026} "PCFMessage:
+      MQCFH [type: 2, strucLength: 36, version: 2, command: 41 (MQCMD_INQUIRE_Q_STATUS), msgSeqNumber: 1, control: 0, compCode: 0, reason: 0, parameterCount: 6]
+      MQCFST [type: 4, strucLength: 68, parameter: 2016 (MQCA_Q_NAME), codedCharSetId: 819, stringLength: 48, string: AMQ.5AF1608820C7D76E                            ]
+      MQCFIN [type: 3, strucLength: 16, parameter: 1103 (MQIACF_Q_STATUS_TYPE), value: 1105]
+      MQCFIN [type: 3, strucLength: 16, parameter: 3 (MQIA_CURRENT_Q_DEPTH), value: 12]
+      MQCFIN [type: 3, strucLength: 16, parameter: 1227 (MQIACF_OLDEST_MSG_AGE), value: -1]
+      MQCFIL [type: 5, strucLength: 24, parameter: 1226 (MQIACF_Q_TIME_INDICATOR), count: 2, values: {-1, -1}]
+      MQCFIN [type: 3, strucLength: 16, parameter: 1027 (MQIACF_UNCOMMITTED_MSGS), value: 0]"
 
-        1 = {PCFMessage@6029} "PCFMessage:
-        MQCFH [type: 2, strucLength: 36, version: 2, command: 41 (MQCMD_INQUIRE_Q_STATUS), msgSeqNumber: 2, control: 0, compCode: 0, reason: 0, parameterCount: 6]
-        MQCFST [type: 4, strucLength: 68, parameter: 2016 (MQCA_Q_NAME), codedCharSetId: 819, stringLength: 48, string: DEV.DEAD.LETTER.QUEUE                           ]
-        MQCFIN [type: 3, strucLength: 16, parameter: 1103 (MQIACF_Q_STATUS_TYPE), value: 1105]
-        MQCFIN [type: 3, strucLength: 16, parameter: 3 (MQIA_CURRENT_Q_DEPTH), value: 0]
-        MQCFIN [type: 3, strucLength: 16, parameter: 1227 (MQIACF_OLDEST_MSG_AGE), value: -1]
-        MQCFIL [type: 5, strucLength: 24, parameter: 1226 (MQIACF_Q_TIME_INDICATOR), count: 2, values: {-1, -1}]
-        MQCFIN [type: 3, strucLength: 16, parameter: 1027 (MQIACF_UNCOMMITTED_MSGS), value: 0]"
+      1 = {PCFMessage@6029} "PCFMessage:
+      MQCFH [type: 2, strucLength: 36, version: 2, command: 41 (MQCMD_INQUIRE_Q_STATUS), msgSeqNumber: 2, control: 0, compCode: 0, reason: 0, parameterCount: 6]
+      MQCFST [type: 4, strucLength: 68, parameter: 2016 (MQCA_Q_NAME), codedCharSetId: 819, stringLength: 48, string: DEV.DEAD.LETTER.QUEUE                           ]
+      MQCFIN [type: 3, strucLength: 16, parameter: 1103 (MQIACF_Q_STATUS_TYPE), value: 1105]
+      MQCFIN [type: 3, strucLength: 16, parameter: 3 (MQIA_CURRENT_Q_DEPTH), value: 0]
+      MQCFIN [type: 3, strucLength: 16, parameter: 1227 (MQIACF_OLDEST_MSG_AGE), value: -1]
+      MQCFIL [type: 5, strucLength: 24, parameter: 1226 (MQIACF_Q_TIME_INDICATOR), count: 2, values: {-1, -1}]
+      MQCFIN [type: 3, strucLength: 16, parameter: 1027 (MQIACF_UNCOMMITTED_MSGS), value: 0]"
 
-        2 = {PCFMessage@6030} "PCFMessage:
-        MQCFH [type: 2, strucLength: 36, version: 2, command: 41 (MQCMD_INQUIRE_Q_STATUS), msgSeqNumber: 3, control: 0, compCode: 0, reason: 0, parameterCount: 6]
-        MQCFST [type: 4, strucLength: 68, parameter: 2016 (MQCA_Q_NAME), codedCharSetId: 819, stringLength: 48, string: DEV.QUEUE.1                                     ]
-        MQCFIN [type: 3, strucLength: 16, parameter: 1103 (MQIACF_Q_STATUS_TYPE), value: 1105]
-        MQCFIN [type: 3, strucLength: 16, parameter: 3 (MQIA_CURRENT_Q_DEPTH), value: 1]
-        MQCFIN [type: 3, strucLength: 16, parameter: 1227 (MQIACF_OLDEST_MSG_AGE), value: -1]
-        MQCFIL [type: 5, strucLength: 24, parameter: 1226 (MQIACF_Q_TIME_INDICATOR), count: 2, values: {-1, -1}]
-        MQCFIN [type: 3, strucLength: 16, parameter: 1027 (MQIACF_UNCOMMITTED_MSGS), value: 0]"
-    */
-    private PCFMessage[] createPCFResponseForInquireQStatusCmd() {
-        PCFMessage response1 = new PCFMessage(2, CMQCFC.MQCMD_INQUIRE_Q_STATUS, 1, false);
-        response1.addParameter(CMQC.MQCA_Q_NAME, "AMQ.5AF1608820C7D76E");
-        response1.addParameter(CMQCFC.MQIACF_Q_STATUS_TYPE, 1105);
-        response1.addParameter(CMQC.MQIA_CURRENT_Q_DEPTH, 12);
-        response1.addParameter(CMQCFC.MQIACF_OLDEST_MSG_AGE, -1);
-        response1.addParameter(CMQCFC.MQIACF_Q_TIME_INDICATOR, new int[]{-1, -1});
-        response1.addParameter(CMQCFC.MQIACF_UNCOMMITTED_MSGS, 0);
+      2 = {PCFMessage@6030} "PCFMessage:
+      MQCFH [type: 2, strucLength: 36, version: 2, command: 41 (MQCMD_INQUIRE_Q_STATUS), msgSeqNumber: 3, control: 0, compCode: 0, reason: 0, parameterCount: 6]
+      MQCFST [type: 4, strucLength: 68, parameter: 2016 (MQCA_Q_NAME), codedCharSetId: 819, stringLength: 48, string: DEV.QUEUE.1                                     ]
+      MQCFIN [type: 3, strucLength: 16, parameter: 1103 (MQIACF_Q_STATUS_TYPE), value: 1105]
+      MQCFIN [type: 3, strucLength: 16, parameter: 3 (MQIA_CURRENT_Q_DEPTH), value: 1]
+      MQCFIN [type: 3, strucLength: 16, parameter: 1227 (MQIACF_OLDEST_MSG_AGE), value: -1]
+      MQCFIL [type: 5, strucLength: 24, parameter: 1226 (MQIACF_Q_TIME_INDICATOR), count: 2, values: {-1, -1}]
+      MQCFIN [type: 3, strucLength: 16, parameter: 1027 (MQIACF_UNCOMMITTED_MSGS), value: 0]"
+  */
+  private PCFMessage[] createPCFResponseForInquireQStatusCmd() {
+    PCFMessage response1 = new PCFMessage(2, CMQCFC.MQCMD_INQUIRE_Q_STATUS, 1, false);
+    response1.addParameter(CMQC.MQCA_Q_NAME, "AMQ.5AF1608820C7D76E");
+    response1.addParameter(CMQCFC.MQIACF_Q_STATUS_TYPE, 1105);
+    response1.addParameter(CMQC.MQIA_CURRENT_Q_DEPTH, 12);
+    response1.addParameter(CMQCFC.MQIACF_OLDEST_MSG_AGE, -1);
+    response1.addParameter(CMQCFC.MQIACF_Q_TIME_INDICATOR, new int[] {-1, -1});
+    response1.addParameter(CMQCFC.MQIACF_UNCOMMITTED_MSGS, 0);
 
-        PCFMessage response2 = new PCFMessage(2, CMQCFC.MQCMD_INQUIRE_Q_STATUS, 2, false);
-        response2.addParameter(CMQC.MQCA_Q_NAME, "DEV.DEAD.LETTER.QUEUE");
-        response2.addParameter(CMQCFC.MQIACF_Q_STATUS_TYPE, 1105);
-        response2.addParameter(CMQC.MQIA_CURRENT_Q_DEPTH, 0);
-        response2.addParameter(CMQCFC.MQIACF_OLDEST_MSG_AGE, -1);
-        response2.addParameter(CMQCFC.MQIACF_Q_TIME_INDICATOR, new int[]{-1, -1});
-        response2.addParameter(CMQCFC.MQIACF_UNCOMMITTED_MSGS, 0);
+    PCFMessage response2 = new PCFMessage(2, CMQCFC.MQCMD_INQUIRE_Q_STATUS, 2, false);
+    response2.addParameter(CMQC.MQCA_Q_NAME, "DEV.DEAD.LETTER.QUEUE");
+    response2.addParameter(CMQCFC.MQIACF_Q_STATUS_TYPE, 1105);
+    response2.addParameter(CMQC.MQIA_CURRENT_Q_DEPTH, 0);
+    response2.addParameter(CMQCFC.MQIACF_OLDEST_MSG_AGE, -1);
+    response2.addParameter(CMQCFC.MQIACF_Q_TIME_INDICATOR, new int[] {-1, -1});
+    response2.addParameter(CMQCFC.MQIACF_UNCOMMITTED_MSGS, 0);
 
-        PCFMessage response3 = new PCFMessage(2, CMQCFC.MQCMD_INQUIRE_Q_STATUS, 1, false);
-        response3.addParameter(CMQC.MQCA_Q_NAME, "DEV.QUEUE.1");
-        response3.addParameter(CMQCFC.MQIACF_Q_STATUS_TYPE, 1105);
-        response3.addParameter(CMQC.MQIA_CURRENT_Q_DEPTH, 1);
-        response3.addParameter(CMQCFC.MQIACF_OLDEST_MSG_AGE, -1);
-        response3.addParameter(CMQCFC.MQIACF_Q_TIME_INDICATOR, new int[]{-1, -1});
-        response3.addParameter(CMQCFC.MQIACF_UNCOMMITTED_MSGS, 10);
+    PCFMessage response3 = new PCFMessage(2, CMQCFC.MQCMD_INQUIRE_Q_STATUS, 1, false);
+    response3.addParameter(CMQC.MQCA_Q_NAME, "DEV.QUEUE.1");
+    response3.addParameter(CMQCFC.MQIACF_Q_STATUS_TYPE, 1105);
+    response3.addParameter(CMQC.MQIA_CURRENT_Q_DEPTH, 1);
+    response3.addParameter(CMQCFC.MQIACF_OLDEST_MSG_AGE, -1);
+    response3.addParameter(CMQCFC.MQIACF_Q_TIME_INDICATOR, new int[] {-1, -1});
+    response3.addParameter(CMQCFC.MQIACF_UNCOMMITTED_MSGS, 10);
 
-        return new PCFMessage[]{ response1, response2, response3 };
-    }
+    return new PCFMessage[] {response1, response2, response3};
+  }
 
-    /*
-        PCFMessage:
-        MQCFH [type: 1, strucLength: 36, version: 1, command: 13 (MQCMD_INQUIRE_Q), msgSeqNumber: 1, control: 1, compCode: 0, reason: 0, parameterCount: 3]
-        MQCFST [type: 4, strucLength: 24, parameter: 2016 (MQCA_Q_NAME), codedCharSetId: 0, stringLength: 1, string: *]
-        MQCFIN [type: 3, strucLength: 16, parameter: 20 (MQIA_Q_TYPE), value: 1001]
-        MQCFIL [type: 5, strucLength: 36, parameter: 1002 (MQIACF_Q_ATTRS), count: 5, values: {2016, 15, 3, 17, 18}]
-     */
-    private PCFMessage createPCFRequestForInquireQCmd() {
-        PCFMessage request = new PCFMessage(CMQCFC.MQCMD_INQUIRE_Q);
-        request.addParameter(CMQC.MQCA_Q_NAME, "*");
-        request.addParameter(CMQC.MQIA_Q_TYPE, CMQC.MQQT_ALL);
-        request.addParameter(CMQCFC.MQIACF_Q_ATTRS, new int[]{2016, 15, 3, 17, 18});
-        return request;
-    }
+  /*
+     PCFMessage:
+     MQCFH [type: 1, strucLength: 36, version: 1, command: 13 (MQCMD_INQUIRE_Q), msgSeqNumber: 1, control: 1, compCode: 0, reason: 0, parameterCount: 3]
+     MQCFST [type: 4, strucLength: 24, parameter: 2016 (MQCA_Q_NAME), codedCharSetId: 0, stringLength: 1, string: *]
+     MQCFIN [type: 3, strucLength: 16, parameter: 20 (MQIA_Q_TYPE), value: 1001]
+     MQCFIL [type: 5, strucLength: 36, parameter: 1002 (MQIACF_Q_ATTRS), count: 5, values: {2016, 15, 3, 17, 18}]
+  */
+  private PCFMessage createPCFRequestForInquireQCmd() {
+    PCFMessage request = new PCFMessage(CMQCFC.MQCMD_INQUIRE_Q);
+    request.addParameter(CMQC.MQCA_Q_NAME, "*");
+    request.addParameter(CMQC.MQIA_Q_TYPE, CMQC.MQQT_ALL);
+    request.addParameter(CMQCFC.MQIACF_Q_ATTRS, new int[] {2016, 15, 3, 17, 18});
+    return request;
+  }
 
-    /*
-        0 = {PCFMessage@6059} "PCFMessage:
-        MQCFH [type: 2, strucLength: 36, version: 1, command: 13 (MQCMD_INQUIRE_Q), msgSeqNumber: 1, control: 0, compCode: 0, reason: 0, parameterCount: 6]
-        MQCFST [type: 4, strucLength: 68, parameter: 2016 (MQCA_Q_NAME), codedCharSetId: 819, stringLength: 48, string: AMQ.5AF1608820C76D80                            ]
-        MQCFIN [type: 3, strucLength: 16, parameter: 20 (MQIA_Q_TYPE), value: 1]
-        MQCFIN [type: 3, strucLength: 16, parameter: 3 (MQIA_CURRENT_Q_DEPTH), value: 0]
-        MQCFIN [type: 3, strucLength: 16, parameter: 17 (MQIA_OPEN_INPUT_COUNT), value: 1]
-        MQCFIN [type: 3, strucLength: 16, parameter: 15 (MQIA_MAX_Q_DEPTH), value: 5000]
-        MQCFIN [type: 3, strucLength: 16, parameter: 18 (MQIA_OPEN_OUTPUT_COUNT), value: 1]"
+  /*
+     0 = {PCFMessage@6059} "PCFMessage:
+     MQCFH [type: 2, strucLength: 36, version: 1, command: 13 (MQCMD_INQUIRE_Q), msgSeqNumber: 1, control: 0, compCode: 0, reason: 0, parameterCount: 6]
+     MQCFST [type: 4, strucLength: 68, parameter: 2016 (MQCA_Q_NAME), codedCharSetId: 819, stringLength: 48, string: AMQ.5AF1608820C76D80                            ]
+     MQCFIN [type: 3, strucLength: 16, parameter: 20 (MQIA_Q_TYPE), value: 1]
+     MQCFIN [type: 3, strucLength: 16, parameter: 3 (MQIA_CURRENT_Q_DEPTH), value: 0]
+     MQCFIN [type: 3, strucLength: 16, parameter: 17 (MQIA_OPEN_INPUT_COUNT), value: 1]
+     MQCFIN [type: 3, strucLength: 16, parameter: 15 (MQIA_MAX_Q_DEPTH), value: 5000]
+     MQCFIN [type: 3, strucLength: 16, parameter: 18 (MQIA_OPEN_OUTPUT_COUNT), value: 1]"
 
-        1 = {PCFMessage@6060} "PCFMessage:
-        MQCFH [type: 2, strucLength: 36, version: 1, command: 13 (MQCMD_INQUIRE_Q), msgSeqNumber: 2, control: 0, compCode: 0, reason: 0, parameterCount: 6]
-        MQCFST [type: 4, strucLength: 68, parameter: 2016 (MQCA_Q_NAME), codedCharSetId: 819, stringLength: 48, string: DEV.DEAD.LETTER.QUEUE                           ]
-        MQCFIN [type: 3, strucLength: 16, parameter: 20 (MQIA_Q_TYPE), value: 1]
-        MQCFIN [type: 3, strucLength: 16, parameter: 3 (MQIA_CURRENT_Q_DEPTH), value: 0]
-        MQCFIN [type: 3, strucLength: 16, parameter: 17 (MQIA_OPEN_INPUT_COUNT), value: 0]
-        MQCFIN [type: 3, strucLength: 16, parameter: 15 (MQIA_MAX_Q_DEPTH), value: 5000]
-        MQCFIN [type: 3, strucLength: 16, parameter: 18 (MQIA_OPEN_OUTPUT_COUNT), value: 0]"
+     1 = {PCFMessage@6060} "PCFMessage:
+     MQCFH [type: 2, strucLength: 36, version: 1, command: 13 (MQCMD_INQUIRE_Q), msgSeqNumber: 2, control: 0, compCode: 0, reason: 0, parameterCount: 6]
+     MQCFST [type: 4, strucLength: 68, parameter: 2016 (MQCA_Q_NAME), codedCharSetId: 819, stringLength: 48, string: DEV.DEAD.LETTER.QUEUE                           ]
+     MQCFIN [type: 3, strucLength: 16, parameter: 20 (MQIA_Q_TYPE), value: 1]
+     MQCFIN [type: 3, strucLength: 16, parameter: 3 (MQIA_CURRENT_Q_DEPTH), value: 0]
+     MQCFIN [type: 3, strucLength: 16, parameter: 17 (MQIA_OPEN_INPUT_COUNT), value: 0]
+     MQCFIN [type: 3, strucLength: 16, parameter: 15 (MQIA_MAX_Q_DEPTH), value: 5000]
+     MQCFIN [type: 3, strucLength: 16, parameter: 18 (MQIA_OPEN_OUTPUT_COUNT), value: 0]"
 
-        2 = {PCFMessage@6061} "PCFMessage:
-        MQCFH [type: 2, strucLength: 36, version: 1, command: 13 (MQCMD_INQUIRE_Q), msgSeqNumber: 3, control: 0, compCode: 0, reason: 0, parameterCount: 6]
-        MQCFST [type: 4, strucLength: 68, parameter: 2016 (MQCA_Q_NAME), codedCharSetId: 819, stringLength: 48, string: DEV.QUEUE.1                                     ]
-        MQCFIN [type: 3, strucLength: 16, parameter: 20 (MQIA_Q_TYPE), value: 1]
-        MQCFIN [type: 3, strucLength: 16, parameter: 3 (MQIA_CURRENT_Q_DEPTH), value: 0]
-        MQCFIN [type: 3, strucLength: 16, parameter: 17 (MQIA_OPEN_INPUT_COUNT), value: 0]
-        MQCFIN [type: 3, strucLength: 16, parameter: 15 (MQIA_MAX_Q_DEPTH), value: 5000]
-        MQCFIN [type: 3, strucLength: 16, parameter: 18 (MQIA_OPEN_OUTPUT_COUNT), value: 0]"
-     */
+     2 = {PCFMessage@6061} "PCFMessage:
+     MQCFH [type: 2, strucLength: 36, version: 1, command: 13 (MQCMD_INQUIRE_Q), msgSeqNumber: 3, control: 0, compCode: 0, reason: 0, parameterCount: 6]
+     MQCFST [type: 4, strucLength: 68, parameter: 2016 (MQCA_Q_NAME), codedCharSetId: 819, stringLength: 48, string: DEV.QUEUE.1                                     ]
+     MQCFIN [type: 3, strucLength: 16, parameter: 20 (MQIA_Q_TYPE), value: 1]
+     MQCFIN [type: 3, strucLength: 16, parameter: 3 (MQIA_CURRENT_Q_DEPTH), value: 0]
+     MQCFIN [type: 3, strucLength: 16, parameter: 17 (MQIA_OPEN_INPUT_COUNT), value: 0]
+     MQCFIN [type: 3, strucLength: 16, parameter: 15 (MQIA_MAX_Q_DEPTH), value: 5000]
+     MQCFIN [type: 3, strucLength: 16, parameter: 18 (MQIA_OPEN_OUTPUT_COUNT), value: 0]"
+  */
 
-    private PCFMessage[] createPCFResponseForInquireQCmd() {
-        PCFMessage response1 = new PCFMessage(2, CMQCFC.MQCMD_INQUIRE_Q, 1, false);
-        response1.addParameter(CMQC.MQCA_Q_NAME, "AMQ.5AF1608820C76D80");
-        response1.addParameter(CMQC.MQIA_Q_TYPE, 1);
-        response1.addParameter(CMQC.MQIA_CURRENT_Q_DEPTH, 1);
-        response1.addParameter(CMQC.MQIA_OPEN_INPUT_COUNT, 1);
-        response1.addParameter(CMQC.MQIA_MAX_Q_DEPTH, 5000);
-        response1.addParameter(CMQC.MQIA_OPEN_OUTPUT_COUNT, 1);
-        response1.addParameter(CMQC.MQIA_USAGE, CMQC.MQUS_NORMAL);
+  private PCFMessage[] createPCFResponseForInquireQCmd() {
+    PCFMessage response1 = new PCFMessage(2, CMQCFC.MQCMD_INQUIRE_Q, 1, false);
+    response1.addParameter(CMQC.MQCA_Q_NAME, "AMQ.5AF1608820C76D80");
+    response1.addParameter(CMQC.MQIA_Q_TYPE, 1);
+    response1.addParameter(CMQC.MQIA_CURRENT_Q_DEPTH, 1);
+    response1.addParameter(CMQC.MQIA_OPEN_INPUT_COUNT, 1);
+    response1.addParameter(CMQC.MQIA_MAX_Q_DEPTH, 5000);
+    response1.addParameter(CMQC.MQIA_OPEN_OUTPUT_COUNT, 1);
+    response1.addParameter(CMQC.MQIA_USAGE, CMQC.MQUS_NORMAL);
 
-        PCFMessage response2 = new PCFMessage(2, CMQCFC.MQCMD_INQUIRE_Q, 2, false);
-        response2.addParameter(CMQC.MQCA_Q_NAME, "DEV.DEAD.LETTER.QUEUE");
-        response2.addParameter(CMQC.MQIA_Q_TYPE, 1);
-        response2.addParameter(CMQC.MQIA_CURRENT_Q_DEPTH, 2);
-        response2.addParameter(CMQC.MQIA_OPEN_INPUT_COUNT, 2);
-        response2.addParameter(CMQC.MQIA_MAX_Q_DEPTH, 5000);
-        response2.addParameter(CMQC.MQIA_OPEN_OUTPUT_COUNT, 2);
-        response2.addParameter(CMQC.MQIA_USAGE, CMQC.MQUS_TRANSMISSION);
+    PCFMessage response2 = new PCFMessage(2, CMQCFC.MQCMD_INQUIRE_Q, 2, false);
+    response2.addParameter(CMQC.MQCA_Q_NAME, "DEV.DEAD.LETTER.QUEUE");
+    response2.addParameter(CMQC.MQIA_Q_TYPE, 1);
+    response2.addParameter(CMQC.MQIA_CURRENT_Q_DEPTH, 2);
+    response2.addParameter(CMQC.MQIA_OPEN_INPUT_COUNT, 2);
+    response2.addParameter(CMQC.MQIA_MAX_Q_DEPTH, 5000);
+    response2.addParameter(CMQC.MQIA_OPEN_OUTPUT_COUNT, 2);
+    response2.addParameter(CMQC.MQIA_USAGE, CMQC.MQUS_TRANSMISSION);
 
-        PCFMessage response3 = new PCFMessage(2, CMQCFC.MQCMD_INQUIRE_Q, 3, false);
-        response3.addParameter(CMQC.MQCA_Q_NAME, "DEV.QUEUE.1");
-        response3.addParameter(CMQC.MQIA_Q_TYPE, 1);
-        response3.addParameter(CMQC.MQIA_CURRENT_Q_DEPTH, 3);
-        response3.addParameter(CMQC.MQIA_OPEN_INPUT_COUNT, 3);
-        response3.addParameter(CMQC.MQIA_MAX_Q_DEPTH, 5000);
-        response3.addParameter(CMQC.MQIA_OPEN_OUTPUT_COUNT, 3);
-        response3.addParameter(CMQC.MQIA_USAGE, CMQC.MQUS_TRANSMISSION);
+    PCFMessage response3 = new PCFMessage(2, CMQCFC.MQCMD_INQUIRE_Q, 3, false);
+    response3.addParameter(CMQC.MQCA_Q_NAME, "DEV.QUEUE.1");
+    response3.addParameter(CMQC.MQIA_Q_TYPE, 1);
+    response3.addParameter(CMQC.MQIA_CURRENT_Q_DEPTH, 3);
+    response3.addParameter(CMQC.MQIA_OPEN_INPUT_COUNT, 3);
+    response3.addParameter(CMQC.MQIA_MAX_Q_DEPTH, 5000);
+    response3.addParameter(CMQC.MQIA_OPEN_OUTPUT_COUNT, 3);
+    response3.addParameter(CMQC.MQIA_USAGE, CMQC.MQUS_TRANSMISSION);
 
-        return new PCFMessage[]{ response1, response2, response3 };
-    }
+    return new PCFMessage[] {response1, response2, response3};
+  }
 
-    /*
-        PCFMessage:
-        MQCFH [type: 1, strucLength: 36, version: 1, command: 17 (MQCMD_RESET_Q_STATS), msgSeqNumber: 1, control: 1, compCode: 0, reason: 0, parameterCount: 1]
-        MQCFST [type: 4, strucLength: 24, parameter: 2016 (MQCA_Q_NAME), codedCharSetId: 0, stringLength: 1, string: *]
-     */
-    private PCFMessage createPCFRequestForResetQStatsCmd() {
-        PCFMessage request = new PCFMessage(CMQCFC.MQCMD_RESET_Q_STATS);
-        request.addParameter(CMQC.MQCA_Q_NAME, "*");
-        return request;
-    }
+  /*
+     PCFMessage:
+     MQCFH [type: 1, strucLength: 36, version: 1, command: 17 (MQCMD_RESET_Q_STATS), msgSeqNumber: 1, control: 1, compCode: 0, reason: 0, parameterCount: 1]
+     MQCFST [type: 4, strucLength: 24, parameter: 2016 (MQCA_Q_NAME), codedCharSetId: 0, stringLength: 1, string: *]
+  */
+  private PCFMessage createPCFRequestForResetQStatsCmd() {
+    PCFMessage request = new PCFMessage(CMQCFC.MQCMD_RESET_Q_STATS);
+    request.addParameter(CMQC.MQCA_Q_NAME, "*");
+    return request;
+  }
 
-    /*
-        0 = {PCFMessage@6144} "PCFMessage:
-        MQCFH [type: 2, strucLength: 36, version: 1, command: 17 (MQCMD_RESET_Q_STATS), msgSeqNumber: 1, control: 0, compCode: 0, reason: 0, parameterCount: 5]
-        MQCFST [type: 4, strucLength: 68, parameter: 2016 (MQCA_Q_NAME), codedCharSetId: 819, stringLength: 48, string: DEV.DEAD.LETTER.QUEUE                           ]
-        MQCFIN [type: 3, strucLength: 16, parameter: 37 (MQIA_MSG_ENQ_COUNT), value: 0]
-        MQCFIN [type: 3, strucLength: 16, parameter: 38 (MQIA_MSG_DEQ_COUNT), value: 0]
-        MQCFIN [type: 3, strucLength: 16, parameter: 36 (MQIA_HIGH_Q_DEPTH), value: 0]
-        MQCFIN [type: 3, strucLength: 16, parameter: 35 (MQIA_TIME_SINCE_RESET), value: 65]"
-     */
-    private PCFMessage[] createPCFResponseForResetQStatsCmd() {
-        PCFMessage response1 = new PCFMessage(2, CMQCFC.MQCMD_RESET_Q_STATS, 1, false);
-        response1.addParameter(CMQC.MQCA_Q_NAME, "DEV.DEAD.LETTER.QUEUE");
-        response1.addParameter(CMQC.MQIA_MSG_ENQ_COUNT, 3);
-        response1.addParameter(CMQC.MQIA_MSG_DEQ_COUNT, 0);
-        response1.addParameter(CMQC.MQIA_HIGH_Q_DEPTH, 10);
-        response1.addParameter(CMQC.MQIA_TIME_SINCE_RESET, 65);
+  /*
+     0 = {PCFMessage@6144} "PCFMessage:
+     MQCFH [type: 2, strucLength: 36, version: 1, command: 17 (MQCMD_RESET_Q_STATS), msgSeqNumber: 1, control: 0, compCode: 0, reason: 0, parameterCount: 5]
+     MQCFST [type: 4, strucLength: 68, parameter: 2016 (MQCA_Q_NAME), codedCharSetId: 819, stringLength: 48, string: DEV.DEAD.LETTER.QUEUE                           ]
+     MQCFIN [type: 3, strucLength: 16, parameter: 37 (MQIA_MSG_ENQ_COUNT), value: 0]
+     MQCFIN [type: 3, strucLength: 16, parameter: 38 (MQIA_MSG_DEQ_COUNT), value: 0]
+     MQCFIN [type: 3, strucLength: 16, parameter: 36 (MQIA_HIGH_Q_DEPTH), value: 0]
+     MQCFIN [type: 3, strucLength: 16, parameter: 35 (MQIA_TIME_SINCE_RESET), value: 65]"
+  */
+  private PCFMessage[] createPCFResponseForResetQStatsCmd() {
+    PCFMessage response1 = new PCFMessage(2, CMQCFC.MQCMD_RESET_Q_STATS, 1, false);
+    response1.addParameter(CMQC.MQCA_Q_NAME, "DEV.DEAD.LETTER.QUEUE");
+    response1.addParameter(CMQC.MQIA_MSG_ENQ_COUNT, 3);
+    response1.addParameter(CMQC.MQIA_MSG_DEQ_COUNT, 0);
+    response1.addParameter(CMQC.MQIA_HIGH_Q_DEPTH, 10);
+    response1.addParameter(CMQC.MQIA_TIME_SINCE_RESET, 65);
 
-        return new PCFMessage[]{ response1 };
-    }
+    return new PCFMessage[] {response1};
+  }
 }

--- a/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/QueueManagerMetricsCollectorTest.java
+++ b/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/QueueManagerMetricsCollectorTest.java
@@ -13,8 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.appdynamics.extensions.webspheremq.metricscollector;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
 
 import com.appdynamics.extensions.AMonitorJob;
 import com.appdynamics.extensions.MetricWriteHelper;
@@ -32,145 +34,153 @@ import com.ibm.mq.constants.CMQCFC;
 import com.ibm.mq.headers.pcf.PCFMessage;
 import com.ibm.mq.headers.pcf.PCFMessageAgent;
 import com.singularity.ee.agent.systemagent.api.AManagedMonitor;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.CountDownLatch;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class QueueManagerMetricsCollectorTest {
 
-    QueueManagerMetricsCollector classUnderTest;
+  QueueManagerMetricsCollector classUnderTest;
 
-    @Mock
-    AMonitorJob aMonitorJob;
+  @Mock AMonitorJob aMonitorJob;
 
-    @Mock
-    PCFMessageAgent pcfMessageAgent;
+  @Mock PCFMessageAgent pcfMessageAgent;
 
-    @Mock
-    MetricWriteHelper metricWriteHelper;
+  @Mock MetricWriteHelper metricWriteHelper;
 
-    MonitorContextConfiguration monitorContextConfig;
-    Map<String, WMQMetricOverride> queueMgrMetricsToReport;
-    QueueManager queueManager;
-    ArgumentCaptor<List> pathCaptor;
-    MetricCreator metricCreator;
-    MetricsCollectorContext context;
+  MonitorContextConfiguration monitorContextConfig;
+  Map<String, WMQMetricOverride> queueMgrMetricsToReport;
+  QueueManager queueManager;
+  ArgumentCaptor<List> pathCaptor;
+  MetricCreator metricCreator;
+  MetricsCollectorContext context;
 
-    @BeforeEach
-    public void setup() {
-        monitorContextConfig = new MonitorContextConfiguration("WMQMonitor", "Custom Metrics|WMQMonitor|", PathResolver.resolveDirectory(AManagedMonitor.class), aMonitorJob);
-        monitorContextConfig.setConfigYml("src/test/resources/conf/config.yml");
-        Map<String, ?> configMap = monitorContextConfig.getConfigYml();
-        ObjectMapper mapper = new ObjectMapper();
-        queueManager = mapper.convertValue(((List) configMap.get("queueManagers")).get(0), QueueManager.class);
-        Map<String, Map<String, WMQMetricOverride>> metricsMap = WMQUtil.getMetricsToReportFromConfigYml((List<Map>) configMap.get("mqMetrics"));
-        queueMgrMetricsToReport = metricsMap.get(Constants.METRIC_TYPE_QUEUE_MANAGER);
-        pathCaptor = ArgumentCaptor.forClass(List.class);
-        metricCreator = new MetricCreator(monitorContextConfig.getMetricPrefix(), queueManager);
-        context = new MetricsCollectorContext(queueMgrMetricsToReport, queueManager, pcfMessageAgent, metricWriteHelper);
-    }
+  @BeforeEach
+  public void setup() {
+    monitorContextConfig =
+        new MonitorContextConfiguration(
+            "WMQMonitor",
+            "Custom Metrics|WMQMonitor|",
+            PathResolver.resolveDirectory(AManagedMonitor.class),
+            aMonitorJob);
+    monitorContextConfig.setConfigYml("src/test/resources/conf/config.yml");
+    Map<String, ?> configMap = monitorContextConfig.getConfigYml();
+    ObjectMapper mapper = new ObjectMapper();
+    queueManager =
+        mapper.convertValue(((List) configMap.get("queueManagers")).get(0), QueueManager.class);
+    Map<String, Map<String, WMQMetricOverride>> metricsMap =
+        WMQUtil.getMetricsToReportFromConfigYml((List<Map>) configMap.get("mqMetrics"));
+    queueMgrMetricsToReport = metricsMap.get(Constants.METRIC_TYPE_QUEUE_MANAGER);
+    pathCaptor = ArgumentCaptor.forClass(List.class);
+    metricCreator = new MetricCreator(monitorContextConfig.getMetricPrefix(), queueManager);
+    context =
+        new MetricsCollectorContext(
+            queueMgrMetricsToReport, queueManager, pcfMessageAgent, metricWriteHelper);
+  }
 
-    @Test
-    public void testProcessPCFRequestAndPublishQMetricsForInquireQStatusCmd() throws Exception {
-        CountDownLatch latch = mock(CountDownLatch.class);
-        when(pcfMessageAgent.send(any(PCFMessage.class))).thenReturn(createPCFResponseForInquireQMgrStatusCmd());
-        classUnderTest = new QueueManagerMetricsCollector(context, metricCreator);
-        classUnderTest.publishMetrics();
-        verify(metricWriteHelper, times(1)).transformAndPrintMetrics(pathCaptor.capture());
-        List<String> metricPathsList = Lists.newArrayList();
-        metricPathsList.add("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QM1|Status");
+  @Test
+  public void testProcessPCFRequestAndPublishQMetricsForInquireQStatusCmd() throws Exception {
+    CountDownLatch latch = mock(CountDownLatch.class);
+    when(pcfMessageAgent.send(any(PCFMessage.class)))
+        .thenReturn(createPCFResponseForInquireQMgrStatusCmd());
+    classUnderTest = new QueueManagerMetricsCollector(context, metricCreator);
+    classUnderTest.publishMetrics();
+    verify(metricWriteHelper, times(1)).transformAndPrintMetrics(pathCaptor.capture());
+    List<String> metricPathsList = Lists.newArrayList();
+    metricPathsList.add("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QM1|Status");
 
-        for (List<Metric> metricList : pathCaptor.getAllValues()) {
-            for (Metric metric : metricList) {
-                if (metricPathsList.contains(metric.getMetricPath())) {
-                    if (metric.getMetricPath().equals("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QM1|Status")) {
-                        assertThat(metric.getMetricValue()).isEqualTo("2");
-                        assertThat(metric.getMetricValue()).isNotEqualTo("10");
-                    }
-                }
-            }
+    for (List<Metric> metricList : pathCaptor.getAllValues()) {
+      for (Metric metric : metricList) {
+        if (metricPathsList.contains(metric.getMetricPath())) {
+          if (metric
+              .getMetricPath()
+              .equals("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QM1|Status")) {
+            assertThat(metric.getMetricValue()).isEqualTo("2");
+            assertThat(metric.getMetricValue()).isNotEqualTo("10");
+          }
         }
+      }
     }
+  }
 
+  /*  Request
+     PCFMessage:
+     MQCFH [type: 1, strucLength: 36, version: 1, command: 161 (MQCMD_INQUIRE_Q_MGR_STATUS), msgSeqNumber: 1, control: 1, compCode: 0, reason: 0, parameterCount: 1]
+     MQCFIL [type: 5, strucLength: 20, parameter: 1229 (MQIACF_Q_MGR_STATUS_ATTRS), count: 1, values: {1009}]
 
-    /*  Request
-        PCFMessage:
-        MQCFH [type: 1, strucLength: 36, version: 1, command: 161 (MQCMD_INQUIRE_Q_MGR_STATUS), msgSeqNumber: 1, control: 1, compCode: 0, reason: 0, parameterCount: 1]
-        MQCFIL [type: 5, strucLength: 20, parameter: 1229 (MQIACF_Q_MGR_STATUS_ATTRS), count: 1, values: {1009}]
+     Response
+     PCFMessage:
+     MQCFH [type: 2, strucLength: 36, version: 1, command: 161 (MQCMD_INQUIRE_Q_MGR_STATUS), msgSeqNumber: 1, control: 1, compCode: 0, reason: 0, parameterCount: 23]
+     MQCFST [type: 4, strucLength: 68, parameter: 2015 (MQCA_Q_MGR_NAME), codedCharSetId: 819, stringLength: 48, string: QM1                                             ]
+     MQCFIN [type: 3, strucLength: 16, parameter: 1149 (MQIACF_Q_MGR_STATUS), value: 2]
+     MQCFST [type: 4, strucLength: 20, parameter: 3208 (null), codedCharSetId: 819, stringLength: 0, string: ]
+     MQCFIN [type: 3, strucLength: 16, parameter: 1416 (null), value: 0]
+     MQCFIN [type: 3, strucLength: 16, parameter: 1232 (MQIACF_CHINIT_STATUS), value: 2]
+     MQCFIN [type: 3, strucLength: 16, parameter: 1233 (MQIACF_CMD_SERVER_STATUS), value: 2]
+     MQCFIN [type: 3, strucLength: 16, parameter: 1230 (MQIACF_CONNECTION_COUNT), value: 23]
+     MQCFST [type: 4, strucLength: 20, parameter: 3071 (MQCACF_CURRENT_LOG_EXTENT_NAME), codedCharSetId: 819, stringLength: 0, string: ]
+     MQCFST [type: 4, strucLength: 20, parameter: 2115 (null), codedCharSetId: 819, stringLength: 0, string: ]
+     MQCFST [type: 4, strucLength: 36, parameter: 2116 (null), codedCharSetId: 819, stringLength: 13, string: Installation1]
+     MQCFST [type: 4, strucLength: 28, parameter: 2117 (null), codedCharSetId: 819, stringLength: 8, string: /opt/mqm]
+     MQCFIN [type: 3, strucLength: 16, parameter: 1409 (null), value: 0]
+     MQCFIN [type: 3, strucLength: 16, parameter: 1420 (null), value: 9]
+     MQCFST [type: 4, strucLength: 44, parameter: 3074 (MQCACF_LOG_PATH), codedCharSetId: 819, stringLength: 24, string: /var/mqm/log/QM1/active/]
+     MQCFIN [type: 3, strucLength: 16, parameter: 1421 (null), value: 9]
+     MQCFST [type: 4, strucLength: 20, parameter: 3073 (MQCACF_MEDIA_LOG_EXTENT_NAME), codedCharSetId: 819, stringLength: 0, string: ]
+     MQCFIN [type: 3, strucLength: 16, parameter: 1417 (null), value: 0]
+     MQCFST [type: 4, strucLength: 20, parameter: 3072 (MQCACF_RESTART_LOG_EXTENT_NAME), codedCharSetId: 819, stringLength: 0, string: ]
+     MQCFIN [type: 3, strucLength: 16, parameter: 1418 (null), value: 1]
+     MQCFIN [type: 3, strucLength: 16, parameter: 1419 (null), value: 0]
+     MQCFIN [type: 3, strucLength: 16, parameter: 1325 (null), value: 0]
+     MQCFST [type: 4, strucLength: 32, parameter: 3175 (null), codedCharSetId: 819, stringLength: 12, string: 2018-05-08  ]
+     MQCFST [type: 4, strucLength: 28, parameter: 3176 (null), codedCharSetId: 819, stringLength: 8, string: 08.32.08]
+  */
 
-        Response
-        PCFMessage:
-        MQCFH [type: 2, strucLength: 36, version: 1, command: 161 (MQCMD_INQUIRE_Q_MGR_STATUS), msgSeqNumber: 1, control: 1, compCode: 0, reason: 0, parameterCount: 23]
-        MQCFST [type: 4, strucLength: 68, parameter: 2015 (MQCA_Q_MGR_NAME), codedCharSetId: 819, stringLength: 48, string: QM1                                             ]
-        MQCFIN [type: 3, strucLength: 16, parameter: 1149 (MQIACF_Q_MGR_STATUS), value: 2]
-        MQCFST [type: 4, strucLength: 20, parameter: 3208 (null), codedCharSetId: 819, stringLength: 0, string: ]
-        MQCFIN [type: 3, strucLength: 16, parameter: 1416 (null), value: 0]
-        MQCFIN [type: 3, strucLength: 16, parameter: 1232 (MQIACF_CHINIT_STATUS), value: 2]
-        MQCFIN [type: 3, strucLength: 16, parameter: 1233 (MQIACF_CMD_SERVER_STATUS), value: 2]
-        MQCFIN [type: 3, strucLength: 16, parameter: 1230 (MQIACF_CONNECTION_COUNT), value: 23]
-        MQCFST [type: 4, strucLength: 20, parameter: 3071 (MQCACF_CURRENT_LOG_EXTENT_NAME), codedCharSetId: 819, stringLength: 0, string: ]
-        MQCFST [type: 4, strucLength: 20, parameter: 2115 (null), codedCharSetId: 819, stringLength: 0, string: ]
-        MQCFST [type: 4, strucLength: 36, parameter: 2116 (null), codedCharSetId: 819, stringLength: 13, string: Installation1]
-        MQCFST [type: 4, strucLength: 28, parameter: 2117 (null), codedCharSetId: 819, stringLength: 8, string: /opt/mqm]
-        MQCFIN [type: 3, strucLength: 16, parameter: 1409 (null), value: 0]
-        MQCFIN [type: 3, strucLength: 16, parameter: 1420 (null), value: 9]
-        MQCFST [type: 4, strucLength: 44, parameter: 3074 (MQCACF_LOG_PATH), codedCharSetId: 819, stringLength: 24, string: /var/mqm/log/QM1/active/]
-        MQCFIN [type: 3, strucLength: 16, parameter: 1421 (null), value: 9]
-        MQCFST [type: 4, strucLength: 20, parameter: 3073 (MQCACF_MEDIA_LOG_EXTENT_NAME), codedCharSetId: 819, stringLength: 0, string: ]
-        MQCFIN [type: 3, strucLength: 16, parameter: 1417 (null), value: 0]
-        MQCFST [type: 4, strucLength: 20, parameter: 3072 (MQCACF_RESTART_LOG_EXTENT_NAME), codedCharSetId: 819, stringLength: 0, string: ]
-        MQCFIN [type: 3, strucLength: 16, parameter: 1418 (null), value: 1]
-        MQCFIN [type: 3, strucLength: 16, parameter: 1419 (null), value: 0]
-        MQCFIN [type: 3, strucLength: 16, parameter: 1325 (null), value: 0]
-        MQCFST [type: 4, strucLength: 32, parameter: 3175 (null), codedCharSetId: 819, stringLength: 12, string: 2018-05-08  ]
-        MQCFST [type: 4, strucLength: 28, parameter: 3176 (null), codedCharSetId: 819, stringLength: 8, string: 08.32.08]
-     */
+  private PCFMessage[] createPCFResponseForInquireQMgrStatusCmd() {
+    PCFMessage response1 = new PCFMessage(2, CMQCFC.MQCMD_INQUIRE_Q_MGR_STATUS, 1, true);
+    response1.addParameter(CMQC.MQCA_Q_MGR_NAME, "QM1");
+    response1.addParameter(CMQCFC.MQIACF_Q_MGR_STATUS, 2);
+    response1.addParameter(CMQCFC.MQIACF_CHINIT_STATUS, 2);
+    response1.addParameter(CMQCFC.MQIACF_CMD_SERVER_STATUS, 2);
+    response1.addParameter(CMQCFC.MQIACF_CONNECTION_COUNT, 23);
+    response1.addParameter(CMQCFC.MQCACF_CURRENT_LOG_EXTENT_NAME, "");
+    response1.addParameter(CMQCFC.MQCACF_LOG_PATH, "/var/mqm/log/QM1/active/");
+    response1.addParameter(CMQCFC.MQCACF_MEDIA_LOG_EXTENT_NAME, "");
+    response1.addParameter(CMQCFC.MQCACF_RESTART_LOG_EXTENT_NAME, "");
 
-    private PCFMessage[] createPCFResponseForInquireQMgrStatusCmd() {
-        PCFMessage response1 = new PCFMessage(2, CMQCFC.MQCMD_INQUIRE_Q_MGR_STATUS, 1, true);
-        response1.addParameter(CMQC.MQCA_Q_MGR_NAME, "QM1");
-        response1.addParameter(CMQCFC.MQIACF_Q_MGR_STATUS, 2);
-        response1.addParameter(CMQCFC.MQIACF_CHINIT_STATUS, 2);
-        response1.addParameter(CMQCFC.MQIACF_CMD_SERVER_STATUS, 2);
-        response1.addParameter(CMQCFC.MQIACF_CONNECTION_COUNT, 23);
-        response1.addParameter(CMQCFC.MQCACF_CURRENT_LOG_EXTENT_NAME, "");
-        response1.addParameter(CMQCFC.MQCACF_LOG_PATH, "/var/mqm/log/QM1/active/");
-        response1.addParameter(CMQCFC.MQCACF_MEDIA_LOG_EXTENT_NAME, "");
-        response1.addParameter(CMQCFC.MQCACF_RESTART_LOG_EXTENT_NAME, "");
+    return new PCFMessage[] {response1};
+  }
 
-        return new PCFMessage[]{response1};
+  @Test
+  public void testDisplayName() throws Exception {
+    CountDownLatch latch = mock(CountDownLatch.class);
+    when(pcfMessageAgent.send(any(PCFMessage.class)))
+        .thenReturn(createPCFResponseForInquireQMgrStatusCmd());
+    classUnderTest = new QueueManagerMetricsCollector(context, metricCreator);
+    classUnderTest.publishMetrics();
+    verify(metricWriteHelper, times(1)).transformAndPrintMetrics(pathCaptor.capture());
+    List<String> metricPathsList = Lists.newArrayList();
+    for (List<Metric> metricList : pathCaptor.getAllValues()) {
+      for (Metric metric : metricList) {
+        metricPathsList.add(metric.getMetricPath());
+      }
     }
-
-    @Test
-    public void testDisplayName() throws Exception {
-        CountDownLatch latch = mock(CountDownLatch.class);
-        when(pcfMessageAgent.send(any(PCFMessage.class))).thenReturn(createPCFResponseForInquireQMgrStatusCmd());
-        classUnderTest = new QueueManagerMetricsCollector(context, metricCreator);
-        classUnderTest.publishMetrics();
-        verify(metricWriteHelper, times(1)).transformAndPrintMetrics(pathCaptor.capture());
-        List<String> metricPathsList = Lists.newArrayList();
-        for (List<Metric> metricList : pathCaptor.getAllValues()) {
-            for (Metric metric : metricList) {
-                metricPathsList.add(metric.getMetricPath());
-            }
-        }
-        assertThat(queueManager.getDisplayName()).isEqualTo("QueueManager1");
-        assertThat(metricPathsList).contains("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Status");
-        // NOTE: This was the old test value -- simply hacked to match the actual output. Not sure why it was different/failing
-//        assertThat(metricPathsList).contains("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QManager|Status");
-        assertThat(metricPathsList).contains("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|ConnectionCount");
-    }
-
+    assertThat(queueManager.getDisplayName()).isEqualTo("QueueManager1");
+    assertThat(metricPathsList)
+        .contains("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Status");
+    // NOTE: This was the old test value -- simply hacked to match the actual output. Not sure why
+    // it was different/failing
+    //        assertThat(metricPathsList).contains("Server|Component:Tier1|Custom
+    // Metrics|WebsphereMQ|QManager|Status");
+    assertThat(metricPathsList)
+        .contains(
+            "Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|ConnectionCount");
+  }
 }

--- a/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/TopicMetricsCollectorTest.java
+++ b/src/test/java/com/appdynamics/extensions/webspheremq/metricscollector/TopicMetricsCollectorTest.java
@@ -13,14 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package com.appdynamics.extensions.webspheremq.metricscollector;
+
+import static com.appdynamics.extensions.webspheremq.metricscollector.MetricAssert.assertThatMetric;
+import static com.appdynamics.extensions.webspheremq.metricscollector.MetricPropertiesAssert.standardPropsForAlias;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
 
 import com.appdynamics.extensions.AMonitorJob;
 import com.appdynamics.extensions.MetricWriteHelper;
 import com.appdynamics.extensions.conf.MonitorContextConfiguration;
 import com.appdynamics.extensions.metrics.Metric;
-import com.appdynamics.extensions.metrics.MetricProperties;
 import com.appdynamics.extensions.util.PathResolver;
 import com.appdynamics.extensions.webspheremq.common.Constants;
 import com.appdynamics.extensions.webspheremq.common.WMQUtil;
@@ -33,119 +36,122 @@ import com.ibm.mq.constants.CMQCFC;
 import com.ibm.mq.headers.pcf.PCFMessage;
 import com.ibm.mq.headers.pcf.PCFMessageAgent;
 import com.singularity.ee.agent.systemagent.api.AManagedMonitor;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.math.BigDecimal;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.CountDownLatch;
-import java.util.function.Function;
-
-import static com.appdynamics.extensions.webspheremq.metricscollector.MetricAssert.assertThatMetric;
-import static com.appdynamics.extensions.webspheremq.metricscollector.MetricPropertiesAssert.metricPropertiesMatching;
-import static com.appdynamics.extensions.webspheremq.metricscollector.MetricPropertiesAssert.standardPropsForAlias;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 public class TopicMetricsCollectorTest {
-    private TopicMetricsCollector classUnderTest;
+  private TopicMetricsCollector classUnderTest;
 
-    @Mock
-    private AMonitorJob aMonitorJob;
+  @Mock private AMonitorJob aMonitorJob;
 
-    @Mock
-    private PCFMessageAgent pcfMessageAgent;
+  @Mock private PCFMessageAgent pcfMessageAgent;
 
-    @Mock
-    private MetricWriteHelper metricWriteHelper;
+  @Mock private MetricWriteHelper metricWriteHelper;
 
-    private MonitorContextConfiguration monitorContextConfig;
-    private Map<String, WMQMetricOverride> topicMetricsToReport;
-    private QueueManager queueManager;
-    private ArgumentCaptor<List<Metric>> pathCaptor;
+  private MonitorContextConfiguration monitorContextConfig;
+  private Map<String, WMQMetricOverride> topicMetricsToReport;
+  private QueueManager queueManager;
+  private ArgumentCaptor<List<Metric>> pathCaptor;
 
-    @BeforeEach
-    void setup() {
-        monitorContextConfig = new MonitorContextConfiguration("WMQMonitor", "Custom Metrics|WMQMonitor|", PathResolver.resolveDirectory(AManagedMonitor.class), aMonitorJob);
-        monitorContextConfig.setConfigYml("src/test/resources/conf/config.yml");
-        Map<String, ?> configMap = monitorContextConfig.getConfigYml();
-        ObjectMapper mapper = new ObjectMapper();
-        queueManager = mapper.convertValue(((List)configMap.get("queueManagers")).get(0), QueueManager.class);
-        Map<String, Map<String, WMQMetricOverride>> metricsMap = WMQUtil.getMetricsToReportFromConfigYml((List<Map>) configMap.get("mqMetrics"));
-        topicMetricsToReport = metricsMap.get(Constants.METRIC_TYPE_TOPIC);
-        pathCaptor = ArgumentCaptor.forClass(List.class);
-    }
+  @BeforeEach
+  void setup() {
+    monitorContextConfig =
+        new MonitorContextConfiguration(
+            "WMQMonitor",
+            "Custom Metrics|WMQMonitor|",
+            PathResolver.resolveDirectory(AManagedMonitor.class),
+            aMonitorJob);
+    monitorContextConfig.setConfigYml("src/test/resources/conf/config.yml");
+    Map<String, ?> configMap = monitorContextConfig.getConfigYml();
+    ObjectMapper mapper = new ObjectMapper();
+    queueManager =
+        mapper.convertValue(((List) configMap.get("queueManagers")).get(0), QueueManager.class);
+    Map<String, Map<String, WMQMetricOverride>> metricsMap =
+        WMQUtil.getMetricsToReportFromConfigYml((List<Map>) configMap.get("mqMetrics"));
+    topicMetricsToReport = metricsMap.get(Constants.METRIC_TYPE_TOPIC);
+    pathCaptor = ArgumentCaptor.forClass(List.class);
+  }
 
-    @Test
-    void testPublishMetrics() throws Exception {
-        MetricsCollectorContext collectorContext = new MetricsCollectorContext(topicMetricsToReport, queueManager, pcfMessageAgent, metricWriteHelper);
-        JobSubmitterContext jobContext = new JobSubmitterContext(monitorContextConfig, mock(CountDownLatch.class), collectorContext);
-        classUnderTest = new TopicMetricsCollector(jobContext);
+  @Test
+  void testPublishMetrics() throws Exception {
+    MetricsCollectorContext collectorContext =
+        new MetricsCollectorContext(
+            topicMetricsToReport, queueManager, pcfMessageAgent, metricWriteHelper);
+    JobSubmitterContext jobContext =
+        new JobSubmitterContext(monitorContextConfig, mock(CountDownLatch.class), collectorContext);
+    classUnderTest = new TopicMetricsCollector(jobContext);
 
-        when(pcfMessageAgent.send(any(PCFMessage.class))).thenReturn(createPCFResponseForInquireTopicStatusCmd());
+    when(pcfMessageAgent.send(any(PCFMessage.class)))
+        .thenReturn(createPCFResponseForInquireTopicStatusCmd());
 
-        classUnderTest.publishMetrics();
-        verify(metricWriteHelper, times(2)).transformAndPrintMetrics(pathCaptor.capture());
-        List<String> metricPathsList = Lists.newArrayList();
-        metricPathsList.add("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QM1|Topics|test|PublishCount");
-        metricPathsList.add("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QM1|Topics|dev|SubscriptionCount");
-        metricPathsList.add("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QM1|Topics|system|PublishCount");
+    classUnderTest.publishMetrics();
+    verify(metricWriteHelper, times(2)).transformAndPrintMetrics(pathCaptor.capture());
+    List<String> metricPathsList = Lists.newArrayList();
+    metricPathsList.add(
+        "Server|Component:Tier1|Custom Metrics|WebsphereMQ|QM1|Topics|test|PublishCount");
+    metricPathsList.add(
+        "Server|Component:Tier1|Custom Metrics|WebsphereMQ|QM1|Topics|dev|SubscriptionCount");
+    metricPathsList.add(
+        "Server|Component:Tier1|Custom Metrics|WebsphereMQ|QM1|Topics|system|PublishCount");
 
-        List<List<Metric>> allValues = pathCaptor.getAllValues();
-        assertThat(allValues).hasSize(2);
-        assertThat(allValues.get(0)).hasSize(2);
-        assertThat(allValues.get(1)).hasSize(2);
+    List<List<Metric>> allValues = pathCaptor.getAllValues();
+    assertThat(allValues).hasSize(2);
+    assertThat(allValues.get(0)).hasSize(2);
+    assertThat(allValues.get(1)).hasSize(2);
 
-        assertThatMetric(allValues.get(0).get(0))
-                .hasName("SubscriptionCount")
-                .hasPath("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Topics|test|SubscriptionCount")
-                .hasValue("3")
-                .withPropertiesMatching(standardPropsForAlias("Subscription Count"));
+    assertThatMetric(allValues.get(0).get(0))
+        .hasName("SubscriptionCount")
+        .hasPath(
+            "Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Topics|test|SubscriptionCount")
+        .hasValue("3")
+        .withPropertiesMatching(standardPropsForAlias("Subscription Count"));
 
-        assertThatMetric(allValues.get(0).get(1))
-                .hasName("PublishCount")
-                .hasPath("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Topics|test|PublishCount")
-                .hasValue("2")
-                .withPropertiesMatching(standardPropsForAlias("Publish Count"));
+    assertThatMetric(allValues.get(0).get(1))
+        .hasName("PublishCount")
+        .hasPath(
+            "Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Topics|test|PublishCount")
+        .hasValue("2")
+        .withPropertiesMatching(standardPropsForAlias("Publish Count"));
 
-        assertThatMetric(allValues.get(1).get(0))
-                .hasName("SubscriptionCount")
-                .hasPath("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Topics|dev|SubscriptionCount")
-                .hasValue("4")
-                .withPropertiesMatching(standardPropsForAlias("Subscription Count"));
+    assertThatMetric(allValues.get(1).get(0))
+        .hasName("SubscriptionCount")
+        .hasPath(
+            "Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Topics|dev|SubscriptionCount")
+        .hasValue("4")
+        .withPropertiesMatching(standardPropsForAlias("Subscription Count"));
 
-        assertThatMetric(allValues.get(1).get(1))
-                .hasName("PublishCount")
-                .hasPath("Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Topics|dev|PublishCount")
-                .hasValue("3")
-                .withPropertiesMatching(standardPropsForAlias("Publish Count"));
-    }
+    assertThatMetric(allValues.get(1).get(1))
+        .hasName("PublishCount")
+        .hasPath(
+            "Server|Component:Tier1|Custom Metrics|WebsphereMQ|QueueManager1|Topics|dev|PublishCount")
+        .hasValue("3")
+        .withPropertiesMatching(standardPropsForAlias("Publish Count"));
+  }
 
-    private PCFMessage[] createPCFResponseForInquireTopicStatusCmd() {
-        PCFMessage response1 = new PCFMessage(2, CMQCFC.MQCMD_INQUIRE_TOPIC_STATUS, 1, false);
-        response1.addParameter(CMQC.MQCA_TOPIC_STRING, "test");
-        response1.addParameter(CMQC.MQIA_PUB_COUNT, 2);
-        response1.addParameter(CMQC.MQIA_SUB_COUNT, 3);
+  private PCFMessage[] createPCFResponseForInquireTopicStatusCmd() {
+    PCFMessage response1 = new PCFMessage(2, CMQCFC.MQCMD_INQUIRE_TOPIC_STATUS, 1, false);
+    response1.addParameter(CMQC.MQCA_TOPIC_STRING, "test");
+    response1.addParameter(CMQC.MQIA_PUB_COUNT, 2);
+    response1.addParameter(CMQC.MQIA_SUB_COUNT, 3);
 
-        PCFMessage response2 = new PCFMessage(2, CMQCFC.MQCMD_INQUIRE_TOPIC_STATUS, 2, false);
-        response2.addParameter(CMQC.MQCA_TOPIC_STRING, "dev");
-        response2.addParameter(CMQC.MQIA_PUB_COUNT, 3);
-        response2.addParameter(CMQC.MQIA_SUB_COUNT, 4);
+    PCFMessage response2 = new PCFMessage(2, CMQCFC.MQCMD_INQUIRE_TOPIC_STATUS, 2, false);
+    response2.addParameter(CMQC.MQCA_TOPIC_STRING, "dev");
+    response2.addParameter(CMQC.MQIA_PUB_COUNT, 3);
+    response2.addParameter(CMQC.MQIA_SUB_COUNT, 4);
 
-        PCFMessage response3 = new PCFMessage(2, CMQCFC.MQCMD_INQUIRE_TOPIC_STATUS, 3, false);
-        response3.addParameter(CMQC.MQCA_TOPIC_STRING, "system");
-        response3.addParameter(CMQC.MQIA_PUB_COUNT, 5);
-        response3.addParameter(CMQC.MQIA_SUB_COUNT, 6);
+    PCFMessage response3 = new PCFMessage(2, CMQCFC.MQCMD_INQUIRE_TOPIC_STATUS, 3, false);
+    response3.addParameter(CMQC.MQCA_TOPIC_STRING, "system");
+    response3.addParameter(CMQC.MQIA_PUB_COUNT, 5);
+    response3.addParameter(CMQC.MQIA_SUB_COUNT, 6);
 
-        return new PCFMessage[]{response1, response2, response3};
-    }
-
-
+    return new PCFMessage[] {response1, response2, response3};
+  }
 }


### PR DESCRIPTION
Uses the spotless maven plugin in order to get consistent code formatting. This also provides niceness like ordering imports, changing `final public` to `public final` etc. etc.

The code verification is also part of the build step, so this PR will likely fail until we can reformat all the code, which suggests a moment of repo inactivity.