### PR TITLE
Add performance events reader

### DIFF
--- a/src/integrationTest/java/com/splunk/ibm/mq/integration/tests/JakartaPutGet.java
+++ b/src/integrationTest/java/com/splunk/ibm/mq/integration/tests/JakartaPutGet.java
@@ -15,6 +15,7 @@
  */
 package com.splunk.ibm.mq.integration.tests;
 
+import com.ibm.mq.MQException;
 import com.ibm.mq.MQQueueManager;
 import com.ibm.mq.constants.CMQCFC;
 import com.ibm.mq.headers.pcf.PCFException;
@@ -31,6 +32,7 @@ import jakarta.jms.JMSConsumer;
 import jakarta.jms.JMSContext;
 import jakarta.jms.JMSException;
 import jakarta.jms.JMSProducer;
+import jakarta.jms.JMSRuntimeException;
 import jakarta.jms.TextMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,12 +61,20 @@ public class JakartaPutGet {
 
   private static final Logger logger = LoggerFactory.getLogger(JakartaPutGet.class);
 
-  public static void createQueue(QueueManager manager, String name) {
+  public static void createQueue(QueueManager manager, String name, int maxDepth) {
     MQQueueManager ibmQueueManager = WMQMonitorTask.connectToQueueManager(manager, null);
     PCFMessageAgent agent = WMQMonitorTask.initPCFMesageAgent(manager, ibmQueueManager);
     PCFMessage request = new PCFMessage(CMQCFC.MQCMD_CREATE_Q);
     request.addParameter(com.ibm.mq.constants.CMQC.MQCA_Q_NAME, name);
     request.addParameter(CMQC.MQIA_Q_TYPE, CMQC.MQQT_LOCAL);
+
+    request.addParameter(CMQC.MQIA_MAX_Q_DEPTH, maxDepth);
+    // these parameters are indicated in percentage of max depth.
+    request.addParameter(CMQC.MQIA_Q_DEPTH_HIGH_LIMIT, 75);
+    request.addParameter(CMQC.MQIA_Q_DEPTH_LOW_LIMIT, 20);
+    request.addParameter(CMQC.MQIA_Q_DEPTH_HIGH_EVENT, CMQCFC.MQEVR_ENABLED);
+    request.addParameter(CMQC.MQIA_Q_DEPTH_LOW_EVENT, CMQCFC.MQEVR_ENABLED);
+    request.addParameter(CMQC.MQIA_Q_DEPTH_MAX_EVENT, CMQCFC.MQEVR_ENABLED);
     try {
       agent.send(request);
     } catch (PCFException e) {
@@ -86,7 +96,7 @@ public class JakartaPutGet {
   public static void runPutGet(
       QueueManager manager, String queueName, int numberOfMessages, int sleepIntervalMs) {
 
-    createQueue(manager, queueName);
+    createQueue(manager, queueName, 100000);
     JMSContext context = null;
     try {
       // Create a connection factory
@@ -109,7 +119,6 @@ public class JakartaPutGet {
 
       // Create Jakarta objects
       context = cf.createContext();
-      logger.info("About to create queue {}", queueName);
       Destination destination = context.createQueue("queue:///" + queueName);
 
       for (int i = 0; i < numberOfMessages; i++) {
@@ -128,6 +137,66 @@ public class JakartaPutGet {
 
     } catch (JMSException | InterruptedException jmsex) {
       throw new RuntimeException(jmsex);
+    } finally {
+      if (context != null) {
+        context.close();
+      }
+    }
+  }
+
+  /**
+   * Send a number of messages to the queue.
+   *
+   * @param manager Queue manager configuration
+   * @param queueName Queue that the application uses to put and get messages to and from
+   * @param numberOfMessages Number of messages to send
+   */
+  public static void sendMessages(QueueManager manager, String queueName, int numberOfMessages) {
+
+    createQueue(manager, queueName, 1000);
+    JMSContext context = null;
+    try {
+      // Create a connection factory
+      JmsFactoryFactory ff = JmsFactoryFactory.getInstance(WMQConstants.JAKARTA_WMQ_PROVIDER);
+      JmsConnectionFactory cf = ff.createConnectionFactory();
+
+      // Set the properties
+      cf.setStringProperty(WMQConstants.WMQ_HOST_NAME, manager.getHost());
+      cf.setIntProperty(WMQConstants.WMQ_PORT, manager.getPort());
+      cf.setStringProperty(WMQConstants.WMQ_CHANNEL, manager.getChannelName());
+      cf.setIntProperty(WMQConstants.WMQ_CONNECTION_MODE, WMQConstants.WMQ_CM_CLIENT);
+      cf.setStringProperty(WMQConstants.WMQ_QUEUE_MANAGER, manager.getName());
+      cf.setStringProperty(WMQConstants.WMQ_APPLICATIONNAME, "Message Sender");
+      cf.setBooleanProperty(WMQConstants.USER_AUTHENTICATION_MQCSP, true);
+      cf.setStringProperty(WMQConstants.USERID, manager.getUsername());
+      cf.setStringProperty(WMQConstants.PASSWORD, manager.getPassword());
+      // cf.setStringProperty(WMQConstants.WMQ_SSL_CIPHER_SUITE, "*TLS12ORHIGHER");
+      // cf.setIntProperty(MQConstants.CERTIFICATE_VALIDATION_POLICY,
+      // MQConstants.MQ_CERT_VAL_POLICY_NONE);
+
+      // Create Jakarta objects
+      context = cf.createContext();
+      Destination destination = context.createQueue("queue:///" + queueName);
+
+      for (int i = 0; i < numberOfMessages; i++) {
+        long uniqueNumber = System.currentTimeMillis() % 1000;
+        TextMessage message =
+            context.createTextMessage("Your lucky number today is " + uniqueNumber);
+        message.setIntProperty(WMQConstants.JMS_IBM_CHARACTER_SET, 37);
+        JMSProducer producer = context.createProducer();
+        producer.send(destination, message);
+      }
+
+    } catch (JMSException e) {
+      throw new RuntimeException(e);
+    } catch (JMSRuntimeException e) {
+      if (e.getCause() instanceof MQException) {
+        MQException mqe = (MQException) e.getCause();
+        if (mqe.getReason() == 2053) { // queue is full
+          return;
+        }
+      }
+      throw new RuntimeException(e);
     } finally {
       if (context != null) {
         context.close();

--- a/src/integrationTest/java/com/splunk/ibm/mq/integration/tests/WMQMonitorIntegrationTest.java
+++ b/src/integrationTest/java/com/splunk/ibm/mq/integration/tests/WMQMonitorIntegrationTest.java
@@ -201,9 +201,6 @@ class WMQMonitorIntegrationTest {
         PeriodicMetricReader.builder(testExporter)
             .setExecutor(Executors.newScheduledThreadPool(1))
             .build();
-    SdkMeterProvider meterProvider =
-        SdkMeterProvider.builder().registerMetricReader(reader).build();
-    OpenTelemetrySdk sdk = OpenTelemetrySdk.builder().setMeterProvider(meterProvider).build();
     Map<String, SdkMeterProvider> providers = Main.createSdkMeterProviders(reader, "QM1");
     Map<String, Meter> meters = new HashMap<>();
     for (Map.Entry<String, SdkMeterProvider> e : providers.entrySet()) {

--- a/src/integrationTest/java/com/splunk/ibm/mq/integration/tests/WMQMonitorIntegrationTest.java
+++ b/src/integrationTest/java/com/splunk/ibm/mq/integration/tests/WMQMonitorIntegrationTest.java
@@ -30,18 +30,26 @@ import com.ibm.mq.pcf.CMQC;
 import com.splunk.ibm.mq.WMQMonitorTask;
 import com.splunk.ibm.mq.config.QueueManager;
 import com.splunk.ibm.mq.integration.opentelemetry.TestResultMetricExporter;
+import com.splunk.ibm.mq.opentelemetry.Main;
 import com.splunk.ibm.mq.opentelemetry.OpenTelemetryMetricWriteHelper;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.export.MetricReader;
+import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader;
 import java.io.File;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Paths;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -89,6 +97,16 @@ class WMQMonitorIntegrationTest {
     ObjectMapper mapper = new ObjectMapper();
     QueueManager qManager = mapper.convertValue(queueManagerConfig, QueueManager.class);
     configureQueueManager(qManager);
+
+    // create a queue and fill it up past its capacity.
+    JakartaPutGet.createQueue(qManager, "smallqueue", 10);
+
+    JakartaPutGet.sendMessages(qManager, "smallqueue", 1);
+    Thread.sleep(1000);
+    JakartaPutGet.sendMessages(qManager, "smallqueue", 8);
+    Thread.sleep(1000);
+    JakartaPutGet.sendMessages(qManager, "smallqueue", 5);
+
     JakartaPutGet.runPutGet(qManager, "myqueue", 10, 1);
 
     service.submit(() -> JakartaPutGet.runPutGet(qManager, "myqueue", 1000000, 100));
@@ -142,11 +160,25 @@ class WMQMonitorIntegrationTest {
   void test_monitor_with_full_config() throws Exception {
     logger.info("\n\n\n\n\n\nRunning test: test_monitor_with_full_config");
     TestResultMetricExporter testExporter = new TestResultMetricExporter();
-    MetricWriteHelper metricWriteHelper = new OpenTelemetryMetricWriteHelper(testExporter);
+    MetricReader reader =
+        PeriodicMetricReader.builder(testExporter)
+            .setExecutor(Executors.newScheduledThreadPool(1))
+            .build();
+    Map<String, SdkMeterProvider> providers = Main.createSdkMeterProviders(reader, "QM1");
+    Map<String, Meter> meters = new HashMap<>();
+    for (Map.Entry<String, SdkMeterProvider> e : providers.entrySet()) {
+      meters.put(e.getKey(), e.getValue().get("opentelemetry.io/mq"));
+    }
+    MetricWriteHelper metricWriteHelper = new OpenTelemetryMetricWriteHelper(testExporter, meters);
     String configFile = getConfigFile("conf/test-config.yml");
 
     TestWMQMonitor monitor = new TestWMQMonitor(configFile, metricWriteHelper);
     monitor.testrun();
+
+    reader.forceFlush().join(5, TimeUnit.SECONDS);
+    for (SdkMeterProvider provider : providers.values()) {
+      provider.close();
+    }
     List<MetricData> data = testExporter.getExportedMetrics();
     Set<String> metricNames = new HashSet<>();
     for (MetricData metricData : data) {
@@ -154,13 +186,30 @@ class WMQMonitorIntegrationTest {
     }
     // this value is read from the configuration queue.
     assertThat(metricNames).contains("mq.manager.max.handles");
+    // this value is read from the performance event queue.
+    assertThat(metricNames).contains("mq.queue.depth.full.event");
+    // this value is read from the performance event queue.
+    assertThat(metricNames).contains("mq.queue.depth.high.event");
+    assertThat(metricNames).contains("mq.queue.depth.low.event");
   }
 
   @Test
   void test_wmqmonitor() throws Exception {
     logger.info("\n\n\n\n\n\nRunning test: test_wmqmonitor");
     TestResultMetricExporter testExporter = new TestResultMetricExporter();
-    MetricWriteHelper metricWriteHelper = new OpenTelemetryMetricWriteHelper(testExporter);
+    MetricReader reader =
+        PeriodicMetricReader.builder(testExporter)
+            .setExecutor(Executors.newScheduledThreadPool(1))
+            .build();
+    SdkMeterProvider meterProvider =
+        SdkMeterProvider.builder().registerMetricReader(reader).build();
+    OpenTelemetrySdk sdk = OpenTelemetrySdk.builder().setMeterProvider(meterProvider).build();
+    Map<String, SdkMeterProvider> providers = Main.createSdkMeterProviders(reader, "QM1");
+    Map<String, Meter> meters = new HashMap<>();
+    for (Map.Entry<String, SdkMeterProvider> e : providers.entrySet()) {
+      meters.put(e.getKey(), e.getValue().get("opentelemetry.io/mq"));
+    }
+    MetricWriteHelper metricWriteHelper = new OpenTelemetryMetricWriteHelper(testExporter, meters);
     String configFile = getConfigFile("conf/test-queuemgr-config.yml");
 
     TestWMQMonitor monitor = new TestWMQMonitor(configFile, metricWriteHelper);

--- a/src/integrationTest/resources/conf/test-config.yml
+++ b/src/integrationTest/resources/conf/test-config.yml
@@ -329,6 +329,9 @@ mqMetrics:
             alias: "Max Handles"
             ibmConstant: "com.ibm.mq.constants.CMQC.MQIA_MAX_HANDLES"
 
+  # Sets up reading performance events from the performance events queue.
+  - metricsType: "performanceMetrics"
+
 #Run it as a scheduled task instead of running every minute.
 #If you want to run this every minute, comment this out
 #taskSchedule:

--- a/src/main/java/com/splunk/ibm/mq/WMQMonitorTask.java
+++ b/src/main/java/com/splunk/ibm/mq/WMQMonitorTask.java
@@ -413,8 +413,7 @@ public class WMQMonitorTask implements AMonitorTaskRunnable {
 
   // Inquire performance-specific metrics
   private void inquirePerformanceMetrics(
-      CountDownLatch countDownLatch,
-      MQQueueManager mqQueueManager) {
+      CountDownLatch countDownLatch, MQQueueManager mqQueueManager) {
 
     PerformanceEventQueueCollector collector =
         new PerformanceEventQueueCollector(mqQueueManager, queueManager, metricWriteHelper);

--- a/src/main/java/com/splunk/ibm/mq/WMQMonitorTask.java
+++ b/src/main/java/com/splunk/ibm/mq/WMQMonitorTask.java
@@ -197,8 +197,7 @@ public class WMQMonitorTask implements AMonitorTaskRunnable {
     inquireConfigurationMetrics(
         metricsMap.get(Constants.METRIC_TYPE_CONFIGURATION), countDownLatch, mqQueueManager, agent);
 
-    inquirePerformanceMetrics(
-        metricsMap.get(Constants.METRIC_TYPE_PERFORMANCE), countDownLatch, mqQueueManager, agent);
+    inquirePerformanceMetrics(countDownLatch, mqQueueManager);
 
     // Step 3: Await all jobs to complete
     try {
@@ -414,13 +413,9 @@ public class WMQMonitorTask implements AMonitorTaskRunnable {
 
   // Inquire performance-specific metrics
   private void inquirePerformanceMetrics(
-      Map<String, WMQMetricOverride> performanceMetricsToReport,
       CountDownLatch countDownLatch,
-      MQQueueManager mqQueueManager,
-      PCFMessageAgent agent) {
+      MQQueueManager mqQueueManager) {
 
-    MetricCreator metricCreator =
-        new MetricCreator(monitorContextConfig.getMetricPrefix(), queueManager);
     PerformanceEventQueueCollector collector =
         new PerformanceEventQueueCollector(mqQueueManager, queueManager, metricWriteHelper);
     Runnable job = new MetricsPublisherJob(collector, countDownLatch);

--- a/src/main/java/com/splunk/ibm/mq/common/Constants.java
+++ b/src/main/java/com/splunk/ibm/mq/common/Constants.java
@@ -22,6 +22,7 @@ public class Constants {
   public static final String METRIC_TYPE_LISTENER = "listenerMetrics";
   public static final String METRIC_TYPE_TOPIC = "topicMetrics";
   public static final String METRIC_TYPE_CONFIGURATION = "configurationMetrics";
+  public static final String METRIC_TYPE_PERFORMANCE = "performanceMetrics";
 
   public static final String TRANSPORT_TYPE_CLIENT = "Client";
   public static final String TRANSPORT_TYPE_BINGINGS = "Bindings";

--- a/src/main/java/com/splunk/ibm/mq/common/WMQUtil.java
+++ b/src/main/java/com/splunk/ibm/mq/common/WMQUtil.java
@@ -19,6 +19,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
 import com.splunk.ibm.mq.config.QueueManager;
 import com.splunk.ibm.mq.config.WMQMetricOverride;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.slf4j.Logger;
@@ -47,7 +48,10 @@ public class WMQUtil {
     //
     for (Map mqMetric : mqMetrics) {
       String metricType = (String) mqMetric.get("metricsType");
-      List includeMetrics = (List) ((Map) mqMetric.get("metrics")).get("include");
+      List includeMetrics =
+          mqMetric.get("metrics") == null
+              ? Collections.emptyList()
+              : (List) ((Map) mqMetric.get("metrics")).get("include");
       Map<String, WMQMetricOverride> metricToReport = Maps.newHashMap();
       if (includeMetrics != null) {
         metricToReport = gatherMetricNamesByApplyingIncludeFilter(includeMetrics);

--- a/src/main/java/com/splunk/ibm/mq/config/QueueManager.java
+++ b/src/main/java/com/splunk/ibm/mq/config/QueueManager.java
@@ -36,8 +36,10 @@ public class QueueManager {
   private String replyQueuePrefix;
   private String modelQueueName;
   private String configurationQueueName = "SYSTEM.ADMIN.CONFIG.EVENT";
+  private String performanceEventsQueueName = "SYSTEM.ADMIN.PERFM.EVENT";
   private long consumeConfigurationEventInterval;
   private boolean refreshQueueManagerConfigurationEnabled;
+  private long consumePerformanceEventInterval;
 
   private ResourceFilters queueFilters;
   private ResourceFilters channelFilters;
@@ -249,5 +251,13 @@ public class QueueManager {
   public void setRefreshQueueManagerConfigurationEnabled(
       boolean refreshQueueManagerConfigurationEnabled) {
     this.refreshQueueManagerConfigurationEnabled = refreshQueueManagerConfigurationEnabled;
+  }
+
+  public String getPerformanceEventsQueueName() {
+    return performanceEventsQueueName;
+  }
+
+  public void setPerformanceEventsQueueName(String performanceEventsQueueName) {
+    this.performanceEventsQueueName = performanceEventsQueueName;
   }
 }

--- a/src/main/java/com/splunk/ibm/mq/metricscollector/PerformanceEventQueueCollector.java
+++ b/src/main/java/com/splunk/ibm/mq/metricscollector/PerformanceEventQueueCollector.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.splunk.ibm.mq.metricscollector;
+
+import com.appdynamics.extensions.MetricWriteHelper;
+import com.appdynamics.extensions.logging.ExtensionsLoggerFactory;
+import com.ibm.mq.MQException;
+import com.ibm.mq.MQGetMessageOptions;
+import com.ibm.mq.MQMessage;
+import com.ibm.mq.MQQueue;
+import com.ibm.mq.MQQueueManager;
+import com.ibm.mq.constants.CMQC;
+import com.ibm.mq.constants.MQConstants;
+import com.ibm.mq.headers.pcf.PCFMessage;
+import com.splunk.ibm.mq.config.QueueManager;
+import com.splunk.ibm.mq.opentelemetry.OpenTelemetryMetricWriteHelper;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.LongCounter;
+import java.io.IOException;
+import org.slf4j.Logger;
+
+public final class PerformanceEventQueueCollector implements MetricsPublisher {
+
+  private static final Logger logger =
+      ExtensionsLoggerFactory.getLogger(PerformanceEventQueueCollector.class);
+  private final OpenTelemetryMetricWriteHelper metricWriteHelper;
+  private final QueueManager queueManager;
+  private final MQQueueManager mqQueueManager;
+  private final LongCounter fullQueueDepthCounter;
+  private final LongCounter highQueueDepthCounter;
+  private final LongCounter lowQueueDepthCounter;
+
+  public PerformanceEventQueueCollector(
+      MQQueueManager mqQueueManager,
+      QueueManager queueManager,
+      MetricWriteHelper metricWriteHelper) {
+    if (!(metricWriteHelper instanceof OpenTelemetryMetricWriteHelper)) {
+      throw new IllegalArgumentException(
+          "metricWriteHelper is not an instance of OpenTelemetryMetricWriteHelper");
+    }
+    this.mqQueueManager = mqQueueManager;
+    this.queueManager = queueManager;
+    this.metricWriteHelper = (OpenTelemetryMetricWriteHelper) metricWriteHelper;
+    this.fullQueueDepthCounter =
+        this.metricWriteHelper
+            .getMeter(queueManager.getName())
+            .counterBuilder("mq.queue.depth.full.event")
+            .setUnit("1")
+            .build();
+    this.highQueueDepthCounter =
+        this.metricWriteHelper
+            .getMeter(queueManager.getName())
+            .counterBuilder("mq.queue.depth.high.event")
+            .setUnit("1")
+            .build();
+    this.lowQueueDepthCounter =
+        this.metricWriteHelper
+            .getMeter(queueManager.getName())
+            .counterBuilder("mq.queue.depth.low.event")
+            .setUnit("1")
+            .build();
+  }
+
+  private void readEvents(String performanceEventsQueueName) throws Exception {
+
+    MQQueue queue = null;
+    try {
+      int queueAccessOptions = MQConstants.MQOO_FAIL_IF_QUIESCING | MQConstants.MQOO_INPUT_SHARED;
+      queue = mqQueueManager.accessQueue(performanceEventsQueueName, queueAccessOptions);
+      // keep going until receiving the exception MQConstants.MQRC_NO_MSG_AVAILABLE
+      while (true) {
+        try {
+          MQGetMessageOptions getOptions = new MQGetMessageOptions();
+          getOptions.options = MQConstants.MQGMO_NO_WAIT | MQConstants.MQGMO_FAIL_IF_QUIESCING;
+          MQMessage message = new MQMessage();
+
+          queue.get(message, getOptions);
+          PCFMessage received = new PCFMessage(message);
+          switch (received.getReason()) {
+            case CMQC.MQRC_Q_FULL:
+              {
+                String queueName = received.getStringParameterValue(CMQC.MQCA_BASE_OBJECT_NAME);
+                fullQueueDepthCounter.add(
+                    1, Attributes.of(AttributeKey.stringKey("queue.name"), queueName));
+              }
+              break;
+            case CMQC.MQRC_Q_DEPTH_HIGH:
+              {
+                String queueName = received.getStringParameterValue(CMQC.MQCA_BASE_OBJECT_NAME);
+                highQueueDepthCounter.add(
+                    1, Attributes.of(AttributeKey.stringKey("queue.name"), queueName));
+              }
+              break;
+            case CMQC.MQRC_Q_DEPTH_LOW:
+              {
+                String queueName = received.getStringParameterValue(CMQC.MQCA_BASE_OBJECT_NAME);
+                lowQueueDepthCounter.add(
+                    1, Attributes.of(AttributeKey.stringKey("queue.name"), queueName));
+              }
+              break;
+            default:
+              logger.debug("Unknown event reason {}", received.getReason());
+          }
+
+        } catch (MQException e) {
+          if (e.reasonCode != MQConstants.MQRC_NO_MSG_AVAILABLE) {
+            logger.error(e.getMessage(), e);
+          }
+          break;
+        } catch (IOException e) {
+          logger.error(e.getMessage(), e);
+          break;
+        }
+      }
+    } finally {
+      if (queue != null) {
+        queue.close();
+      }
+    }
+  }
+
+  @Override
+  public void publishMetrics() {
+    long entryTime = System.currentTimeMillis();
+    String performanceEventsQueueName = this.queueManager.getPerformanceEventsQueueName();
+    logger.info(
+        "sending PCF agent request to read performance events from queue {}",
+        performanceEventsQueueName);
+    try {
+      readEvents(performanceEventsQueueName);
+    } catch (Exception e) {
+      logger.error(
+          "Unexpected Error occurred while collecting performance events for queue "
+              + performanceEventsQueueName,
+          e);
+    }
+    long exitTime = System.currentTimeMillis() - entryTime;
+    logger.debug(
+        "Time taken to publish metrics for performance events is {} milliseconds", exitTime);
+  }
+}

--- a/src/main/java/com/splunk/ibm/mq/metricscollector/ReadConfigurationEventQueueCollector.java
+++ b/src/main/java/com/splunk/ibm/mq/metricscollector/ReadConfigurationEventQueueCollector.java
@@ -17,7 +17,6 @@ package com.splunk.ibm.mq.metricscollector;
 
 import com.appdynamics.extensions.MetricWriteHelper;
 import com.appdynamics.extensions.conf.MonitorContextConfiguration;
-import com.appdynamics.extensions.logging.ExtensionsLoggerFactory;
 import com.appdynamics.extensions.metrics.Metric;
 import com.google.common.collect.Lists;
 import com.ibm.mq.MQException;
@@ -37,11 +36,12 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class ReadConfigurationEventQueueCollector implements MetricsPublisher {
 
   private static final Logger logger =
-      ExtensionsLoggerFactory.getLogger(ReadConfigurationEventQueueCollector.class);
+      LoggerFactory.getLogger(ReadConfigurationEventQueueCollector.class);
   private final MetricWriteHelper metricWriteHelper;
   private final QueueManager queueManager;
   private final PCFMessageAgent agent;

--- a/src/main/java/com/splunk/ibm/mq/metricscollector/ReadConfigurationEventQueueCollector.java
+++ b/src/main/java/com/splunk/ibm/mq/metricscollector/ReadConfigurationEventQueueCollector.java
@@ -175,19 +175,4 @@ public final class ReadConfigurationEventQueueCollector implements MetricsPublis
     logger.debug(
         "Time taken to publish metrics for configuration events is {} milliseconds", exitTime);
   }
-
-  private String getMetricsName(String qmNameToBeDisplayed, String... pathelements) {
-    StringBuilder pathBuilder =
-        new StringBuilder(monitorContextConfig.getMetricPrefix())
-            .append("|")
-            .append(qmNameToBeDisplayed)
-            .append("|");
-    for (int i = 0; i < pathelements.length; i++) {
-      pathBuilder.append(pathelements[i]);
-      if (i != pathelements.length - 1) {
-        pathBuilder.append("|");
-      }
-    }
-    return pathBuilder.toString();
-  }
 }

--- a/src/main/java/com/splunk/ibm/mq/opentelemetry/Main.java
+++ b/src/main/java/com/splunk/ibm/mq/opentelemetry/Main.java
@@ -20,9 +20,20 @@ import com.appdynamics.extensions.yml.YmlReader;
 import com.singularity.ee.agent.systemagent.api.TaskExecutionContext;
 import com.singularity.ee.agent.systemagent.api.exception.TaskExecutionException;
 import com.splunk.ibm.mq.WMQMonitor;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporter;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.export.MetricReader;
+import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader;
+import io.opentelemetry.sdk.resources.Resource;
 import java.io.File;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -38,14 +49,6 @@ public class Main {
 
     String configFile = args[0];
     Map<String, ?> config = YmlReader.readFromFileAsMap(new File(configFile));
-
-    Config.setUpSSLConnection(config);
-
-    OtlpGrpcMetricExporter exporter = Config.createOtlpGrpcMetricsExporter(config);
-
-    WMQMonitor monitor = new WMQMonitor(new OpenTelemetryMetricWriteHelper(exporter));
-    TaskExecutionContext taskExecCtx = new TaskExecutionContext();
-
     int numberOfThreads = 1;
     int taskDelaySeconds = 60;
     int initialDelaySeconds = 10;
@@ -57,26 +60,74 @@ public class Main {
           YmlUtils.getInt(taskSchedule.get("initialDelaySeconds"), initialDelaySeconds);
     }
     final ScheduledExecutorService service = Executors.newScheduledThreadPool(numberOfThreads);
-    service.scheduleAtFixedRate(
-        () -> {
-          try {
-            Map<String, String> taskArguments = new HashMap<>();
-            taskArguments.put("config-file", configFile);
-            monitor.execute(taskArguments, taskExecCtx);
-          } catch (TaskExecutionException e) {
-            throw new RuntimeException(e);
-          }
-        },
-        initialDelaySeconds,
-        taskDelaySeconds,
-        TimeUnit.SECONDS);
 
-    Runtime.getRuntime()
-        .addShutdownHook(
-            new Thread(
-                () -> {
-                  service.shutdown();
-                  exporter.shutdown();
-                }));
+    Config.setUpSSLConnection(config);
+
+    OtlpGrpcMetricExporter exporter = Config.createOtlpGrpcMetricsExporter(config);
+
+    MetricReader reader =
+        PeriodicMetricReader.builder(exporter)
+            .setExecutor(service)
+            .setInterval(Duration.of(taskDelaySeconds, ChronoUnit.SECONDS))
+            .build();
+
+    List<String> queueManagerNames = new ArrayList<>();
+    for (Object queueManagerConfig : (List) config.get("queueManagers")) {
+      String queueManagerName = (String) ((Map<String, ?>) queueManagerConfig).get("name");
+      queueManagerNames.add(queueManagerName);
+    }
+    Map<String, SdkMeterProvider> providers =
+        createSdkMeterProviders(reader, queueManagerNames.toArray(new String[0]));
+    Map<String, Meter> meters = new HashMap<>();
+    for (Map.Entry<String, SdkMeterProvider> e : providers.entrySet()) {
+      meters.put(e.getKey(), e.getValue().get("opentelemetry.io/mq"));
+    }
+
+    WMQMonitor monitor = new WMQMonitor(new OpenTelemetryMetricWriteHelper(exporter, meters));
+    TaskExecutionContext taskExecCtx = new TaskExecutionContext();
+
+    try {
+
+      service.scheduleAtFixedRate(
+          () -> {
+            try {
+              Map<String, String> taskArguments = new HashMap<>();
+              taskArguments.put("config-file", configFile);
+              monitor.execute(taskArguments, taskExecCtx);
+            } catch (TaskExecutionException e) {
+              throw new RuntimeException(e);
+            }
+          },
+          initialDelaySeconds,
+          taskDelaySeconds,
+          TimeUnit.SECONDS);
+
+      Runtime.getRuntime()
+          .addShutdownHook(
+              new Thread(
+                  () -> {
+                    service.shutdown();
+                    exporter.shutdown();
+                  }));
+    } finally {
+      for (SdkMeterProvider c : providers.values()) {
+        c.close();
+      }
+    }
+  }
+
+  public static Map<String, SdkMeterProvider> createSdkMeterProviders(
+      MetricReader reader, String... queueManagerNames) {
+    Map<String, SdkMeterProvider> providers = new HashMap<>();
+    for (String q : queueManagerNames) {
+      Attributes attrs = Attributes.of(AttributeKey.stringKey("queue.manager"), q);
+      SdkMeterProvider meterProvider =
+          SdkMeterProvider.builder()
+              .registerMetricReader(reader)
+              .setResource(Resource.create(attrs))
+              .build();
+      providers.put(q, meterProvider);
+    }
+    return providers;
   }
 }

--- a/src/main/java/com/splunk/ibm/mq/opentelemetry/OpenTelemetryMetricWriteHelper.java
+++ b/src/main/java/com/splunk/ibm/mq/opentelemetry/OpenTelemetryMetricWriteHelper.java
@@ -26,6 +26,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/com/splunk/ibm/mq/opentelemetry/OpenTelemetryMetricWriteHelper.java
+++ b/src/main/java/com/splunk/ibm/mq/opentelemetry/OpenTelemetryMetricWriteHelper.java
@@ -63,6 +63,7 @@ public class OpenTelemetryMetricWriteHelper extends MetricWriteHelper {
     this.exporter.export(metrics);
   }
 
+  @Nullable
   public Meter getMeter(String queueManager) {
     return this.meters.get(queueManager);
   }

--- a/src/main/java/com/splunk/ibm/mq/opentelemetry/OpenTelemetryMetricWriteHelper.java
+++ b/src/main/java/com/splunk/ibm/mq/opentelemetry/OpenTelemetryMetricWriteHelper.java
@@ -18,12 +18,14 @@ package com.splunk.ibm.mq.opentelemetry;
 import com.appdynamics.extensions.MetricWriteHelper;
 import com.appdynamics.extensions.metrics.Metric;
 import com.appdynamics.extensions.metrics.transformers.Transformer;
+import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import java.math.BigDecimal;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,9 +35,12 @@ public class OpenTelemetryMetricWriteHelper extends MetricWriteHelper {
       LoggerFactory.getLogger(OpenTelemetryMetricWriteHelper.class);
 
   private final MetricExporter exporter;
+  private final Map<String, Meter> meters;
 
-  public OpenTelemetryMetricWriteHelper(MetricExporter otlpGrpcMetricExporter) {
+  public OpenTelemetryMetricWriteHelper(
+      MetricExporter otlpGrpcMetricExporter, Map<String, Meter> meters) {
     this.exporter = otlpGrpcMetricExporter;
+    this.meters = meters;
   }
 
   @Override
@@ -56,6 +61,10 @@ public class OpenTelemetryMetricWriteHelper extends MetricWriteHelper {
 
   public void exportMetrics(Collection<MetricData> metrics) {
     this.exporter.export(metrics);
+  }
+
+  public Meter getMeter(String queueManager) {
+    return this.meters.get(queueManager);
   }
 
   @Override


### PR DESCRIPTION
This PR adds a new class of metric collection, specifically to capture performance metrics exposed by system queues when queue manager performance events are enabled and the queue limits are set.

The events are made available in a system queue and we can consume them and report them as cumulative counters.