### PR TITLE
Leverage autoconfigure

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -211,3 +211,5 @@ sslConnection:
 # Configure the OTLP exporter using system properties keys following the specification https://opentelemetry.io/docs/languages/java/configuration/
 otlpExporter:
   otel.exporter.otlp.endpoint: http://localhost:4318
+  otel.exporter.otlp.protocol: http/protobuf
+  otel.metric.export.interval: 5s

--- a/config.yml
+++ b/config.yml
@@ -213,3 +213,5 @@ otlpExporter:
   otel.exporter.otlp.endpoint: http://localhost:4318
   otel.exporter.otlp.protocol: http/protobuf
   otel.metric.export.interval: 5s
+  otel.logs.exporter: none
+  otel.traces.exporter: none

--- a/golden/config.yml
+++ b/golden/config.yml
@@ -212,3 +212,5 @@ otlpExporter:
   otel.metric.export.interval: 20s
   otel.exporter.otlp.protocol: http/protobuf
   otel.exporter.otlp.endpoint: http://0.0.0.0:4318
+  otel.logs.exporter: none
+  otel.traces.exporter: none

--- a/golden/config.yml
+++ b/golden/config.yml
@@ -211,4 +211,4 @@ sslConnection:
 otlpExporter:
   otel.metric.export.interval: 5s
   otel.exporter.otlp.protocol: http/protobuf
-  otel.exporter.otlp.endpoint: http://localhost:4318
+  otel.exporter.otlp.endpoint: http://0.0.0.0:4318

--- a/golden/config.yml
+++ b/golden/config.yml
@@ -209,6 +209,6 @@ sslConnection:
   keyStorePassword: ""
 
 otlpExporter:
-  otel.metric.export.interval: 5s
+  otel.metric.export.interval: 20s
   otel.exporter.otlp.protocol: http/protobuf
   otel.exporter.otlp.endpoint: http://0.0.0.0:4318

--- a/golden/config.yml
+++ b/golden/config.yml
@@ -207,3 +207,8 @@ sslConnection:
 
   keyStorePath: ""
   keyStorePassword: ""
+
+otlpExporter:
+  otel.metric.export.interval: 5s
+  otel.exporter.otlp.protocol: http/protobuf
+  otel.exporter.otlp.endpoint: http://localhost:4318

