### PR TITLE
Channel metrics directly as otel metrics

### DIFF
--- a/src/main/java/com/splunk/ibm/mq/WMQMonitorTask.java
+++ b/src/main/java/com/splunk/ibm/mq/WMQMonitorTask.java
@@ -237,7 +237,8 @@ public class WMQMonitorTask implements Runnable {
         groupMetricsByCommand(metricsToReport);
 
     processMetricType(
-        metricsByCommand, "MQCMD_INQUIRE_CHANNEL_STATUS", ChannelMetricsCollector::new, agent);
+        metricsByCommand, "MQCMD_INQUIRE_CHANNEL_STATUS",
+        (ctx, metricCreator) -> new ChannelMetricsCollector(ctx), agent);
     processMetricType(
         metricsByCommand, "MQCMD_INQUIRE_CHANNEL", InquireChannelCmdCollector::new, agent);
   }

--- a/src/main/java/com/splunk/ibm/mq/metricscollector/ChannelMetricsCollector.java
+++ b/src/main/java/com/splunk/ibm/mq/metricscollector/ChannelMetricsCollector.java
@@ -15,17 +15,15 @@
  */
 package com.splunk.ibm.mq.metricscollector;
 
-import static com.ibm.mq.constants.CMQC.MQRC_SELECTOR_ERROR;
-import static com.ibm.mq.constants.CMQCFC.MQRCCF_CHL_STATUS_NOT_FOUND;
+import static com.ibm.mq.constants.CMQCFC.MQIACH_CHANNEL_STATUS;
 
-import com.appdynamics.extensions.metrics.Metric;
-import com.google.common.collect.Lists;
 import com.ibm.mq.constants.CMQC;
 import com.ibm.mq.constants.CMQCFC;
-import com.ibm.mq.headers.pcf.PCFException;
 import com.ibm.mq.headers.pcf.PCFMessage;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
