### PR TITLE
Expose creating the queue connection

### DIFF
--- a/src/main/java/com/splunk/ibm/mq/WMQMonitorTask.java
+++ b/src/main/java/com/splunk/ibm/mq/WMQMonitorTask.java
@@ -25,7 +25,6 @@ import com.ibm.mq.MQException;
 import com.ibm.mq.MQQueueManager;
 import com.ibm.mq.headers.MQDataException;
 import com.ibm.mq.headers.pcf.PCFMessageAgent;
-import com.singularity.ee.agent.systemagent.api.exception.TaskExecutionException;
 import com.splunk.ibm.mq.common.Constants;
 import com.splunk.ibm.mq.common.WMQUtil;
 import com.splunk.ibm.mq.config.QueueManager;
@@ -50,15 +49,14 @@ import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
-import java.util.function.BiFunction;
-import java.util.function.Function;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Encapsulates all metrics collection for all artifacts related to a queue manager. */
 public class WMQMonitorTask implements AMonitorTaskRunnable {
 
-  public static final Logger logger = LoggerFactory.getLogger(WMQMonitorTask.class);
+  public static final Logger logger =
+      LoggerFactory.getLogger(WMQMonitorTask.class);
   private final QueueManager queueManager;
   private final MonitorContextConfiguration monitorContextConfig;
   private final Map<String, ?> configMap;
@@ -85,20 +83,14 @@ public class WMQMonitorTask implements AMonitorTaskRunnable {
     // manager password.
     String encryptionKey = (String) configMap.get("encryptionKey");
     try {
-      WMQContext auth = new WMQContext(queueManager, encryptionKey);
-      Hashtable env = auth.getMQEnvironment();
-      try {
-        ibmQueueManager = new MQQueueManager(queueManager.getName(), env);
-      } catch (MQException mqe) {
-        logger.error(mqe.getMessage(), mqe);
-        throw new TaskExecutionException(mqe.getMessage());
-      }
+      ibmQueueManager = createMQQueueManager(encryptionKey, queueManager);
+
       logger.debug(
           "MQQueueManager connection initiated for queueManager {} in thread {}",
           queueManagerTobeDisplayed,
           Thread.currentThread().getName());
       heartBeatMetricValue = BigDecimal.ONE;
-      agent = initPCFMesageAgent(ibmQueueManager);
+      agent = initPCFMesageAgent(this.queueManager, ibmQueueManager);
       extractAndReportMetrics(ibmQueueManager, agent);
     } catch (Exception e) {
       logger.error("Error in run of " + Thread.currentThread().getName(), e);
@@ -117,8 +109,21 @@ public class WMQMonitorTask implements AMonitorTaskRunnable {
     }
   }
 
-  private PCFMessageAgent initPCFMesageAgent(MQQueueManager ibmQueueManager) {
-    PCFMessageAgent agent = null;
+  public static MQQueueManager createMQQueueManager(
+      String encryptionKey, QueueManager queueManager) {
+    WMQContext auth = new WMQContext(queueManager, encryptionKey);
+    Hashtable env = auth.getMQEnvironment();
+    try {
+      return new MQQueueManager(queueManager.getName(), env);
+    } catch (MQException mqe) {
+      logger.error(mqe.getMessage(), mqe);
+      throw new RuntimeException(mqe.getMessage());
+    }
+  }
+
+  public static PCFMessageAgent initPCFMesageAgent(
+      QueueManager queueManager, MQQueueManager ibmQueueManager) {
+    PCFMessageAgent agent;
     try {
       if (!Strings.isNullOrEmpty(queueManager.getModelQueueName())
           && !Strings.isNullOrEmpty(queueManager.getReplyQueuePrefix())) {
@@ -144,253 +149,202 @@ public class WMQMonitorTask implements AMonitorTaskRunnable {
           Thread.currentThread().getName());
     } catch (MQDataException mqe) {
       logger.error(mqe.getMessage(), mqe);
+      throw new RuntimeException(mqe);
     }
     return agent;
   }
 
   private void extractAndReportMetrics(MQQueueManager mqQueueManager, PCFMessageAgent agent) {
-    // Step 1: Retrieve metrics from configuration
     Map<String, Map<String, WMQMetricOverride>> metricsMap =
         WMQUtil.getMetricsToReportFromConfigYml((List<Map>) configMap.get("mqMetrics"));
+
     CountDownLatch countDownLatch = new CountDownLatch(metricsMap.size());
 
-    // Step 2: Inquire each metric type
-    inquireQueueMangerMetrics(
-        metricsMap.get(Constants.METRIC_TYPE_QUEUE_MANAGER), countDownLatch, agent);
+    Map<String, WMQMetricOverride> qMgrMetricsToReport =
+        metricsMap.get(Constants.METRIC_TYPE_QUEUE_MANAGER);
+    if (qMgrMetricsToReport != null) {
+      Map<String, Map<String, WMQMetricOverride>> metricsByCommand = new HashMap<>();
+      for (String key : qMgrMetricsToReport.keySet()) {
+        WMQMetricOverride wmqOverride = qMgrMetricsToReport.get(key);
+        String cmd =
+            wmqOverride.getIbmCommand() == null
+                ? "MQCMD_INQUIRE_Q_MGR_STATUS"
+                : wmqOverride.getIbmCommand();
+        metricsByCommand.putIfAbsent(cmd, new HashMap<>());
+        metricsByCommand.get(cmd).put(key, wmqOverride);
+      }
+      Map<String, WMQMetricOverride> queueManagerMetricsToReport =
+          metricsByCommand.get("MQCMD_INQUIRE_Q_MGR_STATUS");
+      if (queueManagerMetricsToReport != null) {
+        MetricCreator metricCreator =
+            new MetricCreator(monitorContextConfig.getMetricPrefix(), queueManager);
+        MetricsCollectorContext context =
+            new MetricsCollectorContext(
+                queueManagerMetricsToReport, queueManager, agent, metricWriteHelper);
+        MetricsPublisher qMgrMetricsCollector =
+            new QueueManagerMetricsCollector(context, metricCreator);
+        Runnable job = new MetricsPublisherJob(qMgrMetricsCollector, countDownLatch);
+        monitorContextConfig
+            .getContext()
+            .getExecutorService()
+            .execute("QueueManagerMetricsCollector", job);
+      }
+      Map<String, WMQMetricOverride> inquireMetricsToReport =
+          metricsByCommand.get("MQCMD_INQUIRE_Q_MGR");
+      if (inquireMetricsToReport != null) {
+        MetricCreator metricCreator =
+            new MetricCreator(
+                monitorContextConfig.getMetricPrefix(),
+                queueManager,
+                InquireQueueManagerCmdCollector.ARTIFACT);
+        MetricsCollectorContext context =
+            new MetricsCollectorContext(
+                inquireMetricsToReport, queueManager, agent, metricWriteHelper);
+        MetricsPublisher inquireQueueMgrMetricsCollector =
+            new InquireQueueManagerCmdCollector(context, metricCreator);
+        Runnable job = new MetricsPublisherJob(inquireQueueMgrMetricsCollector, countDownLatch);
+        monitorContextConfig
+            .getContext()
+            .getExecutorService()
+            .execute("InquireQueueManagerCmdCollector", job);
+      }
+    } else {
+      logger.warn("No queue manager metrics to report");
+    }
 
-    inquireChannelMetrics(metricsMap.get(Constants.METRIC_TYPE_CHANNEL), countDownLatch, agent);
+    Map<String, WMQMetricOverride> channelMetricsToReport =
+        metricsMap.get(Constants.METRIC_TYPE_CHANNEL);
+    if (channelMetricsToReport != null) {
+      Map<String, Map<String, WMQMetricOverride>> metricsByCommand = new HashMap<>();
+      for (String key : channelMetricsToReport.keySet()) {
+        WMQMetricOverride wmqOverride = channelMetricsToReport.get(key);
+        String cmd =
+            wmqOverride.getIbmCommand() == null
+                ? "MQCMD_INQUIRE_CHANNEL_STATUS"
+                : wmqOverride.getIbmCommand();
+        metricsByCommand.putIfAbsent(cmd, new HashMap<>());
+        metricsByCommand.get(cmd).put(key, wmqOverride);
+      }
+      if (metricsByCommand.get("MQCMD_INQUIRE_CHANNEL_STATUS") != null) {
+        Map<String, WMQMetricOverride> metricsToReport =
+            metricsByCommand.get("MQCMD_INQUIRE_CHANNEL_STATUS");
+        MetricCreator metricCreator =
+            new MetricCreator(
+                monitorContextConfig.getMetricPrefix(),
+                queueManager,
+                ChannelMetricsCollector.ARTIFACT);
+        MetricsCollectorContext context =
+            new MetricsCollectorContext(metricsToReport, queueManager, agent, metricWriteHelper);
+        MetricsPublisher channelMetricsCollector =
+            new ChannelMetricsCollector(context, metricCreator);
+        Runnable job = new MetricsPublisherJob(channelMetricsCollector, countDownLatch);
+        monitorContextConfig
+            .getContext()
+            .getExecutorService()
+            .execute("ChannelMetricsCollector", job);
+      }
+      if (metricsByCommand.get("MQCMD_INQUIRE_CHANNEL") != null) {
+        MetricCreator metricCreator =
+            new MetricCreator(
+                monitorContextConfig.getMetricPrefix(),
+                queueManager,
+                InquireChannelCmdCollector.ARTIFACT);
+        Map<String, WMQMetricOverride> metricsToReport =
+            metricsByCommand.get("MQCMD_INQUIRE_CHANNEL");
+        MetricsCollectorContext context =
+            new MetricsCollectorContext(metricsToReport, queueManager, agent, metricWriteHelper);
+        MetricsPublisher inquireChannelMetricsCollector =
+            new InquireChannelCmdCollector(context, metricCreator);
+        Runnable job = new MetricsPublisherJob(inquireChannelMetricsCollector, countDownLatch);
+        monitorContextConfig
+            .getContext()
+            .getExecutorService()
+            .execute("InquireChannelCmdCollector", job);
+      }
+    } else {
+      logger.warn("No channel metrics to report");
+    }
 
-    inquireQueueMetrics(
-        metricsMap.get(Constants.METRIC_TYPE_QUEUE),
-        QueueCollectorSharedState.getInstance(),
-        countDownLatch,
-        agent);
+    Map<String, WMQMetricOverride> queueMetricsToReport =
+        metricsMap.get(Constants.METRIC_TYPE_QUEUE);
+    if (queueMetricsToReport != null) {
+      QueueCollectorSharedState sharedState = QueueCollectorSharedState.getInstance();
+      MetricsCollectorContext collectorContext =
+          new MetricsCollectorContext(queueMetricsToReport, queueManager, agent, metricWriteHelper);
+      JobSubmitterContext jobSubmitterContext =
+          new JobSubmitterContext(monitorContextConfig, countDownLatch, collectorContext);
+      MetricsPublisher queueMetricsCollector =
+          new QueueMetricsCollector(queueMetricsToReport, sharedState, jobSubmitterContext);
+      Runnable job = new MetricsPublisherJob(queueMetricsCollector, countDownLatch);
+      monitorContextConfig.getContext().getExecutorService().execute("QueueMetricsCollector", job);
+    } else {
+      logger.warn("No queue metrics to report");
+    }
 
-    inquireListenerMetrics(
-        metricsMap.get(Constants.METRIC_TYPE_LISTENER),
-        ListenerMetricsCollector::new,
-        countDownLatch,
-        agent);
+    Map<String, WMQMetricOverride> listenerMetricsToReport =
+        metricsMap.get(Constants.METRIC_TYPE_LISTENER);
+    if (listenerMetricsToReport != null) {
+      MetricCreator metricCreator =
+          new MetricCreator(
+              monitorContextConfig.getMetricPrefix(),
+              queueManager,
+              ListenerMetricsCollector.ARTIFACT);
+      MetricsCollectorContext context =
+          new MetricsCollectorContext(
+              listenerMetricsToReport, queueManager, agent, metricWriteHelper);
+      MetricsPublisher listenerMetricsCollector =
+          new ListenerMetricsCollector(context, metricCreator);
+      Runnable job = new MetricsPublisherJob(listenerMetricsCollector, countDownLatch);
+      monitorContextConfig
+          .getContext()
+          .getExecutorService()
+          .execute("ListenerMetricsCollector", job);
+    } else {
+      logger.warn("No listener metrics to report");
+    }
 
-    inquireTopicMetrics(
-        metricsMap.get(Constants.METRIC_TYPE_TOPIC),
-        TopicMetricsCollector::new,
-        countDownLatch,
-        agent);
+    Map<String, WMQMetricOverride> topicMetricsToReport =
+        metricsMap.get(Constants.METRIC_TYPE_TOPIC);
+    if (topicMetricsToReport != null) {
+      MetricsCollectorContext collectorContext =
+          new MetricsCollectorContext(topicMetricsToReport, queueManager, agent, metricWriteHelper);
+      JobSubmitterContext jobSubmitterContext =
+          new JobSubmitterContext(monitorContextConfig, countDownLatch, collectorContext);
+      MetricsPublisher topicsMetricsCollector = new TopicMetricsCollector(jobSubmitterContext);
+      Runnable job = new MetricsPublisherJob(topicsMetricsCollector, countDownLatch);
+      monitorContextConfig.getContext().getExecutorService().execute("TopicMetricsCollector", job);
+    } else {
+      logger.warn("No topic metrics to report");
+    }
 
-    inquireConfigurationMetrics(
-        metricsMap.get(Constants.METRIC_TYPE_CONFIGURATION), countDownLatch, mqQueueManager, agent);
+    Map<String, WMQMetricOverride> configurationMetricsToReport =
+        metricsMap.get(Constants.METRIC_TYPE_CONFIGURATION);
+    if (configurationMetricsToReport != null) {
+      MetricCreator metricCreator =
+          new MetricCreator(monitorContextConfig.getMetricPrefix(), queueManager);
+      ReadConfigurationEventQueueCollector configurationEventQueueCollector =
+          new ReadConfigurationEventQueueCollector(
+              configurationMetricsToReport,
+              this.monitorContextConfig,
+              agent,
+              mqQueueManager,
+              queueManager,
+              metricWriteHelper,
+              metricCreator);
+      Runnable job = new MetricsPublisherJob(configurationEventQueueCollector, countDownLatch);
+      monitorContextConfig
+          .getContext()
+          .getExecutorService()
+          .execute("ReadConfigurationEventQueueCollector", job);
+    } else {
+      logger.warn("No configuration queue metrics to report");
+    }
 
-    // Step 3: Await all jobs to complete
     try {
       countDownLatch.await();
     } catch (InterruptedException e) {
       logger.error("Error while the thread {} is waiting ", Thread.currentThread().getName(), e);
     }
-  }
-
-  private void inquireQueueMangerMetrics(
-      Map<String, WMQMetricOverride> metricsToReport,
-      CountDownLatch countDownLatch,
-      PCFMessageAgent agent) {
-    if (metricsToReport == null) {
-      logger.warn("No metrics to report for type Queue Manager.");
-      return;
-    }
-
-    Map<String, Map<String, WMQMetricOverride>> metricsByCommand =
-        groupMetricsByCommand(metricsToReport);
-
-    processMetricType(
-        metricsByCommand,
-        "MQCMD_INQUIRE_Q_MGR_STATUS",
-        QueueManagerMetricsCollector::new,
-        countDownLatch,
-        agent);
-    processMetricType(
-        metricsByCommand,
-        "MQCMD_INQUIRE_Q_MGR",
-        InquireQueueManagerCmdCollector::new,
-        countDownLatch,
-        agent);
-  }
-
-  private void inquireChannelMetrics(
-      Map<String, WMQMetricOverride> metricsToReport,
-      CountDownLatch countDownLatch,
-      PCFMessageAgent agent) {
-    if (metricsToReport == null) {
-      logger.warn("No metrics to report for type Channel.");
-      return;
-    }
-
-    Map<String, Map<String, WMQMetricOverride>> metricsByCommand =
-        groupMetricsByCommand(metricsToReport);
-
-    processMetricType(
-        metricsByCommand,
-        "MQCMD_INQUIRE_CHANNEL_STATUS",
-        ChannelMetricsCollector::new,
-        countDownLatch,
-        agent);
-    processMetricType(
-        metricsByCommand,
-        "MQCMD_INQUIRE_CHANNEL",
-        InquireChannelCmdCollector::new,
-        countDownLatch,
-        agent);
-  }
-
-  // Helper to process general metric types
-  private void processMetricType(
-      Map<String, Map<String, WMQMetricOverride>> metricsByCommand,
-      String primaryCommand,
-      BiFunction<MetricsCollectorContext, MetricCreator, MetricsPublisher>
-          primaryCollectorConstructor,
-      CountDownLatch countDownLatch,
-      PCFMessageAgent agent) {
-
-    if (metricsByCommand.containsKey(primaryCommand)) {
-      submitJob(
-          metricsByCommand.get(primaryCommand),
-          primaryCollectorConstructor,
-          primaryCommand,
-          countDownLatch,
-          agent);
-    }
-  }
-
-  // Helper to submit metrics collector jobs
-  private void submitJob(
-      Map<String, WMQMetricOverride> metrics,
-      BiFunction<MetricsCollectorContext, MetricCreator, MetricsPublisher> collectorConstructor,
-      String commandType,
-      CountDownLatch countDownLatch,
-      PCFMessageAgent agent) {
-
-    MetricCreator metricCreator =
-        new MetricCreator(monitorContextConfig.getMetricPrefix(), queueManager, commandType);
-    MetricsCollectorContext context =
-        new MetricsCollectorContext(metrics, queueManager, agent, metricWriteHelper);
-    MetricsPublisher collector = collectorConstructor.apply(context, metricCreator);
-    Runnable job = new MetricsPublisherJob(collector, countDownLatch);
-    monitorContextConfig.getContext().getExecutorService().execute(commandType, job);
-  }
-
-  // Helper to group metrics by IBM command
-  private Map<String, Map<String, WMQMetricOverride>> groupMetricsByCommand(
-      Map<String, WMQMetricOverride> metricsToReport) {
-
-    Map<String, Map<String, WMQMetricOverride>> metricsByCommand = new HashMap<>();
-    for (Map.Entry<String, WMQMetricOverride> entry : metricsToReport.entrySet()) {
-      WMQMetricOverride wmqOverride = entry.getValue();
-      String command =
-          wmqOverride.getIbmCommand() != null ? wmqOverride.getIbmCommand() : "UNKNOWN_COMMAND";
-      metricsByCommand.putIfAbsent(command, new HashMap<>());
-      metricsByCommand.get(command).put(entry.getKey(), wmqOverride);
-    }
-    return metricsByCommand;
-  }
-
-  // Inquire for queue metrics
-  private void inquireQueueMetrics(
-      Map<String, WMQMetricOverride> queueMetrics,
-      QueueCollectorSharedState sharedState,
-      CountDownLatch countDownLatch,
-      PCFMessageAgent agent) {
-
-    if (queueMetrics == null) {
-      logger.warn("No queue metrics to report");
-      return;
-    }
-
-    MetricsCollectorContext collectorContext =
-        new MetricsCollectorContext(queueMetrics, queueManager, agent, metricWriteHelper);
-    JobSubmitterContext jobSubmitterContext =
-        new JobSubmitterContext(monitorContextConfig, countDownLatch, collectorContext);
-    MetricsPublisher queueMetricsCollector =
-        new QueueMetricsCollector(queueMetrics, sharedState, jobSubmitterContext);
-    Runnable job = new MetricsPublisherJob(queueMetricsCollector, countDownLatch);
-    monitorContextConfig.getContext().getExecutorService().execute("QueueMetricsCollector", job);
-  }
-
-  // Inquire for listener metrics
-  private void inquireListenerMetrics(
-      Map<String, WMQMetricOverride> metricsToReport,
-      BiFunction<MetricsCollectorContext, MetricCreator, MetricsPublisher> collectorConstructor,
-      CountDownLatch countDownLatch,
-      PCFMessageAgent agent) {
-
-    if (metricsToReport == null) {
-      logger.warn("No metrics to report for Listener.");
-      return;
-    }
-
-    MetricsCollectorContext context =
-        new MetricsCollectorContext(metricsToReport, queueManager, agent, metricWriteHelper);
-    MetricCreator metricCreator =
-        new MetricCreator(
-            monitorContextConfig.getMetricPrefix(),
-            queueManager,
-            ListenerMetricsCollector.ARTIFACT);
-    MetricsPublisher metricsCollector = collectorConstructor.apply(context, metricCreator);
-    Runnable job = new MetricsPublisherJob(metricsCollector, countDownLatch);
-    monitorContextConfig
-        .getContext()
-        .getExecutorService()
-        .execute(ListenerMetricsCollector.ARTIFACT, job);
-  }
-
-  // Inquire for topic metrics
-  private void inquireTopicMetrics(
-      Map<String, WMQMetricOverride> metricsToReport,
-      Function<JobSubmitterContext, MetricsPublisher> collectorConstructor,
-      CountDownLatch countDownLatch,
-      PCFMessageAgent agent) {
-
-    if (metricsToReport == null) {
-      logger.warn("No metrics to report for Topic.");
-      return;
-    }
-
-    MetricsCollectorContext context =
-        new MetricsCollectorContext(metricsToReport, queueManager, agent, metricWriteHelper);
-    JobSubmitterContext jobSubmitterContext =
-        new JobSubmitterContext(monitorContextConfig, countDownLatch, context);
-    MetricsPublisher metricsCollector = collectorConstructor.apply(jobSubmitterContext);
-    Runnable job = new MetricsPublisherJob(metricsCollector, countDownLatch);
-    // not sure why the name is always 'null'.  might have to revisit
-    monitorContextConfig.getContext().getExecutorService().execute(null, job);
-  }
-
-  // Inquire configuration-specific metrics
-  private void inquireConfigurationMetrics(
-      Map<String, WMQMetricOverride> configurationMetricsToReport,
-      CountDownLatch countDownLatch,
-      MQQueueManager mqQueueManager,
-      PCFMessageAgent agent) {
-
-    if (configurationMetricsToReport == null) {
-      logger.warn("No configuration metrics to report");
-      return;
-    }
-
-    MetricCreator metricCreator =
-        new MetricCreator(monitorContextConfig.getMetricPrefix(), queueManager);
-    ReadConfigurationEventQueueCollector collector =
-        new ReadConfigurationEventQueueCollector(
-            configurationMetricsToReport,
-            monitorContextConfig,
-            agent,
-            mqQueueManager,
-            queueManager,
-            metricWriteHelper,
-            metricCreator);
-    Runnable job = new MetricsPublisherJob(collector, countDownLatch);
-    monitorContextConfig
-        .getContext()
-        .getExecutorService()
-        .execute("ConfigurationMetricsCollector", job);
   }
 
   /** Destroy the agent and disconnect from queue manager */


### PR DESCRIPTION
refactor the WMQMonitorTask methods used to create a connection to the queue for reuse in tests