### PR TITLE
Decouple from appd tasks

### DIFF
--- a/src/integrationTest/java/com/splunk/ibm/mq/integration/tests/WMQMonitorIntegrationTest.java
+++ b/src/integrationTest/java/com/splunk/ibm/mq/integration/tests/WMQMonitorIntegrationTest.java
@@ -196,7 +196,7 @@ class WMQMonitorIntegrationTest {
     MetricWriteHelper metricWriteHelper = new OpenTelemetryMetricWriteHelper(testExporter, meters);
     String configFile = getConfigFile("conf/test-config.yml");
 
-    TestWMQMonitor monitor = new TestWMQMonitor(configFile, metricWriteHelper);
+    TestWMQMonitor monitor = new TestWMQMonitor(configFile, metricWriteHelper, service);
     monitor.testrun();
 
     reader.forceFlush().join(5, TimeUnit.SECONDS);
@@ -238,7 +238,7 @@ class WMQMonitorIntegrationTest {
     MetricWriteHelper metricWriteHelper = new OpenTelemetryMetricWriteHelper(testExporter, meters);
     String configFile = getConfigFile("conf/test-queuemgr-config.yml");
 
-    TestWMQMonitor monitor = new TestWMQMonitor(configFile, metricWriteHelper);
+    TestWMQMonitor monitor = new TestWMQMonitor(configFile, metricWriteHelper, service);
     monitor.testrun();
   }
 }

--- a/src/main/java/com/splunk/ibm/mq/WMQMonitor.java
+++ b/src/main/java/com/splunk/ibm/mq/WMQMonitor.java
@@ -15,10 +15,7 @@
  */
 package com.splunk.ibm.mq;
 
-import com.appdynamics.extensions.ABaseMonitor;
-import com.appdynamics.extensions.Constants;
-import com.appdynamics.extensions.MetricWriteHelper;
-import com.appdynamics.extensions.TasksExecutionServiceProvider;
+import com.appdynamics.extensions.*;
 import com.appdynamics.extensions.util.AssertUtils;
 import com.appdynamics.extensions.util.CryptoUtils;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -64,8 +61,19 @@ public class WMQMonitor extends ABaseMonitor {
       QueueManager qManager = mapper.convertValue(queueManager, QueueManager.class);
       WMQMonitorTask wmqTask =
           new WMQMonitorTask(
-              tasksExecutionServiceProvider, this.getContextConfiguration(), qManager);
-      tasksExecutionServiceProvider.submit((String) queueManager.get("name"), wmqTask);
+              tasksExecutionServiceProvider, getContextConfiguration(), qManager);
+      AMonitorTaskRunnable taskRunnable = new AMonitorTaskRunnable() {
+        @Override
+        public void onTaskComplete() {
+          //NOP will remove this soon...
+        }
+
+        @Override
+        public void run() {
+          wmqTask.run();
+        }
+      };
+      tasksExecutionServiceProvider.submit((String) queueManager.get("name"), taskRunnable);
     }
   }
 

--- a/src/main/java/com/splunk/ibm/mq/WMQMonitorTask.java
+++ b/src/main/java/com/splunk/ibm/mq/WMQMonitorTask.java
@@ -58,7 +58,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Encapsulates all metrics collection for all artifacts related to a queue manager. */
-public class WMQMonitorTask implements AMonitorTaskRunnable {
+public class WMQMonitorTask implements Runnable {
 
   public static final Logger logger = LoggerFactory.getLogger(WMQMonitorTask.class);
   private final QueueManager queueManager;
@@ -77,6 +77,7 @@ public class WMQMonitorTask implements AMonitorTaskRunnable {
     this.metricWriteHelper = tasksExecutionServiceProvider.getMetricWriteHelper();
   }
 
+  @Override
   public void run() {
     String queueManagerName = WMQUtil.getQueueManagerNameFromConfig(queueManager);
     logger.debug("WMQMonitor thread for queueManager {} started.", queueManagerName);
@@ -425,11 +426,5 @@ public class WMQMonitorTask implements AMonitorTaskRunnable {
             e);
       }
     }
-  }
-
-  public void onTaskComplete() {
-    logger.info(
-        "WebSphereMQ monitor thread completed for queueManager: {}",
-        WMQUtil.getQueueManagerNameFromConfig(queueManager));
   }
 }

--- a/src/main/java/com/splunk/ibm/mq/WMQMonitorTask.java
+++ b/src/main/java/com/splunk/ibm/mq/WMQMonitorTask.java
@@ -15,9 +15,7 @@
  */
 package com.splunk.ibm.mq;
 
-import com.appdynamics.extensions.AMonitorTaskRunnable;
 import com.appdynamics.extensions.MetricWriteHelper;
-import com.appdynamics.extensions.TasksExecutionServiceProvider;
 import com.appdynamics.extensions.conf.MonitorContextConfiguration;
 import com.appdynamics.extensions.util.StringUtils;
 import com.google.common.base.Strings;
@@ -68,13 +66,13 @@ public class WMQMonitorTask implements Runnable {
   private List<MetricsPublisher> pendingJobs = new ArrayList<>();
 
   public WMQMonitorTask(
-      TasksExecutionServiceProvider tasksExecutionServiceProvider,
+      MetricWriteHelper metricWriteHelper,
       MonitorContextConfiguration monitorContextConfig,
       QueueManager queueManager) {
     this.monitorContextConfig = monitorContextConfig;
     this.queueManager = queueManager;
     this.configMap = monitorContextConfig.getConfigYml();
-    this.metricWriteHelper = tasksExecutionServiceProvider.getMetricWriteHelper();
+    this.metricWriteHelper = metricWriteHelper;
   }
 
   @Override

--- a/src/main/java/com/splunk/ibm/mq/opentelemetry/Main.java
+++ b/src/main/java/com/splunk/ibm/mq/opentelemetry/Main.java
@@ -92,7 +92,7 @@ public class Main {
         () -> {
           try {
             WMQMonitor monitor =
-                new WMQMonitor(new OpenTelemetryMetricWriteHelper(exporter, meters));
+                new WMQMonitor(service, new OpenTelemetryMetricWriteHelper(exporter, meters));
             TaskExecutionContext taskExecCtx = new TaskExecutionContext();
             Map<String, String> taskArguments = new HashMap<>();
             taskArguments.put("config-file", configFile);


### PR DESCRIPTION
Phase 1 -- in which `WMQMonitorTask` no longer inherits from `AMonitorTaskRunnable ` but is instead just a meager `Runnable` that can be submitted to a humble `ExecutorService`.

Up next - freeing `WMQMonitor` from `ABaseMonitor`.