### PR TITLE
Remove dependency on appd-exts-commons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,9 +80,14 @@
             <version>${ibm.mq.lib.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.appdynamics</groupId>
-            <artifactId>appd-exts-commons</artifactId>
-            <version>2.2.13</version>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>2.4</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.19.0</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/src/main/java/com/splunk/ibm/mq/WMQContext.java
+++ b/src/main/java/com/splunk/ibm/mq/WMQContext.java
@@ -15,7 +15,6 @@
  */
 package com.splunk.ibm.mq;
 
-import com.google.common.base.Strings;
 import com.ibm.mq.constants.CMQC;
 import com.splunk.ibm.mq.config.QueueManager;
 import java.util.Hashtable;
@@ -70,7 +69,7 @@ public class WMQContext {
     if (null != propVal) {
       if (propVal instanceof String) {
         String propString = (String) propVal;
-        if (Strings.isNullOrEmpty(propString)) {
+        if (propString.isEmpty()) {
           return;
         }
       }

--- a/src/main/java/com/splunk/ibm/mq/WMQMonitor.java
+++ b/src/main/java/com/splunk/ibm/mq/WMQMonitor.java
@@ -16,7 +16,6 @@
 package com.splunk.ibm.mq;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.Lists;
 import com.ibm.mq.MQQueueManager;
 import com.ibm.mq.headers.pcf.PCFMessageAgent;
 import com.splunk.ibm.mq.config.QueueManager;
@@ -52,7 +51,7 @@ public class WMQMonitor {
     List<Map<String, ?>> queueManagers = getQueueManagers(config);
     ObjectMapper mapper = new ObjectMapper();
 
-    this.queueManagers = Lists.newArrayList();
+    this.queueManagers = new ArrayList<>();
 
     for (Map<String, ?> queueManager : queueManagers) {
       try {
@@ -135,7 +134,7 @@ public class WMQMonitor {
     logger.debug("Queueing {} jobs", jobs.size());
     MetricsCollectorContext context =
         new MetricsCollectorContext(queueManager, agent, mqQueueManager, this.metricsConfig);
-    List<Callable<Void>> tasks = Lists.newArrayList();
+    List<Callable<Void>> tasks = new ArrayList<>();
     for (Consumer<MetricsCollectorContext> collector : jobs) {
       tasks.add(
           () -> {

--- a/src/main/java/com/splunk/ibm/mq/config/ExcludeFilters.java
+++ b/src/main/java/com/splunk/ibm/mq/config/ExcludeFilters.java
@@ -15,7 +15,6 @@
  */
 package com.splunk.ibm.mq.config;
 
-import com.google.common.base.Strings;
 import com.splunk.ibm.mq.metricscollector.FilterType;
 import java.util.Collection;
 import java.util.HashSet;
@@ -55,7 +54,7 @@ public class ExcludeFilters {
   }
 
   public boolean isExcluded(String resourceName) {
-    if (Strings.isNullOrEmpty(resourceName)) {
+    if (resourceName == null || resourceName.isEmpty()) {
       return true;
     }
     switch (FilterType.valueOf(type)) {

--- a/src/main/java/com/splunk/ibm/mq/metricscollector/ChannelMetricsCollector.java
+++ b/src/main/java/com/splunk/ibm/mq/metricscollector/ChannelMetricsCollector.java
@@ -18,7 +18,6 @@ package com.splunk.ibm.mq.metricscollector;
 import static com.ibm.mq.constants.CMQC.MQRC_SELECTOR_ERROR;
 import static com.ibm.mq.constants.CMQCFC.MQRCCF_CHL_STATUS_NOT_FOUND;
 
-import com.google.common.collect.Lists;
 import com.ibm.mq.constants.CMQC;
 import com.ibm.mq.constants.CMQCFC;
 import com.ibm.mq.headers.pcf.PCFException;
@@ -28,6 +27,7 @@ import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.metrics.LongGauge;
 import io.opentelemetry.api.metrics.Meter;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
@@ -99,7 +99,7 @@ public final class ChannelMetricsCollector implements Consumer<MetricsCollectorC
     // The MQCMD_INQUIRE_CHANNEL_STATUS command queries the current operational status of channels.
     // This includes information about whether a channel is running, stopped, or in another state,
     // as well as details about the channel’s performance and usage.
-    List<String> activeChannels = Lists.newArrayList();
+    List<String> activeChannels = new ArrayList<>();
     for (String channelGenericName : channelGenericNames) {
       PCFMessage request = new PCFMessage(CMQCFC.MQCMD_INQUIRE_CHANNEL_STATUS);
       request.addParameter(CMQCFC.MQCACH_CHANNEL_NAME, channelGenericName);

--- a/src/main/java/com/splunk/ibm/mq/metricscollector/QueueMetricsCollector.java
+++ b/src/main/java/com/splunk/ibm/mq/metricscollector/QueueMetricsCollector.java
@@ -15,9 +15,9 @@
  */
 package com.splunk.ibm.mq.metricscollector;
 
-import com.google.common.collect.Lists;
 import com.splunk.ibm.mq.opentelemetry.ConfigWrapper;
 import io.opentelemetry.api.metrics.Meter;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
@@ -30,7 +30,7 @@ public final class QueueMetricsCollector implements Consumer<MetricsCollectorCon
 
   private static final Logger logger = LoggerFactory.getLogger(QueueMetricsCollector.class);
 
-  private final List<Consumer<MetricsCollectorContext>> publishers = Lists.newArrayList();
+  private final List<Consumer<MetricsCollectorContext>> publishers = new ArrayList<>();
   private final InquireQCmdCollector inquireQueueCmd;
   private final ExecutorService threadPool;
   private final ConfigWrapper config;
@@ -53,7 +53,7 @@ public final class QueueMetricsCollector implements Consumer<MetricsCollectorCon
     inquireQueueCmd.accept(context);
 
     // schedule all other jobs in parallel.
-    List<Callable<Void>> taskJobs = Lists.newArrayList();
+    List<Callable<Void>> taskJobs = new ArrayList<>();
     for (Consumer<MetricsCollectorContext> p : publishers) {
       taskJobs.add(
           () -> {

--- a/src/main/java/com/splunk/ibm/mq/opentelemetry/Config.java
+++ b/src/main/java/com/splunk/ibm/mq/opentelemetry/Config.java
@@ -15,7 +15,6 @@
  */
 package com.splunk.ibm.mq.opentelemetry;
 
-import com.google.common.base.Strings;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -94,7 +93,7 @@ class Config {
 
   private static void configureTrustStore(Map<String, String> sslConnection) {
     String trustStorePath = sslConnection.get("trustStorePath");
-    if (Strings.isNullOrEmpty(trustStorePath)) {
+    if (trustStorePath == null || trustStorePath.isEmpty()) {
       logger.debug(
           "trustStorePath is not set in config.yml, ignoring setting trustStorePath as system property");
       return;
@@ -105,7 +104,7 @@ class Config {
 
     String trustStorePassword = sslConnection.get("trustStorePassword");
 
-    if (!Strings.isNullOrEmpty(trustStorePassword)) {
+    if (trustStorePassword != null && !trustStorePassword.isEmpty()) {
       System.setProperty("javax.net.ssl.trustStorePassword", trustStorePassword);
       logger.debug("System property set for javax.net.ssl.trustStorePassword is xxxxx");
     }
@@ -113,7 +112,7 @@ class Config {
 
   private static void configureKeyStore(Map<String, String> sslConnection) {
     String keyStorePath = sslConnection.get("keyStorePath");
-    if (Strings.isNullOrEmpty(keyStorePath)) {
+    if (keyStorePath == null || keyStorePath.isEmpty()) {
       logger.debug(
           "keyStorePath is not set in config.yml, ignoring setting keyStorePath as system property");
       return;
@@ -122,7 +121,7 @@ class Config {
     System.setProperty("javax.net.ssl.keyStore", keyStorePath);
     logger.debug("System property set for javax.net.ssl.keyStore is {}", keyStorePath);
     String keyStorePassword = sslConnection.get("keyStorePassword");
-    if (!Strings.isNullOrEmpty(keyStorePassword)) {
+    if (keyStorePassword != null && !keyStorePassword.isEmpty()) {
       System.setProperty("javax.net.ssl.keyStorePassword", keyStorePassword);
       logger.debug("System property set for javax.net.ssl.keyStorePassword is xxxxx");
     }

--- a/src/main/java/com/splunk/ibm/mq/util/WMQUtil.java
+++ b/src/main/java/com/splunk/ibm/mq/util/WMQUtil.java
@@ -82,7 +82,7 @@ public class WMQUtil {
     return ibmQueueManager;
   }
 
-  private static boolean isNotNullOrEmpty(String str){
+  private static boolean isNotNullOrEmpty(String str) {
     return str != null && !str.isEmpty();
   }
 }

--- a/src/main/java/com/splunk/ibm/mq/util/WMQUtil.java
+++ b/src/main/java/com/splunk/ibm/mq/util/WMQUtil.java
@@ -15,7 +15,6 @@
  */
 package com.splunk.ibm.mq.util;
 
-import com.google.common.base.Strings;
 import com.ibm.mq.MQException;
 import com.ibm.mq.MQQueueManager;
 import com.ibm.mq.headers.MQDataException;
@@ -36,8 +35,8 @@ public class WMQUtil {
       QueueManager queueManager, MQQueueManager ibmQueueManager) {
     try {
       PCFMessageAgent agent;
-      if (!Strings.isNullOrEmpty(queueManager.getModelQueueName())
-          && !Strings.isNullOrEmpty(queueManager.getReplyQueuePrefix())) {
+      if (isNotNullOrEmpty(queueManager.getModelQueueName())
+          && isNotNullOrEmpty(queueManager.getReplyQueuePrefix())) {
         logger.debug("Initializing the PCF agent for model queue and reply queue prefix.");
         agent = new PCFMessageAgent();
         agent.setModelQueueName(queueManager.getModelQueueName());
@@ -81,5 +80,9 @@ public class WMQUtil {
         queueManager.getName(),
         Thread.currentThread().getName());
     return ibmQueueManager;
+  }
+
+  private static boolean isNotNullOrEmpty(String str){
+    return str != null && !str.isEmpty();
   }
 }

--- a/src/test/java/com/splunk/ibm/mq/metricscollector/ChannelMetricsCollectorTest.java
+++ b/src/test/java/com/splunk/ibm/mq/metricscollector/ChannelMetricsCollectorTest.java
@@ -24,7 +24,6 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.Lists;
 import com.ibm.mq.constants.CMQCFC;
 import com.ibm.mq.headers.pcf.PCFException;
 import com.ibm.mq.headers.pcf.PCFMessage;
@@ -37,6 +36,7 @@ import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -91,7 +91,7 @@ class ChannelMetricsCollectorTest {
     reader.forceFlush().join(1, TimeUnit.SECONDS);
 
     List<String> metricsList =
-        Lists.newArrayList(
+        Arrays.asList(
             "mq.message.count",
             "mq.status",
             "mq.byte.sent",

--- a/src/test/java/com/splunk/ibm/mq/metricscollector/ChannelMetricsCollectorTest.java
+++ b/src/test/java/com/splunk/ibm/mq/metricscollector/ChannelMetricsCollectorTest.java
@@ -36,7 +36,7 @@ import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader;
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -91,13 +91,14 @@ class ChannelMetricsCollectorTest {
     reader.forceFlush().join(1, TimeUnit.SECONDS);
 
     List<String> metricsList =
-        Arrays.asList(
-            "mq.message.count",
-            "mq.status",
-            "mq.byte.sent",
-            "mq.byte.received",
-            "mq.buffers.sent",
-            "mq.buffers.received");
+        new ArrayList<>(
+            List.of(
+                "mq.message.count",
+                "mq.status",
+                "mq.byte.sent",
+                "mq.byte.received",
+                "mq.buffers.sent",
+                "mq.buffers.received"));
 
     for (MetricData metric : testExporter.getExportedMetrics()) {
       if (metricsList.remove(metric.getName())) {

--- a/src/test/java/com/splunk/ibm/mq/metricscollector/InquireChannelCmdCollectorTest.java
+++ b/src/test/java/com/splunk/ibm/mq/metricscollector/InquireChannelCmdCollectorTest.java
@@ -20,7 +20,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.Lists;
 import com.ibm.mq.constants.CMQCFC;
 import com.ibm.mq.constants.CMQXC;
 import com.ibm.mq.headers.pcf.PCFMessage;
@@ -33,6 +32,7 @@ import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -81,7 +81,7 @@ class InquireChannelCmdCollectorTest {
     classUnderTest.accept(context);
     reader.forceFlush().join(1, TimeUnit.SECONDS);
     List<String> metricsList =
-        Lists.newArrayList(
+        Arrays.asList(
             "mq.message.retry.count", "mq.message.received.count", "mq.message.sent.count");
     for (MetricData metric : testExporter.getExportedMetrics()) {
       if (metricsList.remove(metric.getName())) {

--- a/src/test/java/com/splunk/ibm/mq/metricscollector/InquireChannelCmdCollectorTest.java
+++ b/src/test/java/com/splunk/ibm/mq/metricscollector/InquireChannelCmdCollectorTest.java
@@ -32,7 +32,7 @@ import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader;
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -81,8 +81,9 @@ class InquireChannelCmdCollectorTest {
     classUnderTest.accept(context);
     reader.forceFlush().join(1, TimeUnit.SECONDS);
     List<String> metricsList =
-        Arrays.asList(
-            "mq.message.retry.count", "mq.message.received.count", "mq.message.sent.count");
+        new ArrayList<>(
+            List.of(
+                "mq.message.retry.count", "mq.message.received.count", "mq.message.sent.count"));
     for (MetricData metric : testExporter.getExportedMetrics()) {
       if (metricsList.remove(metric.getName())) {
         if (metric.getName().equals("mq.message.retry.count")) {

--- a/src/test/java/com/splunk/ibm/mq/metricscollector/QueueManagerMetricsCollectorTest.java
+++ b/src/test/java/com/splunk/ibm/mq/metricscollector/QueueManagerMetricsCollectorTest.java
@@ -31,7 +31,7 @@ import com.splunk.ibm.mq.opentelemetry.ConfigWrapper;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader;
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -78,7 +78,7 @@ class QueueManagerMetricsCollectorTest {
     classUnderTest = new QueueManagerMetricsCollector(meterProvider.get("opentelemetry.io/mq"));
     classUnderTest.accept(context);
     reader.forceFlush().join(1, TimeUnit.SECONDS);
-    List<String> metricsList = Arrays.asList("mq.manager.status");
+    List<String> metricsList = new ArrayList<>(List.of("mq.manager.status"));
 
     for (MetricData metric : testExporter.getExportedMetrics()) {
       if (metricsList.remove(metric.getName())) {

--- a/src/test/java/com/splunk/ibm/mq/metricscollector/QueueManagerMetricsCollectorTest.java
+++ b/src/test/java/com/splunk/ibm/mq/metricscollector/QueueManagerMetricsCollectorTest.java
@@ -20,7 +20,6 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.Lists;
 import com.ibm.mq.constants.CMQC;
 import com.ibm.mq.constants.CMQCFC;
 import com.ibm.mq.headers.pcf.PCFMessage;
@@ -32,6 +31,7 @@ import com.splunk.ibm.mq.opentelemetry.ConfigWrapper;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -78,7 +78,7 @@ class QueueManagerMetricsCollectorTest {
     classUnderTest = new QueueManagerMetricsCollector(meterProvider.get("opentelemetry.io/mq"));
     classUnderTest.accept(context);
     reader.forceFlush().join(1, TimeUnit.SECONDS);
-    List<String> metricsList = Lists.newArrayList("mq.manager.status");
+    List<String> metricsList = Arrays.asList("mq.manager.status");
 
     for (MetricData metric : testExporter.getExportedMetrics()) {
       if (metricsList.remove(metric.getName())) {

--- a/src/test/java/com/splunk/ibm/mq/metricscollector/TopicMetricsCollectorTest.java
+++ b/src/test/java/com/splunk/ibm/mq/metricscollector/TopicMetricsCollectorTest.java
@@ -31,7 +31,7 @@ import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.metrics.data.LongPointData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader;
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -84,7 +84,8 @@ public class TopicMetricsCollectorTest {
     classUnderTest.accept(context);
     reader.forceFlush().join(1, TimeUnit.SECONDS);
 
-    List<String> metricsList = Arrays.asList("mq.publish.count", "mq.subscription.count");
+    List<String> metricsList =
+        new ArrayList<>(List.of("mq.publish.count", "mq.subscription.count"));
 
     for (MetricData metric : testExporter.getExportedMetrics()) {
       if (metricsList.remove(metric.getName())) {

--- a/src/test/java/com/splunk/ibm/mq/metricscollector/TopicMetricsCollectorTest.java
+++ b/src/test/java/com/splunk/ibm/mq/metricscollector/TopicMetricsCollectorTest.java
@@ -19,7 +19,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.Lists;
 import com.ibm.mq.constants.CMQC;
 import com.ibm.mq.constants.CMQCFC;
 import com.ibm.mq.headers.pcf.PCFMessage;
@@ -32,6 +31,7 @@ import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.metrics.data.LongPointData;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -84,7 +84,7 @@ public class TopicMetricsCollectorTest {
     classUnderTest.accept(context);
     reader.forceFlush().join(1, TimeUnit.SECONDS);
 
-    List<String> metricsList = Lists.newArrayList("mq.publish.count", "mq.subscription.count");
+    List<String> metricsList = Arrays.asList("mq.publish.count", "mq.subscription.count");
 
     for (MetricData metric : testExporter.getExportedMetrics()) {
       if (metricsList.remove(metric.getName())) {

--- a/src/test/resources/log4j.xml
+++ b/src/test/resources/log4j.xml
@@ -29,11 +29,6 @@
         <appender-ref ref="ConsoleAppender"/>
     </logger>
 
-    <logger name="com.appdynamics" additivity="false">
-        <level value="debug"/>
-        <appender-ref ref="ConsoleAppender"/>
-    </logger>
-
     <root>
         <priority value="error"/>
         <appender-ref ref="ConsoleAppender"/>


### PR DESCRIPTION
This was being used just to source a couple of transitive dependencies, including snakeyaml, jackson, and guava. The guava usages were minimal, so I just replaced those with standard java calls. We depend on snakeyaml and jackson explicitly now.