--- a/src/integrationTest/java/com/splunk/ibm/mq/integration/tests/WMQMonitorIntegrationTest.java
+++ b/src/integrationTest/java/com/splunk/ibm/mq/integration/tests/WMQMonitorIntegrationTest.java
@@ -270,7 +270,7 @@ class WMQMonitorIntegrationTest {
     ScheduledExecutorService service =
         Executors.newScheduledThreadPool(config.getNumberOfThreads());
     TestResultMetricExporter exporter = new TestResultMetricExporter();
-    Main.run(config, service, exporter);
+    Main.run(config, service);
     Thread.sleep(5000);
     service.shutdown();
     service.awaitTermination(10, TimeUnit.SECONDS);

--- a/src/integrationTest/resources/conf/test-config.yml
+++ b/src/integrationTest/resources/conf/test-config.yml
@@ -193,3 +193,5 @@ otlpExporter:
   otel.exporter.otlp.endpoint: http://0.0.0.0:4318
   otel.exporter.otlp.protocol: http/protobuf
   otel.metric.export.interval: 5s
+  otel.logs.exporter: none
+  otel.traces.exporter: none

--- a/src/integrationTest/resources/conf/test-config.yml
+++ b/src/integrationTest/resources/conf/test-config.yml
@@ -191,3 +191,5 @@ sslConnection:
 # Configure the OTLP exporter using system properties keys following the specification https://opentelemetry.io/docs/languages/java/configuration/
 otlpExporter:
   otel.exporter.otlp.endpoint: http://0.0.0.0:4318
+  otel.exporter.otlp.protocol: http/protobuf
+  otel.metric.export.interval: 5s

--- a/src/integrationTest/resources/conf/test-queuemgr-config.yml
+++ b/src/integrationTest/resources/conf/test-queuemgr-config.yml
@@ -166,3 +166,5 @@ sslConnection:
 # Configure the OTLP exporter using system properties keys following the specification https://opentelemetry.io/docs/languages/java/configuration/
 otlpExporter:
   otel.exporter.otlp.endpoint: http://0.0.0.0:4318
+  otel.exporter.otlp.protocol: http/protobuf
+  otel.metric.export.interval: 5s

--- a/src/integrationTest/resources/conf/test-queuemgr-config.yml
+++ b/src/integrationTest/resources/conf/test-queuemgr-config.yml
@@ -168,3 +168,6 @@ otlpExporter:
   otel.exporter.otlp.endpoint: http://0.0.0.0:4318
   otel.exporter.otlp.protocol: http/protobuf
   otel.metric.export.interval: 5s
+  otel.logs.exporter: none
+  otel.traces.exporter: none
+

--- a/src/main/java/com/splunk/ibm/mq/opentelemetry/Config.java
+++ b/src/main/java/com/splunk/ibm/mq/opentelemetry/Config.java
@@ -15,16 +15,7 @@
  */
 package com.splunk.ibm.mq.opentelemetry;
 
-import static io.opentelemetry.exporter.otlp.internal.OtlpConfigUtil.DATA_TYPE_METRICS;
-
 import com.google.common.base.Strings;
-import io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporter;
-import io.opentelemetry.exporter.otlp.http.metrics.OtlpHttpMetricExporterBuilder;
-import io.opentelemetry.exporter.otlp.internal.OtlpConfigUtil;
-import io.opentelemetry.sdk.autoconfigure.spi.internal.DefaultConfigProperties;
-import io.opentelemetry.sdk.metrics.Aggregation;
-import io.opentelemetry.sdk.metrics.export.MetricExporter;
-import java.util.HashMap;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,35 +25,38 @@ class Config {
 
   private static final Logger logger = LoggerFactory.getLogger(Config.class);
 
-  static MetricExporter createOtlpHttpMetricsExporter(Map<String, ?> config) {
-    OtlpHttpMetricExporterBuilder builder = OtlpHttpMetricExporter.builder();
-
-    Map<String, String> props = new HashMap<>();
-    if (config.get("otlpExporter") instanceof Map) {
-      Map otlpConfig = (Map) config.get("otlpExporter");
-      for (Object key : otlpConfig.keySet()) {
-        if (key instanceof String && otlpConfig.get(key) instanceof String) {
-          props.put((String) key, (String) otlpConfig.get(key));
-        }
-      }
-    }
-
-    // TODO: Don't use internal classes from opentelemetry
-    OtlpConfigUtil.configureOtlpExporterBuilder(
-        DATA_TYPE_METRICS,
-        DefaultConfigProperties.create(props),
-        builder::setEndpoint,
-        builder::addHeader,
-        builder::setCompression,
-        builder::setTimeout,
-        builder::setTrustedCertificates,
-        builder::setClientTls,
-        builder::setRetryPolicy,
-        builder::setMemoryMode);
-
-    builder.setDefaultAggregationSelector((instrumentType) -> Aggregation.lastValue());
-    return builder.build();
-  }
+  // TODO: Delete this boneyard. Are we confident we can do all of this?
+  // TOOD: What about the magical aggregation selector? Can't we just use the default? If not, why
+  // not?
+  //  static MetricExporter createOtlpHttpMetricsExporter(Map<String, ?> config) {
+  //    OtlpHttpMetricExporterBuilder builder = OtlpHttpMetricExporter.builder();
+  //
+  //    Map<String, String> props = new HashMap<>();
+  //    if (config.get("otlpExporter") instanceof Map) {
+  //      Map otlpConfig = (Map) config.get("otlpExporter");
+  //      for (Object key : otlpConfig.keySet()) {
+  //        if (key instanceof String && otlpConfig.get(key) instanceof String) {
+  //          props.put((String) key, (String) otlpConfig.get(key));
+  //        }
+  //      }
+  //    }
+  //
+  //    // TODO: Don't use internal classes from opentelemetry
+  //    OtlpConfigUtil.configureOtlpExporterBuilder(
+  //        DATA_TYPE_METRICS,
+  //        DefaultConfigProperties.create(props),
+  //        builder::setEndpoint,
+  //        builder::addHeader,
+  //        builder::setCompression,
+  //        builder::setTimeout,
+  //        builder::setTrustedCertificates,
+  //        builder::setClientTls,
+  //        builder::setRetryPolicy,
+  //        builder::setMemoryMode);
+  //
+  //    builder.setDefaultAggregationSelector((instrumentType) -> Aggregation.lastValue());
+  //    return builder.build();
+  //  }
 
   static void setUpSSLConnection(Map<String, ?> config) {
     if (config.get("sslConnection") instanceof Map) {

--- a/src/main/java/com/splunk/ibm/mq/opentelemetry/Config.java
+++ b/src/main/java/com/splunk/ibm/mq/opentelemetry/Config.java
@@ -31,15 +31,15 @@ class Config {
   //  static MetricExporter createOtlpHttpMetricsExporter(Map<String, ?> config) {
   //    OtlpHttpMetricExporterBuilder builder = OtlpHttpMetricExporter.builder();
   //
-  //    Map<String, String> props = new HashMap<>();
-  //    if (config.get("otlpExporter") instanceof Map) {
-  //      Map otlpConfig = (Map) config.get("otlpExporter");
-  //      for (Object key : otlpConfig.keySet()) {
-  //        if (key instanceof String && otlpConfig.get(key) instanceof String) {
-  //          props.put((String) key, (String) otlpConfig.get(key));
+  //      Map<String, String> props = new HashMap<>();
+  //      if (config.get("otlpExporter") instanceof Map) {
+  //        Map otlpConfig = (Map) config.get("otlpExporter");
+  //        for (Object key : otlpConfig.keySet()) {
+  //          if (key instanceof String && otlpConfig.get(key) instanceof String) {
+  //            props.put((String) key, (String) otlpConfig.get(key));
+  //          }
   //        }
   //      }
-  //    }
   //
   //    // TODO: Don't use internal classes from opentelemetry
   //    OtlpConfigUtil.configureOtlpExporterBuilder(

--- a/src/main/java/com/splunk/ibm/mq/opentelemetry/Config.java
+++ b/src/main/java/com/splunk/ibm/mq/opentelemetry/Config.java
@@ -25,39 +25,6 @@ class Config {
 
   private static final Logger logger = LoggerFactory.getLogger(Config.class);
 
-  // TODO: Delete this boneyard. Are we confident we can do all of this?
-  // TOOD: What about the magical aggregation selector? Can't we just use the default? If not, why
-  // not?
-  //  static MetricExporter createOtlpHttpMetricsExporter(Map<String, ?> config) {
-  //    OtlpHttpMetricExporterBuilder builder = OtlpHttpMetricExporter.builder();
-  //
-  //      Map<String, String> props = new HashMap<>();
-  //      if (config.get("otlpExporter") instanceof Map) {
-  //        Map otlpConfig = (Map) config.get("otlpExporter");
-  //        for (Object key : otlpConfig.keySet()) {
-  //          if (key instanceof String && otlpConfig.get(key) instanceof String) {
-  //            props.put((String) key, (String) otlpConfig.get(key));
-  //          }
-  //        }
-  //      }
-  //
-  //    // TODO: Don't use internal classes from opentelemetry
-  //    OtlpConfigUtil.configureOtlpExporterBuilder(
-  //        DATA_TYPE_METRICS,
-  //        DefaultConfigProperties.create(props),
-  //        builder::setEndpoint,
-  //        builder::addHeader,
-  //        builder::setCompression,
-  //        builder::setTimeout,
-  //        builder::setTrustedCertificates,
-  //        builder::setClientTls,
-  //        builder::setRetryPolicy,
-  //        builder::setMemoryMode);
-  //
-  //    builder.setDefaultAggregationSelector((instrumentType) -> Aggregation.lastValue());
-  //    return builder.build();
-  //  }
-
   static void setUpSSLConnection(Map<String, ?> config) {
     if (config.get("sslConnection") instanceof Map) {
       Map otlpConfig = (Map) config.get("sslConnection");

--- a/src/main/java/com/splunk/ibm/mq/opentelemetry/Main.java
+++ b/src/main/java/com/splunk/ibm/mq/opentelemetry/Main.java
@@ -63,10 +63,6 @@ public class Main {
     Config.configureSecurity(config);
     Config.setUpSSLConnection(config._exposed());
 
-    run(config, service);
-  }
-
-  public static void run(ConfigWrapper config, final ScheduledExecutorService service) {
     Map<String, String> props = new HashMap<>();
     if (config._exposed().get("otlpExporter") instanceof Map) {
       Map otlpConfig = (Map) config._exposed().get("otlpExporter");
@@ -84,7 +80,13 @@ public class Main {
                 (builder, configProps) -> builder.setResource(Resource.empty()))
             .build();
 
-    MeterProvider meterProvider = sdk.getOpenTelemetrySdk().getMeterProvider();
+    run(config, service, sdk.getOpenTelemetrySdk().getMeterProvider());
+  }
+
+  public static void run(
+      ConfigWrapper config,
+      final ScheduledExecutorService service,
+      final MeterProvider meterProvider) {
 
     Runtime.getRuntime().addShutdownHook(new Thread(service::shutdown));
     WMQMonitor monitor = new WMQMonitor(config, service, meterProvider.get("websphere/mq"));

--- a/src/test/resources/conf/config.yml
+++ b/src/test/resources/conf/config.yml
@@ -213,3 +213,5 @@ sslConnection:
     otel.exporter.otlp.endpoint: https://localhost:4318
     otel.exporter.otlp.protocol: http/protobuf
     otel.metric.export.interval: 5s
+    otel.logs.exporter: none
+    otel.traces.exporter: none

--- a/src/test/resources/conf/config.yml
+++ b/src/test/resources/conf/config.yml
@@ -211,3 +211,5 @@ sslConnection:
   # Configure the OTLP exporter using system properties keys following the specification https://opentelemetry.io/docs/languages/java/configuration/
   otlpExporter:
     otel.exporter.otlp.endpoint: https://localhost:4318
+    otel.exporter.otlp.protocol: http/protobuf
+    otel.metric.export.interval: 5s

--- a/templates/registry/yaml/config.yml.j2
+++ b/templates/registry/yaml/config.yml.j2
@@ -123,3 +123,5 @@ sslConnection:
 # Configure the OTLP exporter using system properties keys following the specification https://opentelemetry.io/docs/languages/java/configuration/
 otlpExporter:
   otel.exporter.otlp.endpoint: http://localhost:4318
+  otel.exporter.otlp.protocol: http/protobuf
+  otel.metric.export.interval: 5s


### PR DESCRIPTION
Instead of attempting to create our own instances of `MeterProvider` and `*Exporter` and use internal otel classes, we should just leverage the autoconfigure module.