@@ -37,15 +35,20 @@ public final class ChannelMetricsCollector implements MetricsPublisher {
   private static final Logger logger = LoggerFactory.getLogger(ChannelMetricsCollector.class);
 
   public static final String ARTIFACT = "Channels";
-  private final MetricCreator metricCreator;
   private final MetricsCollectorContext context;
+  private final ChannelMetrics channelMetrics;
 
   /*
    * The Channel Status values are mentioned here http://www.ibm.com/support/knowledgecenter/SSFKSJ_7.5.0/com.ibm.mq.ref.dev.doc/q090880_.htm
    */
-  public ChannelMetricsCollector(MetricsCollectorContext context, MetricCreator metricCreator) {
+  public ChannelMetricsCollector(MetricsCollectorContext context) {
+    this(context, ChannelMetrics.create());
+  }
+
+  public ChannelMetricsCollector(
+      MetricsCollectorContext context, ChannelMetrics channelMetrics) {
     this.context = context;
-    this.metricCreator = metricCreator;
+    this.channelMetrics = channelMetrics;
   }
 
   @Override
@@ -69,11 +72,23 @@ public final class ChannelMetricsCollector implements MetricsPublisher {
 
     Set<String> channelGenericNames = context.getChannelIncludeFilterNames();
 
-    //
+    Set<String> activeChannels = queryAllChannels(channelGenericNames, attrs);
+
+    logger.info(
+        "Active Channels in queueManager {} are {}", context.getQueueManagerName(), activeChannels);
+
+    channelMetrics.setActiveChannels(activeChannels.size());
+
+    long exitTime = System.currentTimeMillis() - entryTime;
+    logger.debug("Time taken to publish metrics for all channels is {} milliseconds", exitTime);
+  }
+
+  @NotNull
+  private Set<String> queryAllChannels(Set<String> channelGenericNames, int[] attrs) {
     // The MQCMD_INQUIRE_CHANNEL_STATUS command queries the current operational status of channels.
     // This includes information about whether a channel is running, stopped, or in another state,
     // as well as details about the channel’s performance and usage.
-    List<String> activeChannels = Lists.newArrayList();
+    Set<String> activeChannels = new HashSet<>();
     for (String channelGenericName : channelGenericNames) {
       PCFMessage request = new PCFMessage(CMQCFC.MQCMD_INQUIRE_CHANNEL_STATUS);
       request.addParameter(CMQCFC.MQCACH_CHANNEL_NAME, channelGenericName);
@@ -91,8 +106,7 @@ public final class ChannelMetricsCollector implements MetricsPublisher {
             channelGenericName,
             endTime);
         if (response.isEmpty()) {
-          logger.debug("Unexpected error while PCFMessage.send(), response is empty");
-          return;
+          logger.warn("Unexpected error while PCFMessage.send(), response is empty");
         }
 
         List<PCFMessage> messages =
@@ -102,61 +116,38 @@ public final class ChannelMetricsCollector implements MetricsPublisher {
                 .filter(response);
 
         for (PCFMessage message : messages) {
-          String channelName = MessageBuddy.channelName(message);
+          channelMetrics.setAll(constant -> MessageBuddy.getIntParameterValue(message, constant));
+        }
 
-          logger.debug("Pulling out metrics for channel name {}", channelName);
-          List<Metric> responseMetrics = getMetrics(message, channelName, activeChannels);
-          context.transformAndPrintMetrics(responseMetrics);
+        if (channelIsActive(messages)) {
+          activeChannels.add(channelGenericName);
         }
-      } catch (PCFException pcfe) {
-        if (pcfe.getReason() == MQRCCF_CHL_STATUS_NOT_FOUND) {
-          String errorMsg = "Channel- " + channelGenericName + " :";
-          errorMsg +=
-              "Could not collect channel information as channel is stopped or inactive: Reason '3065'\n";
-          errorMsg +=
-              "If the channel type is MQCHT_RECEIVER, MQCHT_SVRCONN or MQCHT_CLUSRCVR, then the only action is to enable the channel, not start it.";
-          logger.error(errorMsg, pcfe);
-        } else if (pcfe.getReason() == MQRC_SELECTOR_ERROR) {
-          logger.error(
-              "Invalid metrics passed while collecting channel metrics, check config.yaml: Reason '2067'",
-              pcfe);
-        }
+
       } catch (Exception e) {
         logger.error(
             "Unexpected error occurred while collecting metrics for channel " + channelGenericName,
             e);
       }
     }
-
-    logger.info(
-        "Active Channels in queueManager {} are {}", context.getQueueManagerName(), activeChannels);
-    Metric activeChannelsCountMetric =
-        metricCreator.createMetric(
-            "ActiveChannelsCount", activeChannels.size(), null, "ActiveChannelsCount");
-    context.transformAndPrintMetric(activeChannelsCountMetric);
-
-    long exitTime = System.currentTimeMillis() - entryTime;
-    logger.debug("Time taken to publish metrics for all channels is {} milliseconds", exitTime);
+    return activeChannels;
   }
 
-  private @NotNull List<Metric> getMetrics(
-      PCFMessage message, String channelName, List<String> activeChannels) throws PCFException {
-    List<Metric> responseMetrics = Lists.newArrayList();
-    context.forEachMetric(
-        (metrickey, wmqOverride) -> {
-          int metricVal = message.getIntParameterValue(wmqOverride.getConstantValue());
-          Metric metric =
-              metricCreator.createMetric(metrickey, metricVal, wmqOverride, channelName, metrickey);
-          responseMetrics.add(metric);
-          // We follow the definition of active channel as documented in
-          // https://www.ibm.com/docs/en/ibm-mq/9.2.x?topic=states-current-active
-          if ("Status".equals(metrickey)
-              && metricVal != CMQCFC.MQCHS_RETRYING
-              && metricVal != CMQCFC.MQCHS_STOPPED
-              && metricVal != CMQCFC.MQCHS_STARTING) {
-            activeChannels.add(channelName);
-          }
-        });
-    return responseMetrics;
+  private boolean channelIsActive(List<PCFMessage> messages) {
+    return messages.stream()
+        .map(
+            msg -> {
+              return MessageBuddy.getIntParameterValue(msg, MQIACH_CHANNEL_STATUS);
+            })
+        .filter(Objects::nonNull)
+        .filter(
+            // TODO: Reassess this. There are other values, like CMQCFC.MQCHS_INACTIVE, for example
+            metricVal ->
+                metricVal != CMQCFC.MQCHS_RETRYING
+                    && metricVal != CMQCFC.MQCHS_STOPPED
+                    && metricVal != CMQCFC.MQCHS_STARTING)
+        .map(x -> true)
+        .findFirst()
+        .orElse(false);
   }
+
 }

--- a/src/main/java/com/splunk/ibm/mq/metricscollector/MessageBuddy.java
+++ b/src/main/java/com/splunk/ibm/mq/metricscollector/MessageBuddy.java
@@ -19,8 +19,12 @@ import com.ibm.mq.constants.CMQC;
 import com.ibm.mq.constants.CMQCFC;
 import com.ibm.mq.headers.pcf.PCFException;
 import com.ibm.mq.headers.pcf.PCFMessage;
+import javax.annotation.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class MessageBuddy {
+  private static final Logger logger = LoggerFactory.getLogger(MessageBuddy.class);
 
   private MessageBuddy() {}
 
@@ -38,5 +42,15 @@ public class MessageBuddy {
 
   public static String queueName(PCFMessage message) throws PCFException {
     return message.getStringParameterValue(CMQC.MQCA_Q_NAME).trim();
+  }
+
+  @Nullable
+  public static Integer getIntParameterValue(PCFMessage message, int param) {
+    try {
+      return message.getIntParameterValue(param);
+    } catch (PCFException e) {
+      logger.error("Error fetching parameter value " + param, e);
+      return null;
+    }
   }
 }

--- a/src/test/java/com/splunk/ibm/mq/metricscollector/ChannelMetricsCollectorTest.java
+++ b/src/test/java/com/splunk/ibm/mq/metricscollector/ChannelMetricsCollectorTest.java
@@ -111,7 +111,7 @@ class ChannelMetricsCollectorTest {
 
     when(pcfMessageAgent.send(any(PCFMessage.class)))
         .thenReturn(createPCFResponseForInquireChannelStatusCmd());
-    classUnderTest = new ChannelMetricsCollector(context, metricCreator);
+    classUnderTest = new ChannelMetricsCollector(context);
 
     classUnderTest.publishMetrics();
 
@@ -259,7 +259,7 @@ class ChannelMetricsCollectorTest {
   @Test
   void testPublishMetrics_nullResponse() throws Exception {
     when(pcfMessageAgent.send(any(PCFMessage.class))).thenReturn(null);
-    classUnderTest = new ChannelMetricsCollector(context, metricCreator);
+    classUnderTest = new ChannelMetricsCollector(context);
 
     classUnderTest.publishMetrics();
 
@@ -269,7 +269,7 @@ class ChannelMetricsCollectorTest {
   @Test
   void testPublishMetrics_emptyResponse() throws Exception {
     when(pcfMessageAgent.send(any(PCFMessage.class))).thenReturn(new PCFMessage[] {});
-    classUnderTest = new ChannelMetricsCollector(context, metricCreator);
+    classUnderTest = new ChannelMetricsCollector(context);
 
     classUnderTest.publishMetrics();
 
@@ -280,7 +280,7 @@ class ChannelMetricsCollectorTest {
   @MethodSource("exceptionsToThrow")
   void testPublishMetrics_pfException(Exception exceptionToThrow) throws Exception {
     when(pcfMessageAgent.send(any(PCFMessage.class))).thenThrow(exceptionToThrow);
-    classUnderTest = new ChannelMetricsCollector(context, metricCreator);
+    classUnderTest = new ChannelMetricsCollector(context);
 
     classUnderTest.publishMetrics();
 
@@ -299,10 +299,10 @@ class ChannelMetricsCollectorTest {
 
   @Test
   void noMetricsToReport() throws Exception {
-    classUnderTest = new ChannelMetricsCollector(context, metricCreator);
+    classUnderTest = new ChannelMetricsCollector(context);
     classUnderTest.publishMetrics();
     verifyNoInteractions(metricWriteHelper);
-    classUnderTest = new ChannelMetricsCollector(context, metricCreator);
+    classUnderTest = new ChannelMetricsCollector(context);
     classUnderTest.publishMetrics();
     verifyNoInteractions(metricWriteHelper);
   }


### PR DESCRIPTION
An example of how we might generate otel metrics directly, without having to go through the appd translation layer. This also initializes the `OpenTelemtrySdk` by using the AutoConfiguredOpenTelemetrySdk` to set things up mostly automatically.

Most of the "this-parameter-maps-to-this-metric" is happening in the `ChannelMetrics` class. I have used a different instrumentation scope name to differentiate these metrics, and in a few cases I have changed the names to be more in alignment with otel naming conventions.

The tests are still going to be failing, but I'd like to get some early feedback on what we think of this approach before we apply it to any other collectors.