### PR TITLE
Decouple from appd job/worker/whatever machinery.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,12 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>26.0.2</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>com.ibm.mq</groupId>
             <artifactId>com.ibm.mq.allclient</artifactId>
             <version>${ibm.mq.lib.version}</version>

--- a/src/integrationTest/java/com/splunk/ibm/mq/integration/tests/TestWMQMonitor.java
+++ b/src/integrationTest/java/com/splunk/ibm/mq/integration/tests/TestWMQMonitor.java
@@ -21,7 +21,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.splunk.ibm.mq.WMQMonitorTask;
 import com.splunk.ibm.mq.config.QueueManager;
 import com.splunk.ibm.mq.opentelemetry.ConfigWrapper;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
@@ -39,15 +38,10 @@ class TestWMQMonitor {
   private final ExecutorService threadPool;
 
   TestWMQMonitor(
-      ConfigWrapper config,
-      String testConfigFile,
-      MetricWriteHelper metricWriteHelper,
-      ExecutorService service) {
+      ConfigWrapper config, MetricWriteHelper metricWriteHelper, ExecutorService service) {
     this.config = config;
     this.metricWriteHelper = metricWriteHelper;
     this.threadPool = service;
-    Map<String, String> args = new HashMap<>();
-    args.put("config-file", testConfigFile);
   }
 
   /**

--- a/src/integrationTest/java/com/splunk/ibm/mq/integration/tests/TestWMQMonitor.java
+++ b/src/integrationTest/java/com/splunk/ibm/mq/integration/tests/TestWMQMonitor.java
@@ -18,9 +18,9 @@ package com.splunk.ibm.mq.integration.tests;
 import com.appdynamics.extensions.MetricWriteHelper;
 import com.appdynamics.extensions.util.AssertUtils;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.splunk.ibm.mq.WMQMonitor;
 import com.splunk.ibm.mq.WMQMonitorTask;
 import com.splunk.ibm.mq.config.QueueManager;
+import com.splunk.ibm.mq.opentelemetry.ConfigWrapper;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -32,17 +32,22 @@ import java.util.concurrent.ExecutorService;
  * facilitates custom configuration through a test configuration file and a test metric write
  * helper.
  */
-class TestWMQMonitor extends WMQMonitor {
+class TestWMQMonitor {
 
   private final MetricWriteHelper metricWriteHelper;
+  private final ConfigWrapper config;
+  private final ExecutorService threadPool;
 
   TestWMQMonitor(
-      String testConfigFile, MetricWriteHelper metricWriteHelper, ExecutorService service) {
-    super(service, metricWriteHelper);
+      ConfigWrapper config,
+      String testConfigFile,
+      MetricWriteHelper metricWriteHelper,
+      ExecutorService service) {
+    this.config = config;
     this.metricWriteHelper = metricWriteHelper;
+    this.threadPool = service;
     Map<String, String> args = new HashMap<>();
     args.put("config-file", testConfigFile);
-    initialize(args);
   }
 
   /**
@@ -53,18 +58,17 @@ class TestWMQMonitor extends WMQMonitor {
    * MetricWriteHelper if provided, initializes a TasksExecutionServiceProvider, and executes the
    * WMQMonitorTask
    */
-  void testrun() {
-    List<Map> queueManagers =
-        (List<Map>) this.getContextConfiguration().getConfigYml().get("queueManagers");
+  void runTest() {
+    List<Map<String, ?>> queueManagers = config.getQueueManagers();
     AssertUtils.assertNotNull(
         queueManagers, "The 'queueManagers' section in config.yml is not initialised");
     ObjectMapper mapper = new ObjectMapper();
     // we override this helper to pass in our opentelemetry helper instead.
     if (metricWriteHelper != null) {
-      for (Map queueManager : queueManagers) {
+      for (Map<String, ?> queueManager : queueManagers) {
         QueueManager qManager = mapper.convertValue(queueManager, QueueManager.class);
         WMQMonitorTask wmqTask =
-            new WMQMonitorTask(metricWriteHelper, getContextConfiguration(), qManager);
+            new WMQMonitorTask(config, metricWriteHelper, qManager, threadPool);
         wmqTask.run();
       }
     }

--- a/src/integrationTest/java/com/splunk/ibm/mq/integration/tests/WMQMonitorIntegrationTest.java
+++ b/src/integrationTest/java/com/splunk/ibm/mq/integration/tests/WMQMonitorIntegrationTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 import com.appdynamics.extensions.MetricWriteHelper;
-import com.appdynamics.extensions.yml.YmlReader;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ibm.mq.MQQueueManager;
 import com.ibm.mq.constants.CMQC;
@@ -31,6 +30,7 @@ import com.ibm.mq.headers.pcf.PCFMessageAgent;
 import com.splunk.ibm.mq.WMQMonitorTask;
 import com.splunk.ibm.mq.config.QueueManager;
 import com.splunk.ibm.mq.integration.opentelemetry.TestResultMetricExporter;
+import com.splunk.ibm.mq.opentelemetry.ConfigWrapper;
 import com.splunk.ibm.mq.opentelemetry.Main;
 import com.splunk.ibm.mq.opentelemetry.OpenTelemetryMetricWriteHelper;
 import io.opentelemetry.api.metrics.Meter;
@@ -66,7 +66,7 @@ class WMQMonitorIntegrationTest {
 
   private static final ExecutorService service =
       Executors.newFixedThreadPool(
-          1,
+          4, /* one gets burned with our @BeforeAll message uzi, 4 is faster than 2 */
           r -> {
             Thread thread = new Thread(r);
             thread.setUncaughtExceptionHandler(
@@ -75,17 +75,16 @@ class WMQMonitorIntegrationTest {
                   fail(e.getMessage());
                 });
             thread.setDaemon(true);
+            thread.setName("WMQMonitorIntegrationTest");
             return thread;
           });
 
-  private static QueueManager getQueueManagerConfig() throws URISyntaxException {
+  private static QueueManager getQueueManagerConfig() throws Exception {
     String configFile = getConfigFile("conf/test-config.yml");
-    Map<String, ?> config = YmlReader.readFromFileAsMap(new File(configFile));
-    Map<String, ?> queueManagerConfig =
-        (Map<String, ?>) ((List) config.get("queueManagers")).get(0);
+    ConfigWrapper wrapper = ConfigWrapper.parse(configFile);
+    Map<String, ?> queueManagerConfig = wrapper.getQueueManagers().get(0);
     ObjectMapper mapper = new ObjectMapper();
-    QueueManager qManager = mapper.convertValue(queueManagerConfig, QueueManager.class);
-    return qManager;
+    return mapper.convertValue(queueManagerConfig, QueueManager.class);
   }
 
   @NotNull
@@ -196,8 +195,9 @@ class WMQMonitorIntegrationTest {
     MetricWriteHelper metricWriteHelper = new OpenTelemetryMetricWriteHelper(testExporter, meters);
     String configFile = getConfigFile("conf/test-config.yml");
 
-    TestWMQMonitor monitor = new TestWMQMonitor(configFile, metricWriteHelper, service);
-    monitor.testrun();
+    ConfigWrapper config = ConfigWrapper.parse(configFile);
+    TestWMQMonitor monitor = new TestWMQMonitor(config, configFile, metricWriteHelper, service);
+    monitor.runTest();
 
     reader.forceFlush().join(5, TimeUnit.SECONDS);
     for (SdkMeterProvider provider : providers.values()) {
@@ -237,8 +237,9 @@ class WMQMonitorIntegrationTest {
     }
     MetricWriteHelper metricWriteHelper = new OpenTelemetryMetricWriteHelper(testExporter, meters);
     String configFile = getConfigFile("conf/test-queuemgr-config.yml");
+    ConfigWrapper config = ConfigWrapper.parse(configFile);
 
-    TestWMQMonitor monitor = new TestWMQMonitor(configFile, metricWriteHelper, service);
-    monitor.testrun();
+    TestWMQMonitor monitor = new TestWMQMonitor(config, configFile, metricWriteHelper, service);
+    monitor.runTest();
   }
 }

--- a/src/integrationTest/java/com/splunk/ibm/mq/integration/tests/WMQMonitorIntegrationTest.java
+++ b/src/integrationTest/java/com/splunk/ibm/mq/integration/tests/WMQMonitorIntegrationTest.java
@@ -196,7 +196,7 @@ class WMQMonitorIntegrationTest {
     String configFile = getConfigFile("conf/test-config.yml");
 
     ConfigWrapper config = ConfigWrapper.parse(configFile);
-    TestWMQMonitor monitor = new TestWMQMonitor(config, configFile, metricWriteHelper, service);
+    TestWMQMonitor monitor = new TestWMQMonitor(config, metricWriteHelper, service);
     monitor.runTest();
 
     reader.forceFlush().join(5, TimeUnit.SECONDS);
@@ -239,7 +239,7 @@ class WMQMonitorIntegrationTest {
     String configFile = getConfigFile("conf/test-queuemgr-config.yml");
     ConfigWrapper config = ConfigWrapper.parse(configFile);
 
-    TestWMQMonitor monitor = new TestWMQMonitor(config, configFile, metricWriteHelper, service);
+    TestWMQMonitor monitor = new TestWMQMonitor(config, metricWriteHelper, service);
     monitor.runTest();
   }
 }

--- a/src/main/java/com/splunk/ibm/mq/TaskJob.java
+++ b/src/main/java/com/splunk/ibm/mq/TaskJob.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.splunk.ibm.mq;
+
+/** This class just runs a delegate and times it and logs any exceptions that might be thrown. */
+public final class TaskJob implements Runnable {
+
+  private final String name;
+  private final Runnable task;
+
+  public TaskJob(String name, Runnable task) {
+    this.name = name;
+    this.task = task;
+  }
+
+  @Override
+  public void run() {
+    try {
+      long startTime = System.currentTimeMillis();
+      task.run();
+      long diffTime = System.currentTimeMillis() - startTime;
+      if (diffTime > 60000L) {
+        WMQMonitor.logger.warn("{} Task took {} ms to complete", name, diffTime);
+      }
+    } catch (Exception e) {
+      WMQMonitor.logger.error("Error while running task name = " + name, e);
+    }
+  }
+}

--- a/src/main/java/com/splunk/ibm/mq/WMQMonitor.java
+++ b/src/main/java/com/splunk/ibm/mq/WMQMonitor.java
@@ -19,15 +19,16 @@ import com.appdynamics.extensions.ABaseMonitor;
 import com.appdynamics.extensions.Constants;
 import com.appdynamics.extensions.MetricWriteHelper;
 import com.appdynamics.extensions.TasksExecutionServiceProvider;
-import com.appdynamics.extensions.util.AssertUtils;
 import com.appdynamics.extensions.util.CryptoUtils;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
 import com.splunk.ibm.mq.config.QueueManager;
+import com.splunk.ibm.mq.opentelemetry.ConfigWrapper;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,9 +38,12 @@ public class WMQMonitor extends ABaseMonitor {
 
   private final MetricWriteHelper metricWriteHelper;
   private final ExecutorService threadPool;
+  private final ConfigWrapper config;
 
-  public WMQMonitor(ExecutorService threadPool, MetricWriteHelper metricWriteHelper) {
+  public WMQMonitor(
+      ConfigWrapper config, ExecutorService threadPool, MetricWriteHelper metricWriteHelper) {
     assert (metricWriteHelper != null);
+    this.config = config;
     this.threadPool = threadPool;
     this.metricWriteHelper = metricWriteHelper;
   }
@@ -53,42 +57,41 @@ public class WMQMonitor extends ABaseMonitor {
   }
 
   protected void doRun(TasksExecutionServiceProvider IGNORED_DUE_TO_LOCAL_OVERRIDE) {
-    List<Map> queueManagers =
-        (List<Map>) getContextConfiguration().getConfigYml().get("queueManagers");
-    AssertUtils.assertNotNull(
-        queueManagers, "The 'queueManagers' section in config.yml is not initialised");
-
+    List<Map<String, ?>> queueManagers = getQueueManagers();
     ObjectMapper mapper = new ObjectMapper();
 
-    for (Map queueManager : queueManagers) {
+    for (Map<String, ?> queueManager : queueManagers) {
       QueueManager qManager = mapper.convertValue(queueManager, QueueManager.class);
-      WMQMonitorTask task =
-          new WMQMonitorTask(metricWriteHelper, getContextConfiguration(), qManager);
+      WMQMonitorTask task = new WMQMonitorTask(config, metricWriteHelper, qManager, threadPool);
       threadPool.submit(new TaskJob((String) queueManager.get("name"), task));
     }
   }
 
   @Override
   protected List<Map<String, ?>> getServers() {
-    List<Map<String, ?>> queueManagers =
-        (List<Map<String, ?>>) getContextConfiguration().getConfigYml().get("queueManagers");
-    AssertUtils.assertNotNull(
-        queueManagers, "The 'queueManagers' section in config.yml is not initialised");
+    return getQueueManagers();
+  }
+
+  @NotNull
+  private List<Map<String, ?>> getQueueManagers() {
+    List<Map<String, ?>> queueManagers = config.getQueueManagers();
+    if (queueManagers.isEmpty()) {
+      throw new IllegalStateException(
+          "The 'queueManagers' section in config.yml is empty or otherwise incorrect.");
+    }
     return queueManagers;
   }
 
   @Override
   protected void initializeMoreStuff(Map<String, String> args) {
-    Map<String, ?> configProperties = this.getContextConfiguration().getConfigYml();
-    Map<String, String> sslConnection = (Map<String, String>) configProperties.get("sslConnection");
-
-    if (sslConnection == null) {
+    Map<String, String> sslConnection = config.getSslConnection();
+    if (sslConnection.isEmpty()) {
       logger.debug(
           "ssl truststore and keystore are not configured in config.yml, if SSL is enabled, pass them as jvm args");
       return;
     }
 
-    String encryptionKey = (String) configProperties.get("encryptionKey");
+    String encryptionKey = config.getEncryptionKey();
 
     configureTrustStore(sslConnection, encryptionKey);
     configureKeyStore(sslConnection, encryptionKey);
@@ -150,30 +153,5 @@ public class WMQMonitor extends ABaseMonitor {
       return CryptoUtils.getPassword(cryptoMap);
     }
     return null;
-  }
-
-  private static final class TaskJob implements Runnable {
-
-    private final String name;
-    private final WMQMonitorTask task;
-
-    private TaskJob(String name, WMQMonitorTask task) {
-      this.name = name;
-      this.task = task;
-    }
-
-    @Override
-    public void run() {
-      try {
-        long startTime = System.currentTimeMillis();
-        task.run();
-        long diffTime = System.currentTimeMillis() - startTime;
-        if (diffTime > 60000L) {
-          logger.warn("{} Task took {} ms to complete", name, diffTime);
-        }
-      } catch (Exception e) {
-        logger.error("Error while running task name = " + name, e);
-      }
-    }
   }
 }

--- a/src/main/java/com/splunk/ibm/mq/WMQMonitorTask.java
+++ b/src/main/java/com/splunk/ibm/mq/WMQMonitorTask.java
@@ -16,7 +16,6 @@
 package com.splunk.ibm.mq;
 
 import com.appdynamics.extensions.MetricWriteHelper;
-import com.appdynamics.extensions.conf.MonitorContextConfiguration;
 import com.appdynamics.extensions.util.StringUtils;
 import com.google.common.base.Strings;
 import com.ibm.mq.MQException;
@@ -43,6 +42,7 @@ import com.splunk.ibm.mq.metricscollector.QueueManagerMetricsCollector;
 import com.splunk.ibm.mq.metricscollector.QueueMetricsCollector;
 import com.splunk.ibm.mq.metricscollector.ReadConfigurationEventQueueCollector;
 import com.splunk.ibm.mq.metricscollector.TopicMetricsCollector;
+import com.splunk.ibm.mq.opentelemetry.ConfigWrapper;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -50,6 +50,7 @@ import java.util.Hashtable;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import org.slf4j.Logger;
@@ -60,19 +61,20 @@ public class WMQMonitorTask implements Runnable {
 
   public static final Logger logger = LoggerFactory.getLogger(WMQMonitorTask.class);
   private final QueueManager queueManager;
-  private final MonitorContextConfiguration monitorContextConfig;
-  private final Map<String, ?> configMap;
+  private final ConfigWrapper config;
   private final MetricWriteHelper metricWriteHelper;
-  private List<MetricsPublisher> pendingJobs = new ArrayList<>();
+  private final List<MetricsPublisher> pendingJobs = new ArrayList<>();
+  private final ExecutorService threadPool;
 
   public WMQMonitorTask(
+      ConfigWrapper config,
       MetricWriteHelper metricWriteHelper,
-      MonitorContextConfiguration monitorContextConfig,
-      QueueManager queueManager) {
-    this.monitorContextConfig = monitorContextConfig;
+      QueueManager queueManager,
+      ExecutorService threadPool) {
+    this.config = config;
     this.queueManager = queueManager;
-    this.configMap = monitorContextConfig.getConfigYml();
     this.metricWriteHelper = metricWriteHelper;
+    this.threadPool = threadPool;
   }
 
   @Override
@@ -85,7 +87,7 @@ public class WMQMonitorTask implements Runnable {
     BigDecimal heartBeatMetricValue = BigDecimal.ZERO;
     // encryptionKey is a global setting; it is needed to allow decrypting the queue manager
     // password.
-    String encryptionKey = (String) configMap.get("encryptionKey");
+    String encryptionKey = config.getEncryptionKey();
     try {
       ibmQueueManager = connectToQueueManager(queueManager, encryptionKey);
       heartBeatMetricValue = BigDecimal.ONE;
@@ -102,8 +104,7 @@ public class WMQMonitorTask implements Runnable {
     } finally {
       cleanUp(ibmQueueManager, agent);
       metricWriteHelper.printMetric(
-          StringUtils.concatMetricPath(
-              monitorContextConfig.getMetricPrefix(), queueManagerName, "HeartBeat"),
+          StringUtils.concatMetricPath(config.getMetricPrefix(), queueManagerName, "HeartBeat"),
           heartBeatMetricValue,
           "AVG.AVG.IND");
       long endTime = System.currentTimeMillis() - startTime;
@@ -168,8 +169,7 @@ public class WMQMonitorTask implements Runnable {
 
   private void extractAndReportMetrics(MQQueueManager mqQueueManager, PCFMessageAgent agent) {
     // Step 1: Retrieve metrics from configuration
-    Map<String, Map<String, WMQMetricOverride>> metricsMap =
-        WMQUtil.getMetricsToReportFromConfigYml((List<Map>) configMap.get("mqMetrics"));
+    Map<String, Map<String, WMQMetricOverride>> metricsMap = config.getMQMetrics();
     pendingJobs.clear();
 
     // Step 2: Inquire each metric type
@@ -199,7 +199,7 @@ public class WMQMonitorTask implements Runnable {
     CountDownLatch countDownLatch = new CountDownLatch(pendingJobs.size());
     for (MetricsPublisher collector : pendingJobs) {
       Runnable job = new MetricsPublisherJob(collector, countDownLatch);
-      monitorContextConfig.getContext().getExecutorService().execute(collector.getName(), job);
+      threadPool.submit(new TaskJob(collector.getName(), job));
     }
     pendingJobs.clear();
 
@@ -265,7 +265,7 @@ public class WMQMonitorTask implements Runnable {
       PCFMessageAgent agent) {
 
     MetricCreator metricCreator =
-        new MetricCreator(monitorContextConfig.getMetricPrefix(), queueManager, commandType);
+        new MetricCreator(config.getMetricPrefix(), queueManager, commandType);
     MetricsCollectorContext context =
         new MetricsCollectorContext(metrics, queueManager, agent, metricWriteHelper);
     MetricsPublisher collector = collectorConstructor.apply(context, metricCreator);
@@ -301,7 +301,7 @@ public class WMQMonitorTask implements Runnable {
     MetricsCollectorContext collectorContext =
         new MetricsCollectorContext(queueMetrics, queueManager, agent, metricWriteHelper);
     JobSubmitterContext jobSubmitterContext =
-        new JobSubmitterContext(monitorContextConfig, collectorContext);
+        new JobSubmitterContext(collectorContext, threadPool, config);
     MetricsPublisher queueMetricsCollector =
         new QueueMetricsCollector(queueMetrics, sharedState, jobSubmitterContext);
     pendingJobs.add(queueMetricsCollector);
@@ -322,9 +322,7 @@ public class WMQMonitorTask implements Runnable {
         new MetricsCollectorContext(metricsToReport, queueManager, agent, metricWriteHelper);
     MetricCreator metricCreator =
         new MetricCreator(
-            monitorContextConfig.getMetricPrefix(),
-            queueManager,
-            ListenerMetricsCollector.ARTIFACT);
+            config.getMetricPrefix(), queueManager, ListenerMetricsCollector.ARTIFACT);
     MetricsPublisher metricsCollector = collectorConstructor.apply(context, metricCreator);
     pendingJobs.add(metricsCollector);
   }
@@ -342,8 +340,7 @@ public class WMQMonitorTask implements Runnable {
 
     MetricsCollectorContext context =
         new MetricsCollectorContext(metricsToReport, queueManager, agent, metricWriteHelper);
-    JobSubmitterContext jobSubmitterContext =
-        new JobSubmitterContext(monitorContextConfig, context);
+    JobSubmitterContext jobSubmitterContext = new JobSubmitterContext(context, threadPool, config);
     MetricsPublisher metricsCollector = collectorConstructor.apply(jobSubmitterContext);
     pendingJobs.add(metricsCollector);
   }
@@ -359,12 +356,10 @@ public class WMQMonitorTask implements Runnable {
       return;
     }
 
-    MetricCreator metricCreator =
-        new MetricCreator(monitorContextConfig.getMetricPrefix(), queueManager);
+    MetricCreator metricCreator = new MetricCreator(config.getMetricPrefix(), queueManager);
     ReadConfigurationEventQueueCollector collector =
         new ReadConfigurationEventQueueCollector(
             configurationMetricsToReport,
-            monitorContextConfig,
             agent,
             mqQueueManager,
             queueManager,

--- a/src/main/java/com/splunk/ibm/mq/metricscollector/ReadConfigurationEventQueueCollector.java
+++ b/src/main/java/com/splunk/ibm/mq/metricscollector/ReadConfigurationEventQueueCollector.java
@@ -16,7 +16,6 @@
 package com.splunk.ibm.mq.metricscollector;
 
 import com.appdynamics.extensions.MetricWriteHelper;
-import com.appdynamics.extensions.conf.MonitorContextConfiguration;
 import com.appdynamics.extensions.metrics.Metric;
 import com.google.common.collect.Lists;
 import com.ibm.mq.MQException;
@@ -45,7 +44,6 @@ public final class ReadConfigurationEventQueueCollector implements MetricsPublis
   private final MetricWriteHelper metricWriteHelper;
   private final QueueManager queueManager;
   private final PCFMessageAgent agent;
-  private final MonitorContextConfiguration monitorContextConfig;
   private final MQQueueManager mqQueueManager;
   private final Map<String, WMQMetricOverride> metricsToReport;
   private final long bootTime;
@@ -53,14 +51,12 @@ public final class ReadConfigurationEventQueueCollector implements MetricsPublis
 
   public ReadConfigurationEventQueueCollector(
       Map<String, WMQMetricOverride> metricsToReport,
-      MonitorContextConfiguration monitorContextConfig,
       PCFMessageAgent agent,
       MQQueueManager mqQueueManager,
       QueueManager queueManager,
       MetricWriteHelper metricWriteHelper,
       MetricCreator metricCreator) {
     this.metricsToReport = metricsToReport;
-    this.monitorContextConfig = monitorContextConfig;
     this.agent = agent;
     this.mqQueueManager = mqQueueManager;
     this.queueManager = queueManager;

--- a/src/main/java/com/splunk/ibm/mq/opentelemetry/Main.java
+++ b/src/main/java/com/splunk/ibm/mq/opentelemetry/Main.java
@@ -15,8 +15,6 @@
  */
 package com.splunk.ibm.mq.opentelemetry;
 
-import com.singularity.ee.agent.systemagent.api.TaskExecutionContext;
-import com.singularity.ee.agent.systemagent.api.exception.TaskExecutionException;
 import com.splunk.ibm.mq.WMQMonitor;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
@@ -90,17 +88,9 @@ public class Main {
 
     service.scheduleAtFixedRate(
         () -> {
-          try {
-            WMQMonitor monitor =
-                new WMQMonitor(
-                    config, service, new OpenTelemetryMetricWriteHelper(exporter, meters));
-            TaskExecutionContext taskExecCtx = new TaskExecutionContext();
-            Map<String, String> taskArguments = new HashMap<>();
-            taskArguments.put("config-file", configFile);
-            monitor.execute(taskArguments, taskExecCtx);
-          } catch (TaskExecutionException e) {
-            throw new RuntimeException(e);
-          }
+          WMQMonitor monitor =
+              new WMQMonitor(config, service, new OpenTelemetryMetricWriteHelper(exporter, meters));
+          monitor.run();
         },
         config.getTaskInitialDelaySeconds(),
         config.getTaskDelaySeconds(),

--- a/src/main/java/com/splunk/ibm/mq/opentelemetry/Main.java
+++ b/src/main/java/com/splunk/ibm/mq/opentelemetry/Main.java
@@ -92,7 +92,8 @@ public class Main {
         () -> {
           try {
             WMQMonitor monitor =
-                new WMQMonitor(service, new OpenTelemetryMetricWriteHelper(exporter, meters));
+                new WMQMonitor(
+                    config, service, new OpenTelemetryMetricWriteHelper(exporter, meters));
             TaskExecutionContext taskExecCtx = new TaskExecutionContext();
             Map<String, String> taskArguments = new HashMap<>();
             taskArguments.put("config-file", configFile);

--- a/src/test/java/com/splunk/ibm/mq/metricscollector/ChannelMetricsCollectorTest.java
+++ b/src/test/java/com/splunk/ibm/mq/metricscollector/ChannelMetricsCollectorTest.java
@@ -74,7 +74,7 @@ class ChannelMetricsCollectorTest {
     monitorContextConfig =
         new MonitorContextConfiguration(
             "WMQMonitor",
-            "Custom Metrics|WMQMonitor|",
+            "IGNORED DUE TO EXISTING IN CONFIG, DON'T BELIEVE THE HYPE",
             PathResolver.resolveDirectory(ChannelMetricsCollectorTest.class),
             aMonitorJob);
     monitorContextConfig.setConfigYml("src/test/resources/conf/config.yml");


### PR DESCRIPTION
This removes a bunch of the machinery dependency on the appd job/task/worker sluge, in favor of just using some thread pools (ExecutorService, ThreadPoolExecutors). In many cases, we're able to leverage the `ConfigWrapper` with a few changes to clean up some things and reduce the direct yaml dependency as well.