### PR TITLE
use a gauge to capture heartbeat metrics

### DIFF
--- a/golden/otelconf.yaml
+++ b/golden/otelconf.yaml
@@ -20,7 +20,7 @@ processors:
   groupbyattrs:
   batch:
     send_batch_size: 5000
-    timeout: 50s
+    timeout: 10s
 service:
   pipelines:
     metrics:

--- a/golden/otelconf.yaml
+++ b/golden/otelconf.yaml
@@ -20,7 +20,7 @@ processors:
   groupbyattrs:
   batch:
     send_batch_size: 5000
-    timeout: 10s
+    timeout: 50s
 service:
   pipelines:
     metrics:

--- a/src/integrationTest/java/com/splunk/ibm/mq/integration/tests/WMQMonitorIntegrationTest.java
+++ b/src/integrationTest/java/com/splunk/ibm/mq/integration/tests/WMQMonitorIntegrationTest.java
@@ -219,6 +219,8 @@ class WMQMonitorIntegrationTest {
     // this value is read from the performance event queue.
     assertThat(metricNames).contains("mq.queue.depth.high.event");
     assertThat(metricNames).contains("mq.queue.depth.low.event");
+    // reads a value from the heartbeat gauge
+    assertThat(metricNames).contains("mq.heartbeat");
   }
 
   @Test

--- a/src/integrationTest/java/com/splunk/ibm/mq/integration/tests/WMQMonitorIntegrationTest.java
+++ b/src/integrationTest/java/com/splunk/ibm/mq/integration/tests/WMQMonitorIntegrationTest.java
@@ -15,7 +15,6 @@
  */
 package com.splunk.ibm.mq.integration.tests;
 
-import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
@@ -30,9 +29,7 @@ import com.splunk.ibm.mq.WMQMonitorTask;
 import com.splunk.ibm.mq.config.QueueManager;
 import com.splunk.ibm.mq.integration.opentelemetry.TestResultMetricExporter;
 import com.splunk.ibm.mq.opentelemetry.ConfigWrapper;
-import com.splunk.ibm.mq.opentelemetry.Main;
 import com.splunk.ibm.mq.opentelemetry.OpenTelemetryMetricWriteHelper;
