### PR TITLE
revert slf4j-api to 1.7.36

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,7 @@ org-junit-jupiter-junit-jupiter-params = "5.12.2"
 org-junit-platform-junit-platform-launcher = "1.13.0"
 org-mockito-mockito-core = "5.17.0"
 org-mockito-mockito-junit-jupiter = "5.17.0"
-org-slf4j-slf4j-api = "2.0.7"
+org-slf4j-slf4j-api = "1.7.36"
 org-yaml-snakeyaml = "2.4"
 
 [libraries]


### PR DESCRIPTION
Moving to slf4j-api breaks support, see https://www.slf4j.org/codes.html#ignoredBindings