### PR TITLE
Authority events

### DIFF
--- a/src/integrationTest/java/com/splunk/ibm/mq/integration/tests/WMQMonitorIntegrationTest.java
+++ b/src/integrationTest/java/com/splunk/ibm/mq/integration/tests/WMQMonitorIntegrationTest.java
@@ -124,9 +124,6 @@ class WMQMonitorIntegrationTest {
     JakartaPutGet.runPutGet(qManager, "myqueue", 10, 1);
 
     service.submit(() -> JakartaPutGet.runPutGet(qManager, "myqueue", 1000000, 100));
-
-    // Give some time for MQ to log all the events.
-    Thread.sleep(10000);
   }
 
   private static void configureQueueManager(QueueManager manager) {

--- a/src/integrationTest/java/com/splunk/ibm/mq/integration/tests/WMQMonitorIntegrationTest.java
+++ b/src/integrationTest/java/com/splunk/ibm/mq/integration/tests/WMQMonitorIntegrationTest.java
@@ -108,12 +108,14 @@ class WMQMonitorIntegrationTest {
     ObjectMapper mapper = new ObjectMapper();
     QueueManager qManager = mapper.convertValue(queueManagerConfig, QueueManager.class);
     configureQueueManager(qManager);
+    Thread.sleep(10000);
 
     // try to login with a bad password:
     JakartaPutGet.tryLoginWithBadPassword(qManager);
 
     // create a queue and fill it up past its capacity.
     JakartaPutGet.createQueue(qManager, "smallqueue", 10);
+    Thread.sleep(10000);
 
     JakartaPutGet.sendMessages(qManager, "smallqueue", 1);
     Thread.sleep(1000);
@@ -122,6 +124,7 @@ class WMQMonitorIntegrationTest {
     JakartaPutGet.sendMessages(qManager, "smallqueue", 5);
 
     JakartaPutGet.runPutGet(qManager, "myqueue", 10, 1);
+    Thread.sleep(10000);
 
     service.submit(() -> JakartaPutGet.runPutGet(qManager, "myqueue", 1000000, 100));
   }

--- a/src/integrationTest/java/com/splunk/ibm/mq/integration/tests/WMQMonitorIntegrationTest.java
+++ b/src/integrationTest/java/com/splunk/ibm/mq/integration/tests/WMQMonitorIntegrationTest.java
@@ -181,7 +181,6 @@ class WMQMonitorIntegrationTest {
   @Test
   void test_monitor_with_full_config() throws Exception {
     logger.info("\n\n\n\n\n\nRunning test: test_monitor_with_full_config");
-
     TestResultMetricExporter testExporter = new TestResultMetricExporter();
     MetricReader reader =
         PeriodicMetricReader.builder(testExporter)
@@ -221,7 +220,6 @@ class WMQMonitorIntegrationTest {
   @Test
   void test_wmqmonitor() throws Exception {
     logger.info("\n\n\n\n\n\nRunning test: test_wmqmonitor");
-
     TestResultMetricExporter testExporter = new TestResultMetricExporter();
     MetricReader reader =
         PeriodicMetricReader.builder(testExporter)

--- a/src/integrationTest/java/com/splunk/ibm/mq/integration/tests/WMQMonitorIntegrationTest.java
+++ b/src/integrationTest/java/com/splunk/ibm/mq/integration/tests/WMQMonitorIntegrationTest.java
@@ -124,6 +124,9 @@ class WMQMonitorIntegrationTest {
     JakartaPutGet.runPutGet(qManager, "myqueue", 10, 1);
 
     service.submit(() -> JakartaPutGet.runPutGet(qManager, "myqueue", 1000000, 100));
+
+    // Give some time for MQ to log all the events.
+    Thread.sleep(10000);
   }
 
   private static void configureQueueManager(QueueManager manager) {

--- a/src/main/java/com/splunk/ibm/mq/config/QueueManager.java
+++ b/src/main/java/com/splunk/ibm/mq/config/QueueManager.java
@@ -37,6 +37,7 @@ public class QueueManager {
   private String modelQueueName;
   private String configurationQueueName = "SYSTEM.ADMIN.CONFIG.EVENT";
   private String performanceEventsQueueName = "SYSTEM.ADMIN.PERFM.EVENT";
+  private String queueManagerEventsQueueName = "SYSTEM.ADMIN.QMGR.EVENT";
   private long consumeConfigurationEventInterval;
   private boolean refreshQueueManagerConfigurationEnabled;
   private long consumePerformanceEventInterval;
@@ -259,5 +260,13 @@ public class QueueManager {
 
   public void setPerformanceEventsQueueName(String performanceEventsQueueName) {
     this.performanceEventsQueueName = performanceEventsQueueName;
+  }
+
+  public String getQueueManagerEventsQueueName() {
+    return this.queueManagerEventsQueueName;
+  }
+
+  public void setQueueManagerEventsQueueName(String queueManagerEventsQueueName) {
+    this.queueManagerEventsQueueName = queueManagerEventsQueueName;
   }
 }

--- a/src/main/java/com/splunk/ibm/mq/metricscollector/QueueManagerEventCollector.java
+++ b/src/main/java/com/splunk/ibm/mq/metricscollector/QueueManagerEventCollector.java
@@ -34,6 +34,7 @@ import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+// Reads queue manager events and counts them as metrics
 public final class QueueManagerEventCollector implements MetricsPublisher {
 
   private static final Logger logger = LoggerFactory.getLogger(QueueManagerEventCollector.class);

--- a/src/main/java/com/splunk/ibm/mq/metricscollector/QueueManagerEventCollector.java
+++ b/src/main/java/com/splunk/ibm/mq/metricscollector/QueueManagerEventCollector.java
@@ -16,7 +16,6 @@
 package com.splunk.ibm.mq.metricscollector;
 
 import com.appdynamics.extensions.MetricWriteHelper;
-import com.appdynamics.extensions.logging.ExtensionsLoggerFactory;
 import com.ibm.mq.MQException;
 import com.ibm.mq.MQGetMessageOptions;
 import com.ibm.mq.MQMessage;
@@ -33,12 +32,11 @@ import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.LongCounter;
 import java.io.IOException;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class QueueManagerEventCollector implements MetricsPublisher {
 
-  private static final Logger logger =
-      ExtensionsLoggerFactory.getLogger(QueueManagerEventCollector.class);
-  private final OpenTelemetryMetricWriteHelper metricWriteHelper;
+  private static final Logger logger = LoggerFactory.getLogger(QueueManagerEventCollector.class);
   private final QueueManager queueManager;
   private final MQQueueManager mqQueueManager;
   private final LongCounter authorityEventCounter;
@@ -53,9 +51,10 @@ public final class QueueManagerEventCollector implements MetricsPublisher {
     }
     this.mqQueueManager = mqQueueManager;
     this.queueManager = queueManager;
-    this.metricWriteHelper = (OpenTelemetryMetricWriteHelper) metricWriteHelper;
+    OpenTelemetryMetricWriteHelper openTelemetryMetricWriteHelper =
+        (OpenTelemetryMetricWriteHelper) metricWriteHelper;
     this.authorityEventCounter =
-        this.metricWriteHelper
+        openTelemetryMetricWriteHelper
             .getMeter(queueManager.getName())
             .counterBuilder("mq.unauthorized.event")
             .setUnit("1")

--- a/src/main/java/com/splunk/ibm/mq/metricscollector/QueueManagerEventCollector.java
+++ b/src/main/java/com/splunk/ibm/mq/metricscollector/QueueManagerEventCollector.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.splunk.ibm.mq.metricscollector;
+
+import com.appdynamics.extensions.MetricWriteHelper;
+import com.appdynamics.extensions.logging.ExtensionsLoggerFactory;
+import com.ibm.mq.MQException;
+import com.ibm.mq.MQGetMessageOptions;
+import com.ibm.mq.MQMessage;
+import com.ibm.mq.MQQueue;
+import com.ibm.mq.MQQueueManager;
+import com.ibm.mq.constants.CMQC;
+import com.ibm.mq.constants.CMQCFC;
+import com.ibm.mq.constants.MQConstants;
+import com.ibm.mq.headers.pcf.PCFMessage;
+import com.splunk.ibm.mq.config.QueueManager;
+import com.splunk.ibm.mq.opentelemetry.OpenTelemetryMetricWriteHelper;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.LongCounter;
+import java.io.IOException;
+import org.slf4j.Logger;
+
+public final class QueueManagerEventCollector implements MetricsPublisher {
+
+  private static final Logger logger =
+      ExtensionsLoggerFactory.getLogger(QueueManagerEventCollector.class);
+  private final OpenTelemetryMetricWriteHelper metricWriteHelper;
+  private final QueueManager queueManager;
+  private final MQQueueManager mqQueueManager;
+  private final LongCounter authorityEventCounter;
+
+  public QueueManagerEventCollector(
+      MQQueueManager mqQueueManager,
+      QueueManager queueManager,
+      MetricWriteHelper metricWriteHelper) {
+    if (!(metricWriteHelper instanceof OpenTelemetryMetricWriteHelper)) {
+      throw new IllegalArgumentException(
+          "metricWriteHelper is not an instance of OpenTelemetryMetricWriteHelper");
+    }
+    this.mqQueueManager = mqQueueManager;
+    this.queueManager = queueManager;
+    this.metricWriteHelper = (OpenTelemetryMetricWriteHelper) metricWriteHelper;
+    this.authorityEventCounter =
+        this.metricWriteHelper
+            .getMeter(queueManager.getName())
+            .counterBuilder("mq.unauthorized.event")
+            .setUnit("1")
+            .build();
+  }
+
+  private void readEvents(String queueManagerEventsQueueName) throws Exception {
+
+    MQQueue queue = null;
+    try {
+      int queueAccessOptions = MQConstants.MQOO_FAIL_IF_QUIESCING | MQConstants.MQOO_INPUT_SHARED;
+      queue = mqQueueManager.accessQueue(queueManagerEventsQueueName, queueAccessOptions);
+      // keep going until receiving the exception MQConstants.MQRC_NO_MSG_AVAILABLE
+      while (true) {
+        try {
+          MQGetMessageOptions getOptions = new MQGetMessageOptions();
+          getOptions.options = MQConstants.MQGMO_NO_WAIT | MQConstants.MQGMO_FAIL_IF_QUIESCING;
+          MQMessage message = new MQMessage();
+
+          queue.get(message, getOptions);
+          PCFMessage received = new PCFMessage(message);
+          if (received.getReason() == CMQC.MQRC_NOT_AUTHORIZED) {
+            String username = received.getStringParameterValue(CMQCFC.MQCACF_USER_IDENTIFIER);
+            String applicationName = received.getStringParameterValue(CMQCFC.MQCACF_APPL_NAME);
+
+            authorityEventCounter.add(
+                1,
+                Attributes.of(
+                    AttributeKey.stringKey("user.name"),
+                    username,
+                    AttributeKey.stringKey("application.name"),
+                    applicationName));
+          } else {
+            logger.debug("Unknown event reason {}", received.getReason());
+          }
+
+        } catch (MQException e) {
+          if (e.reasonCode != MQConstants.MQRC_NO_MSG_AVAILABLE) {
+            logger.error(e.getMessage(), e);
+          }
+          break;
+        } catch (IOException e) {
+          logger.error(e.getMessage(), e);
+          break;
+        }
+      }
+    } finally {
+      if (queue != null) {
+        queue.close();
+      }
+    }
+  }
+
+  @Override
+  public void publishMetrics() {
+    long entryTime = System.currentTimeMillis();
+    String queueManagerEventsQueueName = this.queueManager.getQueueManagerEventsQueueName();
+    logger.info(
+        "sending PCF agent request to read queue manager events from queue {}",
+        queueManagerEventsQueueName);
+    try {
+      readEvents(queueManagerEventsQueueName);
+    } catch (Exception e) {
+      logger.error(
+          "Unexpected Error occurred while collecting queue manager events for queue "
+              + queueManagerEventsQueueName,
+          e);
+    }
+    long exitTime = System.currentTimeMillis() - entryTime;
+    logger.debug(
+        "Time taken to publish metrics for queue manager events is {} milliseconds", exitTime);
+  }
+}


### PR DESCRIPTION
This PR builds on top of #79 and adds a new collector for queue manager events, specifically unauthorized events. The events are reported with the attribute of the user name and the name of the application.