-import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.export.MetricReader;
@@ -41,7 +38,6 @@ import java.io.File;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Paths;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -185,14 +181,11 @@ class WMQMonitorIntegrationTest {
         PeriodicMetricReader.builder(testExporter)
             .setExecutor(Executors.newScheduledThreadPool(1))
             .build();
-    Map<String, SdkMeterProvider> providers =
-        Main.createSdkMeterProviders(reader, singletonList("QM1"));
-    Map<String, Meter> meters = new HashMap<>();
-    for (Map.Entry<String, SdkMeterProvider> e : providers.entrySet()) {
-      meters.put(e.getKey(), e.getValue().get("opentelemetry.io/mq"));
-    }
+    SdkMeterProvider meterProvider =
+        SdkMeterProvider.builder().registerMetricReader(reader).build();
     OpenTelemetryMetricWriteHelper metricWriteHelper =
-        new OpenTelemetryMetricWriteHelper(testExporter, meters);
+        new OpenTelemetryMetricWriteHelper(
+            reader, testExporter, meterProvider.get("opentelemetry.io/mq"));
     String configFile = getConfigFile("conf/test-config.yml");
 
     ConfigWrapper config = ConfigWrapper.parse(configFile);
@@ -200,9 +193,7 @@ class WMQMonitorIntegrationTest {
     monitor.runTest();
 
     reader.forceFlush().join(5, TimeUnit.SECONDS);
-    for (SdkMeterProvider provider : providers.values()) {
-      provider.close();
-    }
+    meterProvider.close();
     List<MetricData> data = testExporter.getExportedMetrics();
     Set<String> metricNames = new HashSet<>();
     for (MetricData metricData : data) {
@@ -231,14 +222,11 @@ class WMQMonitorIntegrationTest {
         PeriodicMetricReader.builder(testExporter)
             .setExecutor(Executors.newScheduledThreadPool(1))
             .build();
-    Map<String, SdkMeterProvider> providers =
-        Main.createSdkMeterProviders(reader, singletonList("QM1"));
-    Map<String, Meter> meters = new HashMap<>();
-    for (Map.Entry<String, SdkMeterProvider> e : providers.entrySet()) {
-      meters.put(e.getKey(), e.getValue().get("opentelemetry.io/mq"));
-    }
+    SdkMeterProvider meterProvider =
+        SdkMeterProvider.builder().registerMetricReader(reader).build();
     OpenTelemetryMetricWriteHelper metricWriteHelper =
-        new OpenTelemetryMetricWriteHelper(testExporter, meters);
+        new OpenTelemetryMetricWriteHelper(
+            reader, testExporter, meterProvider.get("opentelemetry.io/mq"));
     String configFile = getConfigFile("conf/test-queuemgr-config.yml");
     ConfigWrapper config = ConfigWrapper.parse(configFile);
 

--- a/src/main/java/com/splunk/ibm/mq/WMQMonitorTask.java
+++ b/src/main/java/com/splunk/ibm/mq/WMQMonitorTask.java
@@ -41,7 +41,7 @@ import com.splunk.ibm.mq.metricscollector.ReadConfigurationEventQueueCollector;
 import com.splunk.ibm.mq.metricscollector.TopicMetricsCollector;
 import com.splunk.ibm.mq.opentelemetry.ConfigWrapper;
 import com.splunk.ibm.mq.opentelemetry.OpenTelemetryMetricWriteHelper;
-import java.math.BigDecimal;
+import io.opentelemetry.api.metrics.LongGauge;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Hashtable;
@@ -63,6 +63,7 @@ public class WMQMonitorTask implements Runnable {
   private final OpenTelemetryMetricWriteHelper metricWriteHelper;
   private final List<MetricsPublisher> pendingJobs = new ArrayList<>();
   private final ExecutorService threadPool;
+  private final LongGauge heartbeatGauge;
 
   public WMQMonitorTask(
       ConfigWrapper config,
@@ -73,6 +74,13 @@ public class WMQMonitorTask implements Runnable {
     this.queueManager = queueManager;
     this.metricWriteHelper = metricWriteHelper;
     this.threadPool = threadPool;
+    this.heartbeatGauge =
+        metricWriteHelper
+            .getMeter(queueManager.getName())
+            .gaugeBuilder("mq.heartbeat")
+            .setUnit("1")
+            .ofLongs()
+            .build();
   }
 
   @Override
@@ -82,10 +90,10 @@ public class WMQMonitorTask implements Runnable {
     long startTime = System.currentTimeMillis();
     MQQueueManager ibmQueueManager = null;
     PCFMessageAgent agent = null;
-    BigDecimal heartBeatMetricValue = BigDecimal.ZERO;
+    int heartBeatMetricValue = 0;
     try {
       ibmQueueManager = connectToQueueManager(queueManager);
-      heartBeatMetricValue = BigDecimal.ONE;
+      heartBeatMetricValue = 1;
       agent = initPCFMessageAgent(queueManager, ibmQueueManager);
       extractAndReportMetrics(ibmQueueManager, agent);
 
@@ -98,70 +106,13 @@ public class WMQMonitorTask implements Runnable {
           e);
     } finally {
       cleanUp(ibmQueueManager, agent);
-      metricWriteHelper.printMetric(
-          concatMetricPath(config.getMetricPrefix(), queueManagerName, "HeartBeat"),
-          heartBeatMetricValue,
-          "AVG.AVG.IND");
+      heartbeatGauge.set(heartBeatMetricValue);
       long endTime = System.currentTimeMillis() - startTime;
       logger.debug(
           "WMQMonitor thread for queueManager {} ended. Time taken = {} ms",
           queueManagerName,
           endTime);
     }
-  }
-
-  private static String concatMetricPath(String... paths) {
-    StringBuilder sb = new StringBuilder();
-    for (String path : paths) {
-      if (path != null && !path.isEmpty()) {
-        String trimmed = trim(path.trim(), "|").trim();
-        if (trimmed.length() > 0) {
-          sb.append(trimmed).append("|");
-        }
-      }
-    }
-    if (sb.length() > 0) {
-      sb.deleteCharAt(sb.length() - 1);
-    }
-    return sb.toString();
-  }
-
-  /**
-   * Removes the leading and trailing occurence of the string trim.
-   *
-   * <p>trim("||||FOO|BAR|||||","|") => FOO|BAR
-   *
-   * @param str
-   * @param trim
-   * @return
-   */
-  private static String trim(String str, String trim) {
-    str = trimLeading(str, trim);
-    str = trimTrailing(str, trim);
-    return str;
-  }
-
-  private static String trimLeading(String str, String trim) {
-    while (str.startsWith(trim)) {
-      str = str.substring(trim.length());
-    }
-    return str;
-  }
-
-  /**
-   * Removes the trailing occurence of the string trim.
-   *
-   * <p>trim("||||FOO|BAR|||||","|") => ||||FOO|BAR
-   *
-   * @param str
-   * @param trim
-   * @return
-   */
-  private static String trimTrailing(String str, String trim) {
-    while (str.endsWith(trim)) {
-      str = str.substring(0, str.length() - trim.length());
-    }
-    return str;
   }
 
   public static MQQueueManager connectToQueueManager(QueueManager queueManager) {

--- a/src/main/java/com/splunk/ibm/mq/metricscollector/PerformanceEventQueueCollector.java
+++ b/src/main/java/com/splunk/ibm/mq/metricscollector/PerformanceEventQueueCollector.java
@@ -52,19 +52,19 @@ public final class PerformanceEventQueueCollector implements MetricsPublisher {
     this.queueManager = queueManager;
     this.fullQueueDepthCounter =
         openTelemetryMetricWriteHelper
-            .getMeter(queueManager.getName())
+            .getMeter()
             .counterBuilder("mq.queue.depth.full.event")
             .setUnit("1")
             .build();
     this.highQueueDepthCounter =
         openTelemetryMetricWriteHelper
-            .getMeter(queueManager.getName())
+            .getMeter()
             .counterBuilder("mq.queue.depth.high.event")
             .setUnit("1")
             .build();
     this.lowQueueDepthCounter =
         openTelemetryMetricWriteHelper
-            .getMeter(queueManager.getName())
+            .getMeter()
             .counterBuilder("mq.queue.depth.low.event")
             .setUnit("1")
             .build();
@@ -113,21 +113,36 @@ public final class PerformanceEventQueueCollector implements MetricsPublisher {
         {
           String queueName = receivedMsg.getStringParameterValue(CMQC.MQCA_BASE_OBJECT_NAME);
           fullQueueDepthCounter.add(
-              1, Attributes.of(AttributeKey.stringKey("queue.name"), queueName));
+              1,
+              Attributes.of(
+                  AttributeKey.stringKey("queue.manager"),
+                  queueManager.getName(),
+                  AttributeKey.stringKey("queue.name"),
+                  queueName));
         }
         break;
       case CMQC.MQRC_Q_DEPTH_HIGH:
         {
           String queueName = receivedMsg.getStringParameterValue(CMQC.MQCA_BASE_OBJECT_NAME);
           highQueueDepthCounter.add(
-              1, Attributes.of(AttributeKey.stringKey("queue.name"), queueName));
+              1,
+              Attributes.of(
+                  AttributeKey.stringKey("queue.manager"),
+                  queueManager.getName(),
+                  AttributeKey.stringKey("queue.name"),
+                  queueName));
         }
         break;
       case CMQC.MQRC_Q_DEPTH_LOW:
         {
           String queueName = receivedMsg.getStringParameterValue(CMQC.MQCA_BASE_OBJECT_NAME);
           lowQueueDepthCounter.add(
-              1, Attributes.of(AttributeKey.stringKey("queue.name"), queueName));
+              1,
+              Attributes.of(
+                  AttributeKey.stringKey("queue.manager"),
+                  queueManager.getName(),
+                  AttributeKey.stringKey("queue.name"),
+                  queueName));
         }
         break;
       default:

--- a/src/main/java/com/splunk/ibm/mq/metricscollector/QueueManagerEventCollector.java
+++ b/src/main/java/com/splunk/ibm/mq/metricscollector/QueueManagerEventCollector.java
@@ -48,11 +48,7 @@ public final class QueueManagerEventCollector implements MetricsPublisher {
     this.mqQueueManager = mqQueueManager;
     this.queueManager = queueManager;
     this.authorityEventCounter =
-        metricWriteHelper
-            .getMeter(queueManager.getName())
-            .counterBuilder("mq.unauthorized.event")
-            .setUnit("1")
-            .build();
+        metricWriteHelper.getMeter().counterBuilder("mq.unauthorized.event").setUnit("1").build();
   }
 
   private void readEvents(String queueManagerEventsQueueName) throws Exception {
@@ -77,6 +73,8 @@ public final class QueueManagerEventCollector implements MetricsPublisher {
             authorityEventCounter.add(
                 1,
                 Attributes.of(
+                    AttributeKey.stringKey("queue.manager"),
+                    queueManager.getName(),
                     AttributeKey.stringKey("user.name"),
                     username,
                     AttributeKey.stringKey("application.name"),

--- a/src/main/java/com/splunk/ibm/mq/opentelemetry/Config.java
+++ b/src/main/java/com/splunk/ibm/mq/opentelemetry/Config.java
@@ -21,6 +21,7 @@ import io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporter;
 import io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporterBuilder;
 import io.opentelemetry.exporter.otlp.internal.OtlpConfigUtil;
 import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
+import io.opentelemetry.sdk.metrics.Aggregation;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import java.util.HashMap;
 import java.util.Map;
@@ -54,6 +55,7 @@ class Config {
         builder::setRetryPolicy,
         builder::setMemoryMode);
 
+    builder.setDefaultAggregationSelector((instrumentType) -> Aggregation.lastValue());
     return builder.build();
   }
 

--- a/src/main/java/com/splunk/ibm/mq/opentelemetry/MQOtelTranslator.java
+++ b/src/main/java/com/splunk/ibm/mq/opentelemetry/MQOtelTranslator.java
@@ -244,7 +244,6 @@ class MQOtelTranslator {
             {
               put("Status", "mq.manager.status");
               put("ConnectionCount", "mq.connection.count");
-              put("HeartBeat", "mq.heartbeat");
               put("Restart Log Size", "mq.restart.log.size");
               put("Reusable Log Size", "mq.reusable.log.size");
               put("Archive Log Size", "mq.archive.log.size");

--- a/src/main/java/com/splunk/ibm/mq/opentelemetry/Main.java
+++ b/src/main/java/com/splunk/ibm/mq/opentelemetry/Main.java
@@ -72,8 +72,8 @@ public class Main {
 
     MetricReader reader =
         PeriodicMetricReader.builder(exporter)
-            .setExecutor(service)
-            .setInterval(config.getTaskDelay())
+            // we check to send metrics every 5s, while we collect them less often.
+            .setInterval(5, TimeUnit.SECONDS)
             .build();
 
     List<String> queueManagerNames = config.getQueueManagerNames();

--- a/src/main/java/com/splunk/ibm/mq/opentelemetry/Main.java
+++ b/src/main/java/com/splunk/ibm/mq/opentelemetry/Main.java
@@ -16,17 +16,11 @@
 package com.splunk.ibm.mq.opentelemetry;
 
 import com.splunk.ibm.mq.WMQMonitor;
-import io.opentelemetry.api.common.AttributeKey;
-import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import io.opentelemetry.sdk.metrics.export.MetricReader;
 import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader;
 import io.opentelemetry.sdk.resources.Resource;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -70,26 +64,19 @@ public class Main {
 
     MetricExporter exporter = Config.createOtlpHttpMetricsExporter(config._exposed());
 
-    MetricReader reader =
-        PeriodicMetricReader.builder(exporter)
-            // we check to send metrics every 5s, while we collect them less often.
-            .setInterval(5, TimeUnit.SECONDS)
-            .build();
+    MetricReader reader = PeriodicMetricReader.builder(exporter).build();
 
-    List<String> queueManagerNames = config.getQueueManagerNames();
-    Map<String, SdkMeterProvider> providers = createSdkMeterProviders(reader, queueManagerNames);
-    Map<String, Meter> meters = new HashMap<>();
-    for (Map.Entry<String, SdkMeterProvider> e : providers.entrySet()) {
-      meters.put(e.getKey(), e.getValue().get("opentelemetry.io/mq"));
-    }
+    SdkMeterProvider meterProvider =
+        SdkMeterProvider.builder()
+            .setResource(Resource.empty())
+            .registerMetricReader(reader)
+            .build();
 
     Runtime.getRuntime()
         .addShutdownHook(
             new Thread(
                 () -> {
-                  for (SdkMeterProvider c : providers.values()) {
-                    c.close();
-                  }
+                  meterProvider.shutdown();
                   reader.shutdown();
                   service.shutdown();
                   exporter.shutdown();
@@ -98,27 +85,15 @@ public class Main {
     service.scheduleAtFixedRate(
         () -> {
           WMQMonitor monitor =
-              new WMQMonitor(config, service, new OpenTelemetryMetricWriteHelper(exporter, meters));
+              new WMQMonitor(
+                  config,
+                  service,
+                  new OpenTelemetryMetricWriteHelper(
+                      reader, exporter, meterProvider.get("websphere/mq")));
           monitor.run();
         },
         config.getTaskInitialDelaySeconds(),
         config.getTaskDelaySeconds(),
         TimeUnit.SECONDS);
-  }
-
-  public static Map<String, SdkMeterProvider> createSdkMeterProviders(
-      MetricReader reader, List<String> queueManagerNames) {
-    Map<String, SdkMeterProvider> providers = new HashMap<>();
-    for (String queueManagerName : queueManagerNames) {
-      Attributes attrs = Attributes.of(AttributeKey.stringKey("queue.manager"), queueManagerName);
-      SdkMeterProvider meterProvider =
-          SdkMeterProvider.builder()
-              .registerMetricReader(reader)
-              // TODO: We should not be making multiple resources. :(
-              .setResource(Resource.create(attrs))
-              .build();
-      providers.put(queueManagerName, meterProvider);
-    }
-    return providers;
   }
 }


### PR DESCRIPTION
This is a meaningful change as it tests that we can export metrics using the metrics provider rather than translating them.

The changes:
* no more multiple resources. No resource for now.
* a heartbeat gauge is created and passed to all queue manager tasks.
* the exporter default aggregation is now set to send last value of a metric.
* Important: we now send metrics explicitly at the end of each cycle. This way both metrics that are coming from the translation and the metrics reported by gauges are in the same export.
* We no longer tap in the thread pool of tasks to export. Exporting is so important, it might be best to give it its own thread pool. For now, we use the default threadpool, which uses daemon threads - not sure yet if we want to override that.