### PR TITLE
Filter cleanups

### DIFF
--- a/src/main/java/com/splunk/ibm/mq/config/ExcludeFilters.java
+++ b/src/main/java/com/splunk/ibm/mq/config/ExcludeFilters.java
@@ -17,6 +17,7 @@ package com.splunk.ibm.mq.config;
 
 import com.google.common.base.Strings;
 import com.splunk.ibm.mq.metricscollector.FilterType;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -41,7 +42,7 @@ public class ExcludeFilters {
     this.values = values;
   }
 
-  public static boolean isExcluded(String resourceName, Set<ExcludeFilters> excludeFilters) {
+  public static boolean isExcluded(String resourceName, Collection<ExcludeFilters> excludeFilters) {
     if (excludeFilters == null) {
       return false;
     }

--- a/src/main/java/com/splunk/ibm/mq/metricscollector/ChannelMetricsCollector.java
+++ b/src/main/java/com/splunk/ibm/mq/metricscollector/ChannelMetricsCollector.java
@@ -152,5 +152,4 @@ public final class ChannelMetricsCollector implements MetricsPublisher {
     long exitTime = System.currentTimeMillis() - entryTime;
     logger.debug("Time taken to publish metrics for all channels is {} milliseconds", exitTime);
   }
-
 }

--- a/src/main/java/com/splunk/ibm/mq/metricscollector/ChannelMetricsCollector.java
+++ b/src/main/java/com/splunk/ibm/mq/metricscollector/ChannelMetricsCollector.java
@@ -96,11 +96,11 @@ public final class ChannelMetricsCollector implements MetricsPublisher {
         List<PCFMessage> messages =
             MessageFilter.ofKind("channel name")
                 .excluding(context.getChannelExcludeFilters())
-                .withResourceExtractor(this::getChannelNameFromMessage)
+                .withResourceExtractor(MessageBuddy::channelName)
                 .filter(response);
 
         for (PCFMessage message : messages) {
-          String channelName = getChannelNameFromMessage(message);
+          String channelName = MessageBuddy.channelName(message);
 
           logger.debug("Pulling out metrics for channel name {}", channelName);
           List<Metric> responseMetrics = Lists.newArrayList();
@@ -153,7 +153,4 @@ public final class ChannelMetricsCollector implements MetricsPublisher {
     logger.debug("Time taken to publish metrics for all channels is {} milliseconds", exitTime);
   }
 
-  private String getChannelNameFromMessage(PCFMessage message) throws PCFException {
-    return message.getStringParameterValue(CMQCFC.MQCACH_CHANNEL_NAME).trim();
-  }
 }

--- a/src/main/java/com/splunk/ibm/mq/metricscollector/ChannelMetricsCollector.java
+++ b/src/main/java/com/splunk/ibm/mq/metricscollector/ChannelMetricsCollector.java
@@ -94,7 +94,7 @@ public final class ChannelMetricsCollector implements MetricsPublisher {
         }
 
         List<PCFMessage> messages =
-            MessageFilter.ofKind("channel name")
+            MessageFilter.ofKind("channel")
                 .excluding(context.getChannelExcludeFilters())
                 .withResourceExtractor(MessageBuddy::channelName)
                 .filter(response);

--- a/src/main/java/com/splunk/ibm/mq/metricscollector/InquireChannelCmdCollector.java
+++ b/src/main/java/com/splunk/ibm/mq/metricscollector/InquireChannelCmdCollector.java
@@ -27,9 +27,7 @@ import java.util.List;
 import java.util.Set;
 import org.slf4j.Logger;
 
-/**
- * This class is responsible for channel inquiry metric collection.
- */
+/** This class is responsible for channel inquiry metric collection. */
 public final class InquireChannelCmdCollector implements MetricsPublisher {
 
   public static final Logger logger =
@@ -59,7 +57,7 @@ public final class InquireChannelCmdCollector implements MetricsPublisher {
       PCFMessage request = new PCFMessage(CMQCFC.MQCMD_INQUIRE_CHANNEL);
       request.addParameter(CMQCFC.MQCACH_CHANNEL_NAME, channelGenericName);
       request.addParameter(
-          new MQCFIL(MQConstants.MQIACF_CHANNEL_ATTRS, new int[]{MQConstants.MQIACF_ALL}));
+          new MQCFIL(MQConstants.MQIACF_CHANNEL_ATTRS, new int[] {MQConstants.MQIACF_ALL}));
       try {
         logger.debug(
             "sending PCF agent request to query metrics for generic channel {}",
@@ -76,10 +74,11 @@ public final class InquireChannelCmdCollector implements MetricsPublisher {
           return;
         }
 
-        List<PCFMessage> messages = MessageFilter.ofKind("channel")
-            .excluding(context.getChannelExcludeFilters())
-            .withResourceExtractor(MessageBuddy::channelName)
-            .filter(response);
+        List<PCFMessage> messages =
+            MessageFilter.ofKind("channel")
+                .excluding(context.getChannelExcludeFilters())
+                .withResourceExtractor(MessageBuddy::channelName)
+                .filter(response);
 
         for (PCFMessage message : messages) {
           String channelName = MessageBuddy.channelName(message);

--- a/src/main/java/com/splunk/ibm/mq/metricscollector/InquireChannelCmdCollector.java
+++ b/src/main/java/com/splunk/ibm/mq/metricscollector/InquireChannelCmdCollector.java
@@ -64,14 +64,14 @@ public final class InquireChannelCmdCollector implements MetricsPublisher {
             "sending PCF agent request to query metrics for generic channel {}",
             channelGenericName);
         long startTime = System.currentTimeMillis();
-        PCFMessage[] response = context.send(request);
+        List<PCFMessage> response = context.send(request);
         long endTime = System.currentTimeMillis() - startTime;
         logger.debug(
             "PCF agent queue metrics query response for generic queue {} received in {} milliseconds",
             channelGenericName,
             endTime);
-        if (response == null || response.length <= 0) {
-          logger.warn("Unexpected Error while PCFMessage.send(), response is either null or empty");
+        if (response.isEmpty()) {
+          logger.warn("Unexpected error while PCFMessage.send(), response is empty");
           return;
         }
         for (PCFMessage pcfMessage : response) {
@@ -115,8 +115,7 @@ public final class InquireChannelCmdCollector implements MetricsPublisher {
         logger.error(pcfe.getMessage(), pcfe);
       } catch (Exception e) {
         logger.error(
-            "Unexpected Error occoured while collecting metrics for channel " + channelGenericName,
-            e);
+            "Unexpected error while collecting metrics for channel " + channelGenericName, e);
       }
     }
 

--- a/src/main/java/com/splunk/ibm/mq/metricscollector/InquireChannelCmdCollector.java
+++ b/src/main/java/com/splunk/ibm/mq/metricscollector/InquireChannelCmdCollector.java
@@ -76,7 +76,7 @@ public final class InquireChannelCmdCollector implements MetricsPublisher {
           return;
         }
 
-        List<PCFMessage> messages = MessageFilter.ofKind("channel name")
+        List<PCFMessage> messages = MessageFilter.ofKind("channel")
             .excluding(context.getChannelExcludeFilters())
             .withResourceExtractor(MessageBuddy::channelName)
             .filter(response);

--- a/src/main/java/com/splunk/ibm/mq/metricscollector/InquireQueueManagerCmdCollector.java
+++ b/src/main/java/com/splunk/ibm/mq/metricscollector/InquireQueueManagerCmdCollector.java
@@ -48,7 +48,7 @@ public final class InquireQueueManagerCmdCollector implements MetricsPublisher {
         context.getAgentQueueManagerName(),
         entryTime);
     PCFMessage request;
-    PCFMessage[] responses;
+    List<PCFMessage> responses;
     // CMQCFC.MQCMD_INQUIRE_Q_MGR is 2
     request = new PCFMessage(CMQCFC.MQCMD_INQUIRE_Q_MGR);
     // request.addParameter(CMQC.MQCA_Q_MGR_NAME, "*");
@@ -66,14 +66,14 @@ public final class InquireQueueManagerCmdCollector implements MetricsPublisher {
           "PCF agent queuemanager metrics query response for {} received in {} milliseconds",
           context.getAgentQueueManagerName(),
           endTime);
-      if (responses == null || responses.length <= 0) {
-        logger.debug("Unexpected Error while PCFMessage.send(), response is either null or empty");
+      if (responses.isEmpty()) {
+        logger.debug("Unexpected error while PCFMessage.send(), response is either null or empty");
         return;
       }
       List<Metric> responseMetrics = Lists.newArrayList();
       context.forEachMetric(
           (metrickey, wmqOverride) -> {
-            int metricVal = responses[0].getIntParameterValue(wmqOverride.getConstantValue());
+            int metricVal = responses.get(0).getIntParameterValue(wmqOverride.getConstantValue());
             if (logger.isDebugEnabled()) {
               logger.debug("Metric: " + metrickey + "=" + metricVal);
             }

--- a/src/main/java/com/splunk/ibm/mq/metricscollector/InquireQueueManagerCmdCollector.java
+++ b/src/main/java/com/splunk/ibm/mq/metricscollector/InquireQueueManagerCmdCollector.java
@@ -47,10 +47,8 @@ public final class InquireQueueManagerCmdCollector implements MetricsPublisher {
         "publishMetrics entry time for queuemanager {} is {} milliseconds",
         context.getAgentQueueManagerName(),
         entryTime);
-    PCFMessage request;
-    List<PCFMessage> responses;
     // CMQCFC.MQCMD_INQUIRE_Q_MGR is 2
-    request = new PCFMessage(CMQCFC.MQCMD_INQUIRE_Q_MGR);
+    PCFMessage request = new PCFMessage(CMQCFC.MQCMD_INQUIRE_Q_MGR);
     // request.addParameter(CMQC.MQCA_Q_MGR_NAME, "*");
     // CMQCFC.MQIACF_Q_MGR_STATUS_ATTRS is 1001
     request.addParameter(
@@ -60,7 +58,7 @@ public final class InquireQueueManagerCmdCollector implements MetricsPublisher {
       logger.debug(
           "sending PCF agent request to query queuemanager {}", context.getAgentQueueManagerName());
       long startTime = System.currentTimeMillis();
-      responses = context.send(request);
+      List<PCFMessage> responses = context.send(request);
       long endTime = System.currentTimeMillis() - startTime;
       logger.debug(
           "PCF agent queuemanager metrics query response for {} received in {} milliseconds",
@@ -83,7 +81,7 @@ public final class InquireQueueManagerCmdCollector implements MetricsPublisher {
           });
       context.transformAndPrintMetrics(responseMetrics);
     } catch (Exception e) {
-      logger.error(e.getMessage());
+      logger.error("Error collecting QueueManagerCmd metrics", e);
       throw new RuntimeException(e);
     } finally {
       long exitTime = System.currentTimeMillis() - entryTime;

--- a/src/main/java/com/splunk/ibm/mq/metricscollector/InquireTStatusCmdCollector.java
+++ b/src/main/java/com/splunk/ibm/mq/metricscollector/InquireTStatusCmdCollector.java
@@ -113,7 +113,7 @@ final class InquireTStatusCmdCollector implements MetricsPublisher {
       return;
     }
 
-    List<PCFMessage> messages = MessageFilter.ofKind("topic name")
+    List<PCFMessage> messages = MessageFilter.ofKind("topic")
         .excluding(context.getTopicExcludeFilters())
         .withResourceExtractor(MessageBuddy::topicName)
         .filter(response);

--- a/src/main/java/com/splunk/ibm/mq/metricscollector/InquireTStatusCmdCollector.java
+++ b/src/main/java/com/splunk/ibm/mq/metricscollector/InquireTStatusCmdCollector.java
@@ -100,16 +100,16 @@ final class InquireTStatusCmdCollector implements MetricsPublisher {
         topicGenericName,
         command);
     long startTime = System.currentTimeMillis();
-    PCFMessage[] response = context.send(request);
+    List<PCFMessage> response = context.send(request);
     long endTime = System.currentTimeMillis() - startTime;
     logger.debug(
         "PCF agent topic metrics query response for generic topic {} for command {} received in {} milliseconds",
         topicGenericName,
         command,
         endTime);
-    if (response == null || response.length <= 0) {
+    if (response.isEmpty()) {
       logger.debug(
-          "Unexpected Error while PCFMessage.send() for command {}, response is either null or empty",
+          "Unexpected error while PCFMessage.send() for command {}, response is either null or empty",
           command);
       return;
     }

--- a/src/main/java/com/splunk/ibm/mq/metricscollector/InquireTStatusCmdCollector.java
+++ b/src/main/java/com/splunk/ibm/mq/metricscollector/InquireTStatusCmdCollector.java
@@ -114,7 +114,7 @@ final class InquireTStatusCmdCollector implements MetricsPublisher {
     }
 
     List<PCFMessage> messages = MessageFilter.ofKind("topic name")
-        .excluding(context.getChannelExcludeFilters())
+        .excluding(context.getTopicExcludeFilters())
         .withResourceExtractor(MessageBuddy::topicName)
         .filter(response);
 

--- a/src/main/java/com/splunk/ibm/mq/metricscollector/InquireTStatusCmdCollector.java
+++ b/src/main/java/com/splunk/ibm/mq/metricscollector/InquireTStatusCmdCollector.java
@@ -113,10 +113,11 @@ final class InquireTStatusCmdCollector implements MetricsPublisher {
       return;
     }
 
-    List<PCFMessage> messages = MessageFilter.ofKind("topic")
-        .excluding(context.getTopicExcludeFilters())
-        .withResourceExtractor(MessageBuddy::topicName)
-        .filter(response);
+    List<PCFMessage> messages =
+        MessageFilter.ofKind("topic")
+            .excluding(context.getTopicExcludeFilters())
+            .withResourceExtractor(MessageBuddy::topicName)
+            .filter(response);
 
     for (PCFMessage message : messages) {
       String topicName = MessageBuddy.topicName(message);

--- a/src/main/java/com/splunk/ibm/mq/metricscollector/ListenerMetricsCollector.java
+++ b/src/main/java/com/splunk/ibm/mq/metricscollector/ListenerMetricsCollector.java
@@ -76,15 +76,14 @@ public final class ListenerMetricsCollector implements MetricsPublisher {
             "sending PCF agent request to query metrics for generic listener {}",
             listenerGenericName);
         long startTime = System.currentTimeMillis();
-        PCFMessage[] response = context.send(request);
+        List<PCFMessage> response = context.send(request);
         long endTime = System.currentTimeMillis() - startTime;
         logger.debug(
             "PCF agent listener metrics query response for generic listener {} received in {} milliseconds",
             listenerGenericName,
             endTime);
-        if (response == null || response.length <= 0) {
-          logger.debug(
-              "Unexpected Error while PCFMessage.send(), response is either null or empty");
+        if (response.isEmpty()) {
+          logger.debug("Unexpected error while PCFMessage.send(), response is empty");
           return;
         }
         for (PCFMessage pcfMessage : response) {
@@ -110,9 +109,7 @@ public final class ListenerMetricsCollector implements MetricsPublisher {
         }
       } catch (Exception e) {
         logger.error(
-            "Unexpected Error occurred while collecting metrics for listener "
-                + listenerGenericName,
-            e);
+            "Unexpected error while collecting metrics for listener " + listenerGenericName, e);
       }
     }
     long exitTime = System.currentTimeMillis() - entryTime;

--- a/src/main/java/com/splunk/ibm/mq/metricscollector/ListenerMetricsCollector.java
+++ b/src/main/java/com/splunk/ibm/mq/metricscollector/ListenerMetricsCollector.java
@@ -38,8 +38,7 @@ import org.slf4j.LoggerFactory;
  * information such as: - listener is running or stopped - port number and transport type - last
  * error codes - associated command server •
  *
- * <p>It utilizes WMQMetricOverride to map metrics from the configuration to their IBM MQ
- * constants.
+ * <p>It utilizes WMQMetricOverride to map metrics from the configuration to their IBM MQ constants.
  */
 public final class ListenerMetricsCollector implements MetricsPublisher {
 
@@ -89,10 +88,11 @@ public final class ListenerMetricsCollector implements MetricsPublisher {
           return;
         }
 
-        List<PCFMessage> messages = MessageFilter.ofKind("listener")
-            .excluding(context.getListenerExcludeFilters())
-            .withResourceExtractor(MessageBuddy::listenerName)
-            .filter(response);
+        List<PCFMessage> messages =
+            MessageFilter.ofKind("listener")
+                .excluding(context.getListenerExcludeFilters())
+                .withResourceExtractor(MessageBuddy::listenerName)
+                .filter(response);
 
         for (PCFMessage message : messages) {
           String listenerName = MessageBuddy.listenerName(message);

--- a/src/main/java/com/splunk/ibm/mq/metricscollector/ListenerMetricsCollector.java
+++ b/src/main/java/com/splunk/ibm/mq/metricscollector/ListenerMetricsCollector.java
@@ -89,7 +89,7 @@ public final class ListenerMetricsCollector implements MetricsPublisher {
           return;
         }
 
-        List<PCFMessage> messages = MessageFilter.ofKind("listener name")
+        List<PCFMessage> messages = MessageFilter.ofKind("listener")
             .excluding(context.getListenerExcludeFilters())
             .withResourceExtractor(MessageBuddy::listenerName)
             .filter(response);

--- a/src/main/java/com/splunk/ibm/mq/metricscollector/MessageBuddy.java
+++ b/src/main/java/com/splunk/ibm/mq/metricscollector/MessageBuddy.java
@@ -17,4 +17,7 @@ public class MessageBuddy {
     return message.getStringParameterValue(CMQC.MQCA_TOPIC_STRING).trim();
   }
 
+  public static String listenerName(PCFMessage message) throws PCFException {
+    return message.getStringParameterValue(CMQCFC.MQCACH_LISTENER_NAME).trim();
+  }
 }

--- a/src/main/java/com/splunk/ibm/mq/metricscollector/MessageBuddy.java
+++ b/src/main/java/com/splunk/ibm/mq/metricscollector/MessageBuddy.java
@@ -1,0 +1,15 @@
+package com.splunk.ibm.mq.metricscollector;
+
+import com.ibm.mq.constants.CMQCFC;
+import com.ibm.mq.headers.pcf.PCFException;
+import com.ibm.mq.headers.pcf.PCFMessage;
+
+public class MessageBuddy {
+
+  private MessageBuddy(){}
+
+  static String channelName(PCFMessage message) throws PCFException {
+    return message.getStringParameterValue(CMQCFC.MQCACH_CHANNEL_NAME).trim();
+  }
+
+}

--- a/src/main/java/com/splunk/ibm/mq/metricscollector/MessageBuddy.java
+++ b/src/main/java/com/splunk/ibm/mq/metricscollector/MessageBuddy.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.splunk.ibm.mq.metricscollector;
 
 import com.ibm.mq.constants.CMQC;
@@ -7,7 +22,7 @@ import com.ibm.mq.headers.pcf.PCFMessage;
 
 public class MessageBuddy {
 
-  private MessageBuddy(){}
+  private MessageBuddy() {}
 
   static String channelName(PCFMessage message) throws PCFException {
     return message.getStringParameterValue(CMQCFC.MQCACH_CHANNEL_NAME).trim();

--- a/src/main/java/com/splunk/ibm/mq/metricscollector/MessageBuddy.java
+++ b/src/main/java/com/splunk/ibm/mq/metricscollector/MessageBuddy.java
@@ -20,4 +20,8 @@ public class MessageBuddy {
   public static String listenerName(PCFMessage message) throws PCFException {
     return message.getStringParameterValue(CMQCFC.MQCACH_LISTENER_NAME).trim();
   }
+
+  public static String queueName(PCFMessage message) throws PCFException {
+    return message.getStringParameterValue(CMQC.MQCA_Q_NAME).trim();
+  }
 }

--- a/src/main/java/com/splunk/ibm/mq/metricscollector/MessageBuddy.java
+++ b/src/main/java/com/splunk/ibm/mq/metricscollector/MessageBuddy.java
@@ -1,5 +1,6 @@
 package com.splunk.ibm.mq.metricscollector;
 
+import com.ibm.mq.constants.CMQC;
 import com.ibm.mq.constants.CMQCFC;
 import com.ibm.mq.headers.pcf.PCFException;
 import com.ibm.mq.headers.pcf.PCFMessage;
@@ -10,6 +11,10 @@ public class MessageBuddy {
 
   static String channelName(PCFMessage message) throws PCFException {
     return message.getStringParameterValue(CMQCFC.MQCACH_CHANNEL_NAME).trim();
+  }
+
+  static String topicName(PCFMessage message) throws PCFException {
+    return message.getStringParameterValue(CMQC.MQCA_TOPIC_STRING).trim();
   }
 
 }

--- a/src/main/java/com/splunk/ibm/mq/metricscollector/MessageFilter.java
+++ b/src/main/java/com/splunk/ibm/mq/metricscollector/MessageFilter.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.splunk.ibm.mq.metricscollector;
+
+import com.ibm.mq.headers.pcf.PCFException;
+import com.ibm.mq.headers.pcf.PCFMessage;
+import com.splunk.ibm.mq.config.ExcludeFilters;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Helps to consolidate repeated exclude/filtering logic. */
+class MessageFilter {
+
+  private static final Logger logger = LoggerFactory.getLogger(MessageFilter.class);
+
+  private final String kind;
+  private final Collection<ExcludeFilters> filters;
+  private final ResourceExtractor extractor;
+
+  private MessageFilter(
+      String kind, Collection<ExcludeFilters> filters, ResourceExtractor extractor) {
+    this.kind = kind;
+    this.filters = filters;
+    this.extractor = extractor;
+  }
+
+  static MessageFilterBuilder ofKind(String kind) {
+    return new MessageFilterBuilder(kind);
+  }
+
+  public List<PCFMessage> filter(List<PCFMessage> messages) throws PCFException {
+    List<PCFMessage> result = new ArrayList<>();
+    for (PCFMessage message : messages) {
+      String resourceName = extractor.apply(message);
+      // TODO: Uninvert this
+      if (ExcludeFilters.isExcluded(resourceName, filters)) {
+        logger.debug("{} = {} is excluded.", kind, resourceName);
+      } else {
+        result.add(message);
+      }
+    }
+    return result;
+  }
+
+  static class MessageFilterBuilder {
+
+    private Collection<ExcludeFilters> filters;
+    private String kind;
+    private ResourceExtractor extractor;
+
+    public MessageFilterBuilder(String kind) {
+      this.kind = kind;
+    }
+
+    public MessageFilterBuilder excluding(Collection<ExcludeFilters> filters) {
+      this.filters = filters;
+      return this;
+    }
+
+    public MessageFilter withResourceExtractor(ResourceExtractor extractor) {
+      this.extractor = extractor;
+      return new MessageFilter(kind, filters, extractor);
+    }
+  }
+
+  interface ResourceExtractor {
+    // Ugh, exceptions everywhere, huh?
+    String apply(PCFMessage message) throws PCFException;
+  }
+}

--- a/src/main/java/com/splunk/ibm/mq/metricscollector/MessageFilter.java
+++ b/src/main/java/com/splunk/ibm/mq/metricscollector/MessageFilter.java
@@ -48,7 +48,6 @@ class MessageFilter {
     List<PCFMessage> result = new ArrayList<>();
     for (PCFMessage message : messages) {
       String resourceName = extractor.apply(message);
-      // TODO: Uninvert this
       if (ExcludeFilters.isExcluded(resourceName, filters)) {
         logger.debug("{} = {} is excluded.", kind, resourceName);
       } else {

--- a/src/main/java/com/splunk/ibm/mq/metricscollector/MessageFilter.java
+++ b/src/main/java/com/splunk/ibm/mq/metricscollector/MessageFilter.java
@@ -49,7 +49,7 @@ class MessageFilter {
     for (PCFMessage message : messages) {
       String resourceName = extractor.apply(message);
       if (ExcludeFilters.isExcluded(resourceName, filters)) {
-        logger.debug("{} = {} is excluded.", kind, resourceName);
+        logger.debug("{} name = {} is excluded.", kind, resourceName);
       } else {
         result.add(message);
       }

--- a/src/main/java/com/splunk/ibm/mq/metricscollector/MetricsCollectorContext.java
+++ b/src/main/java/com/splunk/ibm/mq/metricscollector/MetricsCollectorContext.java
@@ -15,6 +15,7 @@
  */
 package com.splunk.ibm.mq.metricscollector;
 
+import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 
 import com.appdynamics.extensions.MetricWriteHelper;
@@ -32,6 +33,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -118,8 +120,10 @@ public final class MetricsCollectorContext {
     return queueManager.getQueueFilters().getExclude();
   }
 
-  PCFMessage[] send(PCFMessage request) throws IOException, MQDataException {
-    return agent.send(request);
+  @NotNull
+  List<PCFMessage> send(PCFMessage request) throws IOException, MQDataException {
+    PCFMessage[] result = agent.send(request);
+    return result == null ? emptyList() : Arrays.asList(result);
   }
 
   void forEachMetric(MetricConsumerAction action) throws PCFException {

--- a/src/main/java/com/splunk/ibm/mq/metricscollector/PerformanceEventQueueCollector.java
+++ b/src/main/java/com/splunk/ibm/mq/metricscollector/PerformanceEventQueueCollector.java
@@ -150,7 +150,7 @@ public final class PerformanceEventQueueCollector implements MetricsPublisher {
       readEvents(performanceEventsQueueName);
     } catch (Exception e) {
       logger.error(
-          "Unexpected Error occurred while collecting performance events for queue "
+          "Unexpected error occurred while collecting performance events for queue "
               + performanceEventsQueueName,
           e);
     }

--- a/src/main/java/com/splunk/ibm/mq/metricscollector/QueueCollectionBuddy.java
+++ b/src/main/java/com/splunk/ibm/mq/metricscollector/QueueCollectionBuddy.java
@@ -106,7 +106,7 @@ final class QueueCollectionBuddy {
       return;
     }
 
-    List<PCFMessage> messages = MessageFilter.ofKind("queue name")
+    List<PCFMessage> messages = MessageFilter.ofKind("queue")
         .excluding(context.getQueueExcludeFilters())
         .withResourceExtractor(MessageBuddy::queueName)
         .filter(response);

--- a/src/main/java/com/splunk/ibm/mq/metricscollector/QueueCollectionBuddy.java
+++ b/src/main/java/com/splunk/ibm/mq/metricscollector/QueueCollectionBuddy.java
@@ -24,12 +24,10 @@ import com.google.common.collect.Lists;
 import com.ibm.mq.constants.CMQC;
 import com.ibm.mq.headers.MQDataException;
 import com.ibm.mq.headers.pcf.*;
-import com.splunk.ibm.mq.config.ExcludeFilters;
 import com.splunk.ibm.mq.config.WMQMetricOverride;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -106,10 +104,11 @@ final class QueueCollectionBuddy {
       return;
     }
 
-    List<PCFMessage> messages = MessageFilter.ofKind("queue")
-        .excluding(context.getQueueExcludeFilters())
-        .withResourceExtractor(MessageBuddy::queueName)
-        .filter(response);
+    List<PCFMessage> messages =
+        MessageFilter.ofKind("queue")
+            .excluding(context.getQueueExcludeFilters())
+            .withResourceExtractor(MessageBuddy::queueName)
+            .filter(response);
 
     for (PCFMessage message : messages) {
       handleMessage(message);

--- a/src/main/java/com/splunk/ibm/mq/metricscollector/QueueCollectionBuddy.java
+++ b/src/main/java/com/splunk/ibm/mq/metricscollector/QueueCollectionBuddy.java
@@ -93,17 +93,16 @@ final class QueueCollectionBuddy {
         queueGenericName,
         command);
     long startTime = System.currentTimeMillis();
-    PCFMessage[] response = context.send(request);
+    List<PCFMessage> response = context.send(request);
     long endTime = System.currentTimeMillis() - startTime;
     logger.debug(
         "PCF agent queue metrics query response for generic queue {} for command {} received in {} milliseconds",
         queueGenericName,
         command,
         endTime);
-    if (response == null || response.length == 0) {
+    if (response.isEmpty()) {
       logger.debug(
-          "Unexpected Error while PCFMessage.send() for command {}, response is either null or empty",
-          command);
+          "Unexpected error while PCFMessage.send() for command {}, response is empty", command);
       return;
     }
     for (PCFMessage pcfMessage : response) {

--- a/src/main/java/com/splunk/ibm/mq/metricscollector/QueueManagerEventCollector.java
+++ b/src/main/java/com/splunk/ibm/mq/metricscollector/QueueManagerEventCollector.java
@@ -120,7 +120,7 @@ public final class QueueManagerEventCollector implements MetricsPublisher {
       readEvents(queueManagerEventsQueueName);
     } catch (Exception e) {
       logger.error(
-          "Unexpected Error occurred while collecting queue manager events for queue "
+          "Unexpected error occurred while collecting queue manager events for queue "
               + queueManagerEventsQueueName,
           e);
     }

--- a/src/main/java/com/splunk/ibm/mq/metricscollector/QueueManagerMetricsCollector.java
+++ b/src/main/java/com/splunk/ibm/mq/metricscollector/QueueManagerMetricsCollector.java
@@ -53,20 +53,20 @@ public final class QueueManagerMetricsCollector implements MetricsPublisher {
       logger.debug(
           "sending PCF agent request to query queuemanager {}", context.getAgentQueueManagerName());
       long startTime = System.currentTimeMillis();
-      PCFMessage[] responses = context.send(request);
+      List<PCFMessage> responses = context.send(request);
       long endTime = System.currentTimeMillis() - startTime;
       logger.debug(
           "PCF agent queuemanager metrics query response for {} received in {} milliseconds",
           context.getAgentQueueManagerName(),
           endTime);
-      if (responses == null || responses.length <= 0) {
-        logger.debug("Unexpected Error while PCFMessage.send(), response is either null or empty");
+      if (responses.isEmpty()) {
+        logger.debug("Unexpected error while PCFMessage.send(), response is empty");
         return;
       }
       List<Metric> responseMetrics = Lists.newArrayList();
       context.forEachMetric(
           (metricKey, wmqOverride) -> {
-            int metricVal = responses[0].getIntParameterValue(wmqOverride.getConstantValue());
+            int metricVal = responses.get(0).getIntParameterValue(wmqOverride.getConstantValue());
             if (logger.isDebugEnabled()) {
               logger.debug("Metric: {}={}", metricKey, metricVal);
             }

--- a/src/main/java/com/splunk/ibm/mq/metricscollector/QueueMetricsCollector.java
+++ b/src/main/java/com/splunk/ibm/mq/metricscollector/QueueMetricsCollector.java
@@ -97,5 +97,4 @@ public final class QueueMetricsCollector implements MetricsPublisher {
       logger.error("The thread was interrupted ", e);
     }
   }
-
 }

--- a/src/main/java/com/splunk/ibm/mq/metricscollector/ReadConfigurationEventQueueCollector.java
+++ b/src/main/java/com/splunk/ibm/mq/metricscollector/ReadConfigurationEventQueueCollector.java
@@ -163,7 +163,7 @@ public final class ReadConfigurationEventQueueCollector implements MetricsPublis
 
     } catch (Exception e) {
       logger.error(
-          "Unexpected Error occurred while collecting configuration events for queue "
+          "Unexpected error occurred while collecting configuration events for queue "
               + configurationQueueName,
           e);
     }


### PR DESCRIPTION
A continued modernization effort. A bunch of the collector classes have this exclude filter logic sprinkled inside these deep loops with conditionals and exceptions, which made for poor readability. This refactors that into a new `MessageFilter` class that can be used more consistently and helps to do pre-filtering of messages, instead of considering each one at a time.

The results is tighter loops with less indention.