### PR TITLE
Count more states as active

### DIFF
--- a/src/integrationTest/java/com/splunk/ibm/mq/integration/tests/WMQMonitorIntegrationTest.java
+++ b/src/integrationTest/java/com/splunk/ibm/mq/integration/tests/WMQMonitorIntegrationTest.java
@@ -152,6 +152,8 @@ class WMQMonitorIntegrationTest {
     for (MetricData metricData : data) {
       metricNames.add(metricData.getName());
     }
+    // this value is read from the active channels count:
+    assertThat(metricNames).contains("mq.manager.active.channels");
     // this value is read from the configuration queue.
     assertThat(metricNames).contains("mq.manager.max.handles");
   }

--- a/src/main/java/com/splunk/ibm/mq/WMQMonitorTask.java
+++ b/src/main/java/com/splunk/ibm/mq/WMQMonitorTask.java
@@ -167,7 +167,8 @@ public class WMQMonitorTask implements AMonitorTaskRunnable {
     // Step 1: Retrieve metrics from configuration
     Map<String, Map<String, WMQMetricOverride>> metricsMap =
         WMQUtil.getMetricsToReportFromConfigYml((List<Map>) configMap.get("mqMetrics"));
-    CountDownLatch countDownLatch = new CountDownLatch(metricsMap.size());
+    CountDownLatch countDownLatch =
+        new CountDownLatch(metricsMap.size() + 2); // queue manager and channel metrics have 2 jobs
 
     // Step 2: Inquire each metric type
     inquireQueueMangerMetrics(

--- a/src/main/java/com/splunk/ibm/mq/metricscollector/ChannelMetricsCollector.java
+++ b/src/main/java/com/splunk/ibm/mq/metricscollector/ChannelMetricsCollector.java
@@ -106,6 +106,7 @@ public final class ChannelMetricsCollector implements MetricsPublisher {
                       metricCreator.createMetric(
                           metrickey, metricVal, wmqOverride, channelName, metrickey);
                   responseMetrics.add(metric);
+                  // We follow the definition of active channel as documented in https://www.ibm.com/docs/en/ibm-mq/9.2.x?topic=states-current-active
                   if ("Status".equals(metrickey)
                       && metricVal != CMQCFC.MQCHS_RETRYING
                       && metricVal != CMQCFC.MQCHS_STOPPED

--- a/src/main/java/com/splunk/ibm/mq/metricscollector/ChannelMetricsCollector.java
+++ b/src/main/java/com/splunk/ibm/mq/metricscollector/ChannelMetricsCollector.java
@@ -106,7 +106,10 @@ public final class ChannelMetricsCollector implements MetricsPublisher {
                       metricCreator.createMetric(
                           metrickey, metricVal, wmqOverride, channelName, metrickey);
                   responseMetrics.add(metric);
-                  if ("Status".equals(metrickey) && metricVal == 3) {
+                  if ("Status".equals(metrickey)
+                      && metricVal != CMQCFC.MQCHS_RETRYING
+                      && metricVal != CMQCFC.MQCHS_STOPPED
+                      && metricVal != CMQCFC.MQCHS_STARTING) {
                     activeChannels.add(channelName);
                   }
                 });

--- a/src/main/java/com/splunk/ibm/mq/metricscollector/ChannelMetricsCollector.java
+++ b/src/main/java/com/splunk/ibm/mq/metricscollector/ChannelMetricsCollector.java
@@ -106,7 +106,8 @@ public final class ChannelMetricsCollector implements MetricsPublisher {
                       metricCreator.createMetric(
                           metrickey, metricVal, wmqOverride, channelName, metrickey);
                   responseMetrics.add(metric);
-                  // We follow the definition of active channel as documented in https://www.ibm.com/docs/en/ibm-mq/9.2.x?topic=states-current-active
+                  // We follow the definition of active channel as documented in
+                  // https://www.ibm.com/docs/en/ibm-mq/9.2.x?topic=states-current-active
                   if ("Status".equals(metrickey)
                       && metricVal != CMQCFC.MQCHS_RETRYING
                       && metricVal != CMQCFC.MQCHS_STOPPED

--- a/src/main/java/com/splunk/ibm/mq/opentelemetry/MQOtelTranslator.java
+++ b/src/main/java/com/splunk/ibm/mq/opentelemetry/MQOtelTranslator.java
@@ -251,6 +251,7 @@ class MQOtelTranslator {
               put("Statistics Interval", "mq.manager.statistics.interval");
               put("Max Handles", "mq.manager.max.handles");
               put("Max Active Channels", "mq.manager.max.active.channels");
+              put("ActiveChannelsCount", "mq.manager.active.channels");
             }
           },
           segments -> {


### PR DESCRIPTION
This showed a bug in WMQMonitorTask: our countdown latch is initialized with a smaller number than the number of jobs we submit.