### PR TITLE
Make config classes immutable

### DIFF
--- a/src/main/java/com/appdynamics/extensions/webspheremq/common/WMQUtil.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/common/WMQUtil.java
@@ -66,11 +66,15 @@ public class WMQUtil {
       Map.Entry firstEntry = (Map.Entry) metric.entrySet().iterator().next();
       String metricName = firstEntry.getKey().toString();
       Map<String, ?> metricPropsMap = (Map<String, ?>) metric.get(metricName);
-      WMQMetricOverride override = new WMQMetricOverride();
-      override.setIbmCommand((String) metricPropsMap.get("ibmCommand"));
-      override.setIbmConstant((String) metricPropsMap.get("ibmConstant"));
-      override.setMetricProperties(metricPropsMap);
-      if (override.getConstantValue() == -1) {
+
+      WMQMetricOverride override =
+          WMQMetricOverride.builder()
+              .ibmCommand((String) metricPropsMap.get("ibmCommand"))
+              .ibmConstant((String) metricPropsMap.get("ibmConstant"))
+              .metricProperties(metricPropsMap)
+              .build();
+
+      if (override.hasInvalidConstant()) {
         // Only add the metric which is valid, if constant value
         // resolutes to -1 then it is invalid.
         logger.warn(

--- a/src/main/java/com/appdynamics/extensions/webspheremq/config/WMQMetricOverride.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/config/WMQMetricOverride.java
@@ -15,7 +15,12 @@
  */
 package com.appdynamics.extensions.webspheremq.config;
 
+import static java.util.Collections.unmodifiableMap;
+
+import com.sun.istack.NotNull;
+import java.util.HashMap;
 import java.util.Map;
+import javax.annotation.concurrent.Immutable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,62 +29,91 @@ import org.slf4j.LoggerFactory;
  * functionality to specify and manage IBM constants, commands, and associated metric properties for
  * WebSphere MQ configuration.
  */
-public class WMQMetricOverride {
-
-  String ibmConstant;
-  String ibmCommand;
-  int constantValue = -1;
-  Map<String, ?> metricProperties;
+@Immutable
+public final class WMQMetricOverride {
 
   public static final Logger logger = LoggerFactory.getLogger(WMQMetricOverride.class);
+  private static final int INVALID_CONSTANT = -1;
+
+  private final String ibmConstant;
+  private final String ibmCommand;
+  private final int constantValue;
+  private final Map<String, ?> metricProperties;
+
+  private WMQMetricOverride(Builder builder, int constantValue) {
+    this.ibmCommand = builder.ibmCommand;
+    this.ibmConstant = builder.ibmConstant;
+    this.constantValue = constantValue;
+    this.metricProperties = new HashMap<>(builder.metricProperties);
+  }
 
   public String getIbmConstant() {
     return ibmConstant;
-  }
-
-  public void setIbmConstant(String ibmConstant) {
-    this.ibmConstant = ibmConstant;
   }
 
   public String getIbmCommand() {
     return ibmCommand;
   }
 
-  public Map<String, ?> getMetricProperties() {
-    return metricProperties;
-  }
-
-  public void setMetricProperties(Map<String, ?> metricProperties) {
-    this.metricProperties = metricProperties;
-  }
-
-  public void setIbmCommand(String ibmCommand) {
-    this.ibmCommand = ibmCommand;
-  }
-
   public int getConstantValue() {
-    if (constantValue == -1) {
-      int lastPacSeparatorDotIdx = getIbmConstant().lastIndexOf('.');
-      if (lastPacSeparatorDotIdx != -1) {
-        String declaredField = getIbmConstant().substring(lastPacSeparatorDotIdx + 1);
-        String classStr = getIbmConstant().substring(0, lastPacSeparatorDotIdx);
-        Class clazz;
-        try {
-          clazz = Class.forName(classStr);
-          constantValue = (Integer) clazz.getDeclaredField(declaredField).get(Integer.class);
-        } catch (Exception e) {
-          logger.warn(e.getMessage());
-          logger.warn(
-              "ibmConstant {} is not a valid constant defaulting constant value to -1",
-              getIbmConstant());
-        }
-      }
-    }
     return constantValue;
   }
 
-  public void setConstantValue(int constantValue) {
-    this.constantValue = constantValue;
+  public boolean hasInvalidConstant() {
+    return constantValue == INVALID_CONSTANT;
+  }
+
+  @NotNull
+  public Map<String, ?> getMetricProperties() {
+    return unmodifiableMap(metricProperties);
+  }
+
+  private static int computeConstantValue(String ibmConstant) {
+    int lastPacSeparatorDotIdx = ibmConstant.lastIndexOf('.');
+    if (lastPacSeparatorDotIdx == -1) {
+      return INVALID_CONSTANT;
+    }
+    String declaredField = ibmConstant.substring(lastPacSeparatorDotIdx + 1);
+    String classStr = ibmConstant.substring(0, lastPacSeparatorDotIdx);
+    try {
+      Class<?> clazz = Class.forName(classStr);
+      return (Integer) clazz.getDeclaredField(declaredField).get(Integer.class);
+    } catch (Exception e) {
+      logger.warn(e.getMessage());
+      logger.warn(
+          "ibmConstant {} is not a valid constant defaulting constant value to -1", ibmConstant);
+    }
+    return INVALID_CONSTANT;
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+    private String ibmConstant;
+    private String ibmCommand;
+    private Map<String, ?> metricProperties = new HashMap<>();
+
+    public Builder ibmConstant(String ibmConstant) {
+      this.ibmConstant = ibmConstant;
+      return this;
+    }
+
+    public Builder ibmCommand(String ibmCommand) {
+      this.ibmCommand = ibmCommand;
+      return this;
+    }
+
+    public Builder metricProperties(Map<String, ?> metricProperties) {
+      this.metricProperties = new HashMap<>(metricProperties);
+      return this;
+    }
+
+    public WMQMetricOverride build() {
+      int constantValue = computeConstantValue(ibmConstant);
+      return new WMQMetricOverride(this, constantValue);
+    }
   }
 
   @Override

--- a/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/MetricCreator.java
+++ b/src/main/java/com/appdynamics/extensions/webspheremq/metricscollector/MetricCreator.java
@@ -46,7 +46,7 @@ public final class MetricCreator {
   Metric createMetric(
       String metricName, int metricValue, WMQMetricOverride wmqOverride, String... pathElements) {
     String metricPath = getMetricsName(queueManagerName, pathElements);
-    if (wmqOverride != null && wmqOverride.getMetricProperties() != null) {
+    if (wmqOverride != null) {
       return new Metric(
           metricName, String.valueOf(metricValue), metricPath, wmqOverride.getMetricProperties());
     }


### PR DESCRIPTION
The thought of mutating a config class that is carried around for the lifecycle of the app is a bit terrifying. This cleans it up some and makes it easier to reason about and not accidentally